### PR TITLE
fix(lint): correct eslint-disable placement for no-explicit-any

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,1 @@
-{"sessionId":"87ffca84-27cd-4f11-8b82-ea87e3e9d3a4","pid":77973,"acquiredAt":1774896737524}
+{"sessionId":"d606ba40-5821-4037-bb72-d032e0539f1f","pid":6916,"acquiredAt":1776699107183}

--- a/composables/useRecommendationLetters.ts
+++ b/composables/useRecommendationLetters.ts
@@ -67,14 +67,16 @@ export function useRecommendationLetters() {
     try {
       if (existingId) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const { error: updateError } = await (supabase.from("recommendation_letters") as any)
+        const table = supabase.from("recommendation_letters") as any;
+        const { error: updateError } = await table
           .update(formData)
           .eq("id", existingId)
           .eq("user_id", userStore.user.id);
         if (updateError) throw updateError;
       } else {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const { error: insertError } = await (supabase.from("recommendation_letters") as any)
+        const table = supabase.from("recommendation_letters") as any;
+        const { error: insertError } = await table
           .insert([{ ...formData, user_id: userStore.user.id }])
           .select();
         if (insertError) throw insertError;

--- a/server/api/schools/[id]/enrich.post.ts
+++ b/server/api/schools/[id]/enrich.post.ts
@@ -66,7 +66,10 @@ export default defineEventHandler(async (event) => {
   if (!body.confirmed) {
     const searchName = (body as EnrichSearchBody).schoolName || schoolName;
     if (!searchName) {
-      throw createError({ statusCode: 400, statusMessage: "School name required" });
+      throw createError({
+        statusCode: 400,
+        statusMessage: "School name required",
+      });
     }
 
     logger.info("Searching College Scorecard", { schoolName: searchName });
@@ -123,10 +126,14 @@ export default defineEventHandler(async (event) => {
 
     const mergedInfo: SchoolAcademicInfo = { ...existingInfo, ...enrichedData };
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const academicInfo = mergedInfo as any;
     const { error: updateError } = await supabase
       .from("schools")
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      .update({ academic_info: mergedInfo as any, updated_at: new Date().toISOString() })
+      .update({
+        academic_info: academicInfo,
+        updated_at: new Date().toISOString(),
+      })
       .eq("id", schoolId);
 
     if (updateError) {
@@ -137,7 +144,10 @@ export default defineEventHandler(async (event) => {
       });
     }
 
-    logger.info("School enriched with Scorecard data", { schoolId, scorecardId });
+    logger.info("School enriched with Scorecard data", {
+      schoolId,
+      scorecardId,
+    });
 
     return {
       success: true,

--- a/stores/schools.ts
+++ b/stores/schools.ts
@@ -149,7 +149,10 @@ export const useSchoolStore = defineStore("schools", () => {
   /**
    * Get a single school by ID
    */
-  async function getSchool(id: string, familyId: string): Promise<School | null> {
+  async function getSchool(
+    id: string,
+    familyId: string,
+  ): Promise<School | null> {
     const userStore = useUserStore();
     const supabase = useSupabase();
 
@@ -237,7 +240,11 @@ export const useSchoolStore = defineStore("schools", () => {
   /**
    * Update an existing school
    */
-  async function updateSchool(id: string, updates: Partial<School>, familyId: string) {
+  async function updateSchool(
+    id: string,
+    updates: Partial<School>,
+    familyId: string,
+  ) {
     const userStore = useUserStore();
     const supabase = useSupabase();
 
@@ -334,7 +341,11 @@ export const useSchoolStore = defineStore("schools", () => {
   /**
    * Toggle favorite status of a school
    */
-  async function toggleFavorite(id: string, isFavorite: boolean, familyId: string) {
+  async function toggleFavorite(
+    id: string,
+    isFavorite: boolean,
+    familyId: string,
+  ) {
     return updateSchool(id, { is_favorite: !isFavorite }, familyId);
   }
 
@@ -365,7 +376,8 @@ export const useSchoolStore = defineStore("schools", () => {
 
       // Fetch current status from DB to avoid stale-cache history corruption
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data: currentSchool, error: selectError } = await (supabase as any)
+      const supabaseAny = supabase as any;
+      const { data: currentSchool, error: selectError } = await supabaseAny
         .from("schools")
         .select("status")
         .eq("id", schoolId)
@@ -386,8 +398,7 @@ export const useSchoolStore = defineStore("schools", () => {
         updated_at: now,
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const { data: updatedSchool, error: schoolError } = await (supabase as any)
+      const { data: updatedSchool, error: schoolError } = await supabaseAny
         .from("schools")
         .update(schoolUpdateData)
         .eq("id", schoolId)


### PR DESCRIPTION
Fixes pre-existing lint errors introduced by the quality-sweep PR — moves eslint-disable-next-line comments to the correct lines so the @typescript-eslint/no-explicit-any rule is properly suppressed. Unblocks Dependabot PRs #178 and #182.