### PR TITLE
fix(email): use correct production domain in invite link fallback

### DIFF
--- a/server/utils/emailService.ts
+++ b/server/utils/emailService.ts
@@ -166,7 +166,7 @@ export const sendInviteEmail = async (
   options: SendInviteEmailOptions,
 ): Promise<{ success: boolean; messageId?: string; error?: string }> => {
   const { to, inviterName, familyName, role, token } = options;
-  const baseUrl = process.env.PUBLIC_BASE_URL ?? "https://therecruitingcompass.com";
+  const baseUrl = process.env.PUBLIC_BASE_URL ?? "https://myrecruitingcompass.com";
   const joinUrl = `${baseUrl}/join?token=${encodeURIComponent(token)}`;
   const roleLabel = role === "player" ? "player" : "parent";
 


### PR DESCRIPTION
The invite email was falling back to therecruitingcompass.com when PUBLIC_BASE_URL was unset, but the iOS app only handles Universal Links for myrecruitingcompass.com. Links opened in Safari instead of the app.

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

-
-

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / content
- [ ] Tests
- [ ] Chore / dependency update

## Test plan

- [ ] `npm run type-check` passes
- [ ] `npm run test` passes
- [ ] `npm run lint` passes
- [ ] Tested in browser (dev server)

## Docs checklist

- [ ] Updated `/help` docs if this PR changes user-facing behavior

## Security checklist

- [ ] No secrets or credentials in code
- [ ] User input validated with Zod
- [ ] Auth enforced on new API routes (`requireAuth`)
- [ ] No raw `error.message` exposed in API responses
