### PR TITLE
fix(deep-link): serve AASA with application/json content-type via Vercel

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,12 @@
 {
+  "headers": [
+    {
+      "source": "/.well-known/apple-app-site-association",
+      "headers": [
+        { "key": "Content-Type", "value": "application/json" }
+      ]
+    }
+  ],
   "crons": [
     {
       "path": "/api/cron/cleanup-expired-invites",


### PR DESCRIPTION
With ssr:false, Nuxt's routeRules don't apply to static files — Vercel serves them directly from its CDN with application/octet-stream. iOS silently rejects the AASA unless it receives application/json, causing Universal Links to fall back to Safari for all invite links.

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

-
-

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / content
- [ ] Tests
- [ ] Chore / dependency update

## Test plan

- [ ] `npm run type-check` passes
- [ ] `npm run test` passes
- [ ] `npm run lint` passes
- [ ] Tested in browser (dev server)

## Docs checklist

- [ ] Updated `/help` docs if this PR changes user-facing behavior

## Security checklist

- [ ] No secrets or credentials in code
- [ ] User input validated with Zod
- [ ] Auth enforced on new API routes (`requireAuth`)
- [ ] No raw `error.message` exposed in API responses
