### PR TITLE
chore(security): patch dependency vulnerabilities 2026-05-14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5657,9 +5657,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -5685,9 +5685,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -5703,9 +5703,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@puppeteer/browsers": {
@@ -18399,22 +18399,22 @@
       "license": "ISC"
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
+      "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },


### PR DESCRIPTION
## Security Advisory Patches

This PR fixes **1 HIGH** aggregate vulnerability (`protobufjs` ≤7.5.5) covering **4 HIGH** and **3 MODERATE** severity advisories, detected by the daily Security Scanning workflow.

### Advisories Fixed

| Advisory | Package | Severity | Before | After |
|---|---|---|---|---|
| [GHSA-66ff-xgx4-vchm](https://github.com/advisories/GHSA-66ff-xgx4-vchm) | `protobufjs` | HIGH | 7.5.5 | 7.5.8 |
| [GHSA-75px-5xx7-5xc7](https://github.com/advisories/GHSA-75px-5xx7-5xc7) | `protobufjs` | HIGH | 7.5.5 | 7.5.8 |
| [GHSA-jvwf-75h9-cwgg](https://github.com/advisories/GHSA-jvwf-75h9-cwgg) | `protobufjs` | HIGH | 7.5.5 | 7.5.8 |
| [GHSA-685m-2w69-288q](https://github.com/advisories/GHSA-685m-2w69-288q) | `protobufjs` | HIGH | 7.5.5 | 7.5.8 |
| [GHSA-q6x5-8v7m-xcrf](https://github.com/advisories/GHSA-q6x5-8v7m-xcrf) | `protobufjs` / `@protobufjs/utf8` | MODERATE | 7.5.5 / 1.1.0 | 7.5.8 / 1.1.1 |
| [GHSA-2pr8-phx7-x9h3](https://github.com/advisories/GHSA-2pr8-phx7-x9h3) | `protobufjs` | MODERATE | 7.5.5 | 7.5.8 |
| [GHSA-fx83-v9x8-x52w](https://github.com/advisories/GHSA-fx83-v9x8-x52w) | `protobufjs` | MODERATE | 7.5.5 | 7.5.8 |

### Advisory Summaries

- **GHSA-66ff-xgx4-vchm** (`protobufjs`): Code injection through bytes field defaults in protobuf definitions.
- **GHSA-75px-5xx7-5xc7** (`protobufjs`): Code generation gadget exploitable after prototype pollution.
- **GHSA-jvwf-75h9-cwgg** (`protobufjs`): Process-wide denial of service through unsafe object operations.
- **GHSA-685m-2w69-288q** (`protobufjs`): Denial of service through unbounded protobuf recursion.
- **GHSA-q6x5-8v7m-xcrf** (`protobufjs` / `@protobufjs/utf8`): Overlong UTF-8 decoding vulnerability.
- **GHSA-2pr8-phx7-x9h3** (`protobufjs`): Denial of service from crafted field names in generated code.
- **GHSA-fx83-v9x8-x52w** (`protobufjs`): Prototype injection in generated message constructors.

### Package Version Changes (lockfile only)

| Package | Before | After |
|---|---|---|
| `protobufjs` | 7.5.5 | 7.5.8 |
| `@protobufjs/utf8` | 1.1.0 | 1.1.1 |
| `@protobufjs/codegen` | 2.0.4 | 2.0.5 |
| `@protobufjs/inquire` | 1.1.0 | 1.1.1 |

### Remaining Advisories (Out of Scope)

4 LOW advisories in `@lhci/cli` transitive deps (`tmp`, `inquirer`, `external-editor`) remain. Fixing them requires `npm audit fix --force` which would install `@lhci/cli@0.1.0` — a breaking major-version downgrade. These do not affect production code and do not trigger the workflow failure gate.

### Verification

- `npm audit`: 0 critical, 0 high, 0 moderate after fix ✅
- `npm run type-check`: passed ✅
- `npm test`: 7189 tests across 409 files — all passed ✅
- No major-version bumps applied ✅
- Only `package-lock.json` modified (transitive dependency) ✅

Created by daily security-scan routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_012XQV5EKBraxwWP3EsywTvT)_