### PR TITLE
fix(ui): reduce form max-width from 3xl to 2xl for better desktop UX

### DIFF
--- a/components/Layout/FormPageLayout.vue
+++ b/components/Layout/FormPageLayout.vue
@@ -23,7 +23,7 @@ const headerGradientClass = computed(() => {
 
 <template>
   <div class="min-h-screen bg-slate-50">
-    <div class="mx-auto max-w-3xl px-4 py-8 sm:px-6 lg:px-8">
+    <div class="mx-auto max-w-2xl px-4 py-8 sm:px-6 lg:px-8">
       <div class="mb-6">
         <NuxtLink
           :to="backTo"


### PR DESCRIPTION
- Changes FormPageLayout from max-w-3xl (768px) to max-w-2xl (672px)
- Makes forms more comfortable to fill out on wide desktop screens
- Matches better UX pattern seen in QA environment