### PR TITLE
chore(deps): retarget Dependabot PRs at develop, not main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
   # Enable npm dependency updates
   - package-ecosystem: "npm"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -54,6 +55,7 @@ updates:
   # Enable GitHub Actions workflow updates
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
       day: "monday"


### PR DESCRIPTION
## Summary

Dependabot has been targeting `main` directly (its default — repo default branch). That created the backlog of recent days: every dependency bump landed on `main` while `develop` fell behind, requiring constant back-syncs.

Adding `target-branch: develop` to both ecosystems in `.github/dependabot.yml` so future PRs flow `develop → main` like the rest of our work.

## Out of scope

- This does not touch existing open dependabot PRs (currently none); their next refresh will retarget automatically.

## Test plan

- [ ] CI passes on this PR
- [ ] Next Monday's Dependabot run produces PRs targeting `develop`