### PR TITLE
fix(e2e): unblock CI by killing silent auth-failure path + admin-API user provisioning

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "24"
 
 jobs:
   e2e-tests:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   testDir: "./tests/e2e",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 2 : 4,
   reporter: "html",
   globalSetup: "./tests/e2e/global-setup.ts",

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -31,8 +31,11 @@ async function globalSetup(_config: FullConfig) {
 
   // Provision storageState for each test account.
   // This allows every test to start pre-authenticated — no per-test login needed.
+  // If any account fails to capture, throw to abort the entire run. Continuing with
+  // stale/empty storageState produces 30-minute hangs as every test 401s on Supabase.
   const browser = await chromium.launch();
   await fs.mkdir(AUTH_DIR, { recursive: true });
+  const failures: { role: string; error: unknown }[] = [];
   try {
     for (const [role, account] of Object.entries(TEST_ACCOUNTS)) {
       console.log(`🔐 Capturing storageState for ${role}...`);
@@ -64,19 +67,22 @@ async function globalSetup(_config: FullConfig) {
         await context.storageState({ path: `${AUTH_DIR}/${role}.json` });
         console.log(`  ✅ Saved ${role}.json`);
       } catch (error) {
-        console.warn(
-          `  ⚠️  Could not capture storageState for ${role}:`,
-          error,
-        );
-        console.warn(
-          `     Tests requiring pre-auth for ${role} may fall back to UI login`,
-        );
+        console.error(`  ❌ Failed to capture storageState for ${role}:`, error);
+        failures.push({ role, error });
       } finally {
         await context.close();
       }
     }
   } finally {
     await browser.close();
+  }
+
+  if (failures.length > 0) {
+    const roles = failures.map((f) => f.role).join(", ");
+    throw new Error(
+      `globalSetup: failed to capture storageState for ${failures.length} account(s): ${roles}. ` +
+        `Aborting to avoid a full test run with stale auth — the silent fall-through has caused 30-minute CI hangs in the past.`,
+    );
   }
 
   // Full database seed (only in CI or when explicitly requested)

--- a/tests/e2e/seed/helpers/supabase-admin.ts
+++ b/tests/e2e/seed/helpers/supabase-admin.ts
@@ -228,6 +228,74 @@ async function setupTestAccountData(
   }
 }
 
+/**
+ * Create a one-off test user via Supabase Admin API, bypassing the UI signup flow.
+ *
+ * Use this in tests that don't actually exercise the signup form — they just need
+ * a logged-in user. UI signup takes ~30-45s per call (multi-step form, validation,
+ * redirect, and Supabase's 3-signups-per-hour rate limit on free tier); admin API
+ * creates the user in ~500ms with no rate limit.
+ *
+ * Idempotent: if the user already exists, returns the existing user instead of failing.
+ */
+export async function createOneOffTestUser(opts: {
+  email: string;
+  password: string;
+  displayName: string;
+  role?: "player" | "parent";
+}) {
+  const supabase = getSupabaseAdmin();
+  const role = opts.role ?? "parent";
+  const [firstName, ...rest] = opts.displayName.split(" ");
+  const lastName = rest.join(" ");
+
+  const { data, error } = await supabase.auth.admin.createUser({
+    email: opts.email,
+    password: opts.password,
+    email_confirm: true,
+    user_metadata: {
+      display_name: opts.displayName,
+      first_name: firstName,
+      last_name: lastName,
+      full_name: opts.displayName,
+      role,
+    },
+  });
+
+  if (error) {
+    if (
+      error.message?.includes("already been registered") ||
+      error.message?.includes("already registered")
+    ) {
+      const { data: list } = await supabase.auth.admin.listUsers({
+        page: 1,
+        perPage: 1000,
+      });
+      const existing = list?.users?.find((u) => u.email === opts.email);
+      if (existing) return existing;
+    }
+    throw new Error(`createOneOffTestUser failed: ${error.message}`);
+  }
+  return data.user;
+}
+
+/**
+ * Delete a one-off test user created by `createOneOffTestUser`.
+ *
+ * Safe to call even if the user does not exist (no-op).
+ */
+export async function deleteOneOffTestUser(email: string): Promise<void> {
+  const supabase = getSupabaseAdmin();
+  const { data } = await supabase.auth.admin.listUsers({
+    page: 1,
+    perPage: 1000,
+  });
+  const user = data?.users?.find((u) => u.email === email);
+  if (user) {
+    await supabase.auth.admin.deleteUser(user.id);
+  }
+}
+
 export async function deleteTestAccounts() {
   const supabase = getSupabaseAdmin();
 

--- a/tests/e2e/tier1-critical/remember-me.spec.ts
+++ b/tests/e2e/tier1-critical/remember-me.spec.ts
@@ -1,23 +1,35 @@
 import { test, expect } from "@playwright/test";
 import { AuthPage } from "../pages/AuthPage";
 import { authFixture } from "../fixtures/auth.fixture";
-import { testUsers } from "../fixtures/testData";
+import {
+  createOneOffTestUser,
+  deleteOneOffTestUser,
+} from "../seed/helpers/supabase-admin";
 
 test.describe("Tier 1: Remember Me - Session Persistence", () => {
   // This spec tests the remember-me checkbox on the login form — must start unauthenticated
   test.use({ storageState: { cookies: [], origins: [] } });
 
   let authPage: AuthPage;
+  // Per-test cleanup queue: emails created by admin API in the test, deleted in afterEach.
+  let createdEmails: string[];
 
   test.beforeEach(async ({ page }) => {
     authPage = new AuthPage(page);
+    createdEmails = [];
     await authFixture.clearAuthState(page);
     await authPage.goto();
   });
 
-  test("should render Remember Me checkbox", async ({ page }) => {
-    authPage = new AuthPage(page);
+  test.afterEach(async () => {
+    for (const email of createdEmails) {
+      await deleteOneOffTestUser(email).catch(() => {
+        // Cleanup failure is non-fatal — orphans get pruned by the next full reset.
+      });
+    }
+  });
 
+  test("should render Remember Me checkbox", async ({ page }) => {
     const checkbox = page.locator('[data-testid="remember-me-checkbox"]');
     expect(checkbox).toBeVisible();
 
@@ -29,41 +41,27 @@ test.describe("Tier 1: Remember Me - Session Persistence", () => {
   test("should have Remember Me checkbox unchecked by default", async ({
     page,
   }) => {
-    authPage = new AuthPage(page);
-
     const checkbox = page.locator('[data-testid="remember-me-checkbox"]');
     await expect(checkbox).not.toBeChecked();
   });
 
   test("should store session with 30-day expiry when Remember Me is checked", async ({
     page,
-    context,
   }) => {
-    authPage = new AuthPage(page);
-
-    // Create a unique test user
-    const uniqueEmail = `remember-me-${Date.now()}@example.com`;
+    const uniqueEmail = `remember-me-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
     const password = "TestPassword123!";
-    const displayName = "Remember Me User";
+    await createOneOffTestUser({
+      email: uniqueEmail,
+      password,
+      displayName: "Remember Me User",
+    });
+    createdEmails.push(uniqueEmail);
 
-    // Signup first
-    await authPage.signup(uniqueEmail, password, displayName);
-
-    // Logout to return to login page
-    await authPage.logout();
-    await authPage.expectLoginPage();
-
-    // Check the Remember Me checkbox
+    // Check Remember Me, then log in
     const checkbox = page.locator('[data-testid="remember-me-checkbox"]');
     await checkbox.check();
+    await authPage.login(uniqueEmail, password, /\/(dashboard|verify-email)/);
 
-    // Login
-    await authPage.login(uniqueEmail, password);
-
-    // Wait for navigation to complete
-    await page.waitForURL(/\/(dashboard|verify-email)/);
-
-    // Check that session_preferences is in localStorage with 30-day expiry
     const sessionPrefs = await page.evaluate(() => {
       const prefs = localStorage.getItem("session_preferences");
       return prefs ? JSON.parse(prefs) : null;
@@ -72,10 +70,8 @@ test.describe("Tier 1: Remember Me - Session Persistence", () => {
     expect(sessionPrefs).toBeTruthy();
     expect(sessionPrefs.rememberMe).toBe(true);
 
-    // Verify 30-day expiry (approximately)
     const thirtyDays = 30 * 24 * 60 * 60 * 1000;
     const expiryTime = sessionPrefs.expiresAt - sessionPrefs.lastActivity;
-    // Allow 1 minute tolerance
     expect(expiryTime).toBeGreaterThan(thirtyDays - 60000);
     expect(expiryTime).toBeLessThan(thirtyDays + 60000);
   });
@@ -83,31 +79,19 @@ test.describe("Tier 1: Remember Me - Session Persistence", () => {
   test("should store session with 1-day expiry when Remember Me is unchecked", async ({
     page,
   }) => {
-    authPage = new AuthPage(page);
-
-    // Create a unique test user
-    const uniqueEmail = `no-remember-${Date.now()}@example.com`;
+    const uniqueEmail = `no-remember-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
     const password = "TestPassword123!";
-    const displayName = "No Remember Me User";
+    await createOneOffTestUser({
+      email: uniqueEmail,
+      password,
+      displayName: "No Remember Me User",
+    });
+    createdEmails.push(uniqueEmail);
 
-    // Signup first
-    await authPage.signup(uniqueEmail, password, displayName);
-
-    // Logout to return to login page
-    await authPage.logout();
-    await authPage.expectLoginPage();
-
-    // Don't check the Remember Me checkbox (default)
     const checkbox = page.locator('[data-testid="remember-me-checkbox"]');
     await expect(checkbox).not.toBeChecked();
+    await authPage.login(uniqueEmail, password, /\/(dashboard|verify-email)/);
 
-    // Login
-    await authPage.login(uniqueEmail, password);
-
-    // Wait for navigation to complete
-    await page.waitForURL(/\/(dashboard|verify-email)/);
-
-    // Check that session_preferences is in localStorage with 1-day expiry
     const sessionPrefs = await page.evaluate(() => {
       const prefs = localStorage.getItem("session_preferences");
       return prefs ? JSON.parse(prefs) : null;
@@ -116,36 +100,32 @@ test.describe("Tier 1: Remember Me - Session Persistence", () => {
     expect(sessionPrefs).toBeTruthy();
     expect(sessionPrefs.rememberMe).toBe(false);
 
-    // Verify 1-day expiry (approximately)
     const oneDay = 24 * 60 * 60 * 1000;
     const expiryTime = sessionPrefs.expiresAt - sessionPrefs.lastActivity;
-    // Allow 1 minute tolerance
     expect(expiryTime).toBeGreaterThan(oneDay - 60000);
     expect(expiryTime).toBeLessThan(oneDay + 60000);
   });
 
   test("should clear session_preferences on logout", async ({ page }) => {
-    authPage = new AuthPage(page);
-
-    // Create a unique test user
-    const uniqueEmail = `logout-${Date.now()}@example.com`;
+    const uniqueEmail = `logout-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
     const password = "TestPassword123!";
-    const displayName = "Logout User";
+    await createOneOffTestUser({
+      email: uniqueEmail,
+      password,
+      displayName: "Logout User",
+    });
+    createdEmails.push(uniqueEmail);
 
-    // Signup and login
-    await authPage.signup(uniqueEmail, password, displayName);
+    await authPage.login(uniqueEmail, password, /\/(dashboard|verify-email)/);
 
-    // Verify session_preferences exists
     let sessionPrefs = await page.evaluate(() => {
       const prefs = localStorage.getItem("session_preferences");
       return prefs ? JSON.parse(prefs) : null;
     });
     expect(sessionPrefs).toBeTruthy();
 
-    // Logout
     await authPage.logout();
 
-    // Verify session_preferences is cleared
     sessionPrefs = await page.evaluate(() => {
       return localStorage.getItem("session_preferences");
     });
@@ -153,18 +133,11 @@ test.describe("Tier 1: Remember Me - Session Persistence", () => {
   });
 
   test("should toggle Remember Me checkbox", async ({ page }) => {
-    authPage = new AuthPage(page);
-
     const checkbox = page.locator('[data-testid="remember-me-checkbox"]');
 
-    // Initially unchecked
     await expect(checkbox).not.toBeChecked();
-
-    // Check the checkbox
     await checkbox.check();
     await expect(checkbox).toBeChecked();
-
-    // Uncheck the checkbox
     await checkbox.uncheck();
     await expect(checkbox).not.toBeChecked();
   });
@@ -172,10 +145,8 @@ test.describe("Tier 1: Remember Me - Session Persistence", () => {
   test("should show timeout message when redirected with timeout query parameter", async ({
     page,
   }) => {
-    // Navigate to login page with timeout query parameter
     await page.goto("/login?reason=timeout");
 
-    // Check for timeout message
     const timeoutMessage = page.locator("text=logged out due to inactivity");
     await expect(timeoutMessage).toBeVisible();
   });

--- a/tests/e2e/tier1-critical/session-timeout.spec.ts
+++ b/tests/e2e/tier1-critical/session-timeout.spec.ts
@@ -1,43 +1,49 @@
 import { test, expect } from "@playwright/test";
 import { AuthPage } from "../pages/AuthPage";
 import { authFixture } from "../fixtures/auth.fixture";
+import {
+  createOneOffTestUser,
+  deleteOneOffTestUser,
+} from "../seed/helpers/supabase-admin";
 
 test.describe("Tier 1: Session Timeout - Warning and Logout", () => {
   // This spec tests login/signup and session behavior — must start unauthenticated
   test.use({ storageState: { cookies: [], origins: [] } });
 
   let authPage: AuthPage;
+  let createdEmails: string[];
 
   test.beforeEach(async ({ page }) => {
     authPage = new AuthPage(page);
+    createdEmails = [];
     await authFixture.clearAuthState(page);
     await authPage.goto();
+  });
+
+  test.afterEach(async () => {
+    for (const email of createdEmails) {
+      await deleteOneOffTestUser(email).catch(() => {
+        // Cleanup failure is non-fatal — orphans get pruned by the next full reset.
+      });
+    }
   });
 
   test("should not show warning modal for users without Remember Me", async ({
     page,
   }) => {
-    authPage = new AuthPage(page);
-
-    // Create a unique test user
-    const uniqueEmail = `no-remember-${Date.now()}@example.com`;
+    const uniqueEmail = `no-remember-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
     const password = "TestPassword123!";
-    const displayName = "No Remember Me User";
+    await createOneOffTestUser({
+      email: uniqueEmail,
+      password,
+      displayName: "No Remember Me User",
+    });
+    createdEmails.push(uniqueEmail);
 
-    // Signup without Remember Me
-    await authPage.signup(uniqueEmail, password, displayName);
-    await authPage.logout();
-    await authPage.expectLoginPage();
-
-    // Login without Remember Me
     const checkbox = page.locator('[data-testid="remember-me-checkbox"]');
     await expect(checkbox).not.toBeChecked();
-    await authPage.login(uniqueEmail, password);
+    await authPage.login(uniqueEmail, password, /\/(dashboard|verify-email)/);
 
-    // Wait for page to load
-    await page.waitForURL(/\/(dashboard|verify-email)/);
-
-    // Verify warning modal is NOT visible
     const warningModal = page.locator("text=Session Timeout Warning");
     await expect(warningModal).not.toBeVisible();
   });
@@ -45,46 +51,35 @@ test.describe("Tier 1: Session Timeout - Warning and Logout", () => {
   test("should display warning modal after extended inactivity for Remember Me users", async ({
     page,
   }) => {
-    authPage = new AuthPage(page);
-
-    // Create a unique test user
-    const uniqueEmail = `session-warning-${Date.now()}@example.com`;
+    const uniqueEmail = `session-warning-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
     const password = "TestPassword123!";
-    const displayName = "Session Warning User";
+    await createOneOffTestUser({
+      email: uniqueEmail,
+      password,
+      displayName: "Session Warning User",
+    });
+    createdEmails.push(uniqueEmail);
 
-    // Signup with Remember Me
-    await authPage.signup(uniqueEmail, password, displayName);
-    await authPage.logout();
-    await authPage.expectLoginPage();
-
-    // Check Remember Me and login
     const checkbox = page.locator('[data-testid="remember-me-checkbox"]');
     await checkbox.check();
-    await authPage.login(uniqueEmail, password);
-
-    // Wait for page to load
-    await page.waitForURL(/\/(dashboard|verify-email)/);
+    await authPage.login(uniqueEmail, password, /\/(dashboard|verify-email)/);
 
     // Simulate near-timeout by manipulating localStorage
     await page.evaluate(() => {
       const prefs = localStorage.getItem("session_preferences");
       if (prefs) {
         const parsed = JSON.parse(prefs);
-        // Set lastActivity to 29 days + 56 minutes ago (4 minutes until timeout)
         const thirtyDays = 30 * 24 * 60 * 60 * 1000;
         parsed.lastActivity = Date.now() - (thirtyDays - 4 * 60 * 1000);
         localStorage.setItem("session_preferences", JSON.stringify(parsed));
       }
     });
 
-    // Navigate to any page to trigger middleware check
     await page.goto("/dashboard");
 
-    // Wait for warning modal to appear (may need to wait a bit)
     const warningModal = page.locator("text=Session Timeout Warning");
     await expect(warningModal).toBeVisible({ timeout: 5000 });
 
-    // Verify warning content
     const timerText = page.locator("text=Time remaining:");
     await expect(timerText).toBeVisible();
 
@@ -98,34 +93,25 @@ test.describe("Tier 1: Session Timeout - Warning and Logout", () => {
   test('should extend session when "Stay Logged In" button is clicked', async ({
     page,
   }) => {
-    authPage = new AuthPage(page);
-
-    // Create a unique test user
-    const uniqueEmail = `stay-logged-in-${Date.now()}@example.com`;
+    const uniqueEmail = `stay-logged-in-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
     const password = "TestPassword123!";
-    const displayName = "Stay Logged In User";
+    await createOneOffTestUser({
+      email: uniqueEmail,
+      password,
+      displayName: "Stay Logged In User",
+    });
+    createdEmails.push(uniqueEmail);
 
-    // Signup with Remember Me
-    await authPage.signup(uniqueEmail, password, displayName);
-    await authPage.logout();
-    await authPage.expectLoginPage();
-
-    // Check Remember Me and login
     const checkbox = page.locator('[data-testid="remember-me-checkbox"]');
     await checkbox.check();
-    await authPage.login(uniqueEmail, password);
+    await authPage.login(uniqueEmail, password, /\/(dashboard|verify-email)/);
 
-    // Wait for page to load
-    await page.waitForURL(/\/(dashboard|verify-email)/);
-
-    // Get original lastActivity
     const originalPrefs = await page.evaluate(() => {
       const prefs = localStorage.getItem("session_preferences");
       return prefs ? JSON.parse(prefs) : null;
     });
     const originalLastActivity = originalPrefs.lastActivity;
 
-    // Simulate near-timeout
     await page.evaluate(() => {
       const prefs = localStorage.getItem("session_preferences");
       if (prefs) {
@@ -136,21 +122,16 @@ test.describe("Tier 1: Session Timeout - Warning and Logout", () => {
       }
     });
 
-    // Navigate to trigger warning
     await page.goto("/dashboard");
 
-    // Wait for warning modal
     const warningModal = page.locator("text=Session Timeout Warning");
     await expect(warningModal).toBeVisible({ timeout: 5000 });
 
-    // Click "Stay Logged In"
     const stayButton = page.locator('button:has-text("Stay Logged In")');
     await stayButton.click();
 
-    // Warning should be dismissed
     await expect(warningModal).not.toBeVisible();
 
-    // Verify lastActivity has been updated
     const updatedPrefs = await page.evaluate(() => {
       const prefs = localStorage.getItem("session_preferences");
       return prefs ? JSON.parse(prefs) : null;
@@ -161,27 +142,19 @@ test.describe("Tier 1: Session Timeout - Warning and Logout", () => {
   test('should logout when "Logout Now" button is clicked', async ({
     page,
   }) => {
-    authPage = new AuthPage(page);
-
-    // Create a unique test user
-    const uniqueEmail = `logout-now-${Date.now()}@example.com`;
+    const uniqueEmail = `logout-now-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
     const password = "TestPassword123!";
-    const displayName = "Logout Now User";
+    await createOneOffTestUser({
+      email: uniqueEmail,
+      password,
+      displayName: "Logout Now User",
+    });
+    createdEmails.push(uniqueEmail);
 
-    // Signup with Remember Me
-    await authPage.signup(uniqueEmail, password, displayName);
-    await authPage.logout();
-    await authPage.expectLoginPage();
-
-    // Check Remember Me and login
     const checkbox = page.locator('[data-testid="remember-me-checkbox"]');
     await checkbox.check();
-    await authPage.login(uniqueEmail, password);
+    await authPage.login(uniqueEmail, password, /\/(dashboard|verify-email)/);
 
-    // Wait for page to load
-    await page.waitForURL(/\/(dashboard|verify-email)/);
-
-    // Simulate near-timeout
     await page.evaluate(() => {
       const prefs = localStorage.getItem("session_preferences");
       if (prefs) {
@@ -192,21 +165,16 @@ test.describe("Tier 1: Session Timeout - Warning and Logout", () => {
       }
     });
 
-    // Navigate to trigger warning
     await page.goto("/dashboard");
 
-    // Wait for warning modal
     const warningModal = page.locator("text=Session Timeout Warning");
     await expect(warningModal).toBeVisible({ timeout: 5000 });
 
-    // Click "Logout Now"
     const logoutButton = page.locator('button:has-text("Logout Now")');
     await logoutButton.click();
 
-    // Should be redirected to login page with timeout reason
     await page.waitForURL("/login?reason=timeout");
 
-    // Verify session_preferences is cleared
     const sessionPrefs = await page.evaluate(() => {
       return localStorage.getItem("session_preferences");
     });
@@ -216,48 +184,35 @@ test.describe("Tier 1: Session Timeout - Warning and Logout", () => {
   test("should show timeout message when accessing app after session expiry", async ({
     page,
   }) => {
-    authPage = new AuthPage(page);
-
-    // Create a unique test user
-    const uniqueEmail = `expired-session-${Date.now()}@example.com`;
+    const uniqueEmail = `expired-session-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`;
     const password = "TestPassword123!";
-    const displayName = "Expired Session User";
+    await createOneOffTestUser({
+      email: uniqueEmail,
+      password,
+      displayName: "Expired Session User",
+    });
+    createdEmails.push(uniqueEmail);
 
-    // Signup with Remember Me
-    await authPage.signup(uniqueEmail, password, displayName);
-    await authPage.logout();
-    await authPage.expectLoginPage();
-
-    // Check Remember Me and login
     const checkbox = page.locator('[data-testid="remember-me-checkbox"]');
     await checkbox.check();
-    await authPage.login(uniqueEmail, password);
+    await authPage.login(uniqueEmail, password, /\/(dashboard|verify-email)/);
 
-    // Wait for page to load
-    await page.waitForURL(/\/(dashboard|verify-email)/);
-
-    // Simulate expired session
     await page.evaluate(() => {
       const prefs = localStorage.getItem("session_preferences");
       if (prefs) {
         const parsed = JSON.parse(prefs);
-        // Set lastActivity to 31+ days ago
         parsed.lastActivity = Date.now() - 31 * 24 * 60 * 60 * 1000;
         localStorage.setItem("session_preferences", JSON.stringify(parsed));
       }
     });
 
-    // Navigate to any page - middleware should detect expired session
     await page.goto("/dashboard");
 
-    // Should be redirected to login with timeout reason
     await page.waitForURL("/login?reason=timeout");
 
-    // Verify timeout message is displayed
     const timeoutMessage = page.locator("text=logged out due to inactivity");
     await expect(timeoutMessage).toBeVisible();
 
-    // Verify session_preferences is cleared
     const sessionPrefs = await page.evaluate(() => {
       return localStorage.getItem("session_preferences");
     });


### PR DESCRIPTION
## Summary

Two parallel issues caused every PR to `main` to fail E2E for ~10 days:

1. **Silent auth failure → 30m chromium hang.** `global-setup.ts` catches `storageState` capture errors and continues with empty auth. Every subsequent test 401s on Supabase and hangs waiting for content that never renders, burning the full 30-minute job timeout.
2. **In-test UI signup → ~22 min of waits.** `remember-me.spec.ts` and `session-timeout.spec.ts` call `authPage.signup()` per test (multi-step form, 5+ fields, redirect wait — ~30-45s each). With 10 such tests × 3 retries on free-tier Supabase (3 signups/hour limit), they alone account for most of the timeout budget.

## Changes

### Fail-loud globalSetup
- `tests/e2e/global-setup.ts:34-85` — collect per-account failures and `throw` at the end instead of `console.warn`. CI now fails in seconds with `globalSetup: failed to capture storageState for X account(s): ...` instead of running the full suite with broken auth.

### Tighter retry budget
- `playwright.config.ts:8` — `retries: 2` → `1` in CI. Halves the worst-case retry budget when something does fail.

### Node version alignment
- `.github/workflows/e2e.yml:15` — `NODE_VERSION: "20"` → `"24"`. Matches `security.yml` and `test.yml`. Removes a latent native-deps mismatch risk.

### Admin-API user provisioning replaces UI signup
- `tests/e2e/seed/helpers/supabase-admin.ts` — new `createOneOffTestUser` / `deleteOneOffTestUser` helpers. ~500ms per call vs ~30-45s for UI signup, no Supabase rate limit.
- `tests/e2e/tier1-critical/remember-me.spec.ts` — replaces 3 in-test `authPage.signup()` calls with admin-API creation + UI login (which is what the test actually exercises for session_preferences).
- `tests/e2e/tier1-critical/session-timeout.spec.ts` — same for 5 in-test signup calls.
- Both specs gain an `afterEach` that deletes created users via admin API (best-effort, non-fatal on failure).

## Expected CI impact

- Chromium job: was 30m timeout → expect 6-10 min run.
- WebKit job: stays `continue-on-error: true` so behavior unchanged.
- Dependabot PRs: still skip E2E entirely (workflow `if:` unchanged).

## Out of scope (separate follow-ups, surfaced for awareness)

- **Move E2E off blocking required-check gate** with a staging-smoke job instead — branch protection change, needs you to flip in GitHub UI.
- **Quarantine `tests/e2e/tier2-important/search-workflows.spec.ts`** (29 hardcoded `waitForTimeout` calls = ~14.5s minimum serial wait per worker).
- **Replace UI login in `globalSetup` with admin JWT injection** — bigger refactor; current change is enough to unblock the queue.

## Test plan

- [ ] `npm run type-check` passes locally (verified)
- [ ] CI Code Quality + Unit & Integration tests pass on this PR
- [ ] Manually verify chromium E2E either passes or fails fast (not 30m hang)
- [ ] Confirm `Notify on Security Issues` and `Notify Slack on Success` skip on PR runs (they require secrets)