### PR TITLE
ci: skip Slack notify step when webhook secret is unavailable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,9 +247,12 @@ jobs:
 
     steps:
       - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: env.SLACK_WEBHOOK_URL != ''
         uses: slackapi/slack-github-action@v3
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {
@@ -283,9 +286,12 @@ jobs:
 
     steps:
       - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: env.SLACK_WEBHOOK_URL != ''
         uses: slackapi/slack-github-action@v3
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7974,12 +7974,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@tailwindcss/postcss/node_modules/tailwindcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/vite": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.1.tgz",


### PR DESCRIPTION
## Summary

Every Dependabot PR (and any PR from a fork) currently fails the `Notify Slack on Success` / `Notify Slack on Failure` job in `test.yml` with:

> SlackError: Missing input! Either a method or webhook is required to take action.

This is because PR runs from untrusted contexts don't receive secrets, so `${{ secrets.SLACK_WEBHOOK_URL }}` is empty.

That single noise step is the only thing failing on the 6 fresh Dependabot PRs that just landed (#242–#247) — once this merges and they rebase, they're all green and mergeable.

## Change

Guard the Send Slack notification step with `if: env.SLACK_WEBHOOK_URL != ''`. When the secret is unavailable, the step skips cleanly and the job reports success. Internal pushes to `develop` and `main` still notify Slack as before.

## Test plan

- [ ] CI passes on this PR (it's a develop PR, so Slack secret IS available — step should run and succeed)
- [ ] After merge, next Dependabot PR no longer fails the notify job