### PR TITLE
fix(ci): trigger CI on auto-security-patch PRs via close+reopen

### DIFF
--- a/.github/workflows/auto-security-patch.yml
+++ b/.github/workflows/auto-security-patch.yml
@@ -183,11 +183,17 @@ jobs:
           EOF
           )
 
-          gh pr create \
+          PR_URL=$(gh pr create \
             --base develop \
             --head "$BRANCH" \
             --title "chore(security): patch dependency vulnerabilities $DATE" \
-            --body "$BODY"
+            --body "$BODY")
+          PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+          # GitHub does not fire workflow events for PRs opened with GITHUB_TOKEN.
+          # Close + reopen so Test & Verify / Security Scanning run on this PR.
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          gh pr close "$PR_NUM"
+          gh pr reopen "$PR_NUM"
 
       - name: Summary
         if: always()


### PR DESCRIPTION
## Summary

PR #249 (the first run of our new `auto-security-patch.yml` workflow) surfaced a real bug: the PR opened, but **none of our CI workflows ran on it** — only Vercel and GitGuardian appeared in the checks list. No lint, type-check, unit tests, or `Dependency Vulnerability Scan` to verify the patch actually closed the advisories.

Root cause: [GitHub's documented behavior](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow). PRs opened with `GITHUB_TOKEN` don't fire `pull_request` workflow events. This is intentional — prevents infinite-loop workflow chains.

## Fix

Immediately close and reopen the PR after creating it. The close+reopen is treated as a fresh PR event from a normal actor, triggering all configured workflows.

## Verification path

After this merges, next manual `workflow_dispatch --field force=true` should produce a PR with the full check list (Test & Verify, Security Scanning, Dependency Vulnerability Scan, etc.) — same as a human-opened PR.

## Test plan

- [ ] CI passes on this PR
- [ ] Next auto-security-patch run produces a PR where Test & Verify runs and posts results