### PR TITLE
ci: align test.yml NODE_VERSION with rest of CI (20 → 24)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ concurrency:
 
 env:
   COVERAGE_THRESHOLD: 75
-  NODE_VERSION: "20"
+  NODE_VERSION: "24"
 
 jobs:
   # Step 1: Lint and type-check


### PR DESCRIPTION
## Summary

`test.yml` is the last workflow still on Node 20. After today's E2E fix bumped `e2e.yml` to 24, this aligns the unit/integration test job and staging-smoke-e2e too. `security.yml` already used 24.

Same Node version everywhere removes a class of latent native-deps mismatch bugs where the lockfile resolves one way under one Node version and differently under another.

## Test plan

- [ ] CI passes on Node 24 (lint, type-check, unit + integration tests, coverage threshold)