### PR TITLE
chore: sync develop → main

### DIFF
--- a/.github/workflows/auto-security-patch.yml
+++ b/.github/workflows/auto-security-patch.yml
@@ -183,11 +183,17 @@ jobs:
           EOF
           )
 
-          gh pr create \
+          PR_URL=$(gh pr create \
             --base develop \
             --head "$BRANCH" \
             --title "chore(security): patch dependency vulnerabilities $DATE" \
-            --body "$BODY"
+            --body "$BODY")
+          PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+          # GitHub does not fire workflow events for PRs opened with GITHUB_TOKEN.
+          # Close + reopen so Test & Verify / Security Scanning run on this PR.
+          # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+          gh pr close "$PR_NUM"
+          gh pr reopen "$PR_NUM"
 
       - name: Summary
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ concurrency:
 
 env:
   COVERAGE_THRESHOLD: 75
-  NODE_VERSION: "20"
+  NODE_VERSION: "24"
 
 jobs:
   # Step 1: Lint and type-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -247,9 +247,12 @@ jobs:
 
     steps:
       - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: env.SLACK_WEBHOOK_URL != ''
         uses: slackapi/slack-github-action@v3
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {
@@ -283,9 +286,12 @@ jobs:
 
     steps:
       - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: env.SLACK_WEBHOOK_URL != ''
         uses: slackapi/slack-github-action@v3
         with:
-          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "pa11y-ci": "^4.1.0",
         "prettier": "^3.8.3",
         "supabase": "^2.100.0",
-        "tsx": "^4.21.0",
+        "tsx": "^4.22.2",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.59.0",
         "vitest": "^4.0.17",
@@ -13394,19 +13394,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/get-tsconfig": {
-      "version": "4.13.6",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
-      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-      }
-    },
     "node_modules/get-uri": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
@@ -18883,16 +18870,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/resolve-pkg-maps": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "devOptional": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
-      }
-    },
     "node_modules/restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -20438,14 +20415,13 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
-      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.2.tgz",
+      "integrity": "sha512-6w9FwtT8WQqRAyTNR+Z+86kghRqpmOLjXUrBlBT6T+CQGDuIMm0VmAqaFUFBIeKDTGobE6/YSigZYLeomzBaRg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.27.0",
-        "get-tsconfig": "^4.7.5"
+        "esbuild": "~0.28.0"
       },
       "bin": {
         "tsx": "dist/cli.mjs"
@@ -20455,6 +20431,464 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/tsx/node_modules/fsevents": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7974,12 +7974,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "node_modules/@tailwindcss/postcss/node_modules/tailwindcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/vite": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@nuxt/ui": "^3.3.7",
         "@nuxtjs/supabase": "^2.0.5",
         "@pinia/nuxt": "^0.11.3",
-        "@sentry/nuxt": "^10.50.0",
+        "@sentry/nuxt": "^10.53.1",
         "@sindresorhus/is": "^7.1.1",
         "@supabase/supabase-js": "^2.104.1",
         "@types/leaflet": "^1.9.21",
@@ -3439,9 +3439,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.0.tgz",
-      "integrity": "sha512-DT12SXVwV2eoJrGf4nnsvZojxxeQo+LlNAsoYGRRObPWTeN6APiqZ2+nqDCQDvQX40eLi1AePONS0onoASp3yQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -3662,23 +3662,6 @@
         "@opentelemetry/api": ">=1.0.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-ioredis": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.62.0.tgz",
-      "integrity": "sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.214.0",
-        "@opentelemetry/redis-common": "^0.38.2",
-        "@opentelemetry/semantic-conventions": "^1.33.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-kafkajs": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.23.0.tgz",
@@ -3830,23 +3813,6 @@
         "@opentelemetry/api": "^1.3.0"
       }
     },
-    "node_modules/@opentelemetry/instrumentation-redis": {
-      "version": "0.62.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.62.0.tgz",
-      "integrity": "sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/instrumentation": "^0.214.0",
-        "@opentelemetry/redis-common": "^0.38.2",
-        "@opentelemetry/semantic-conventions": "^1.27.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.3.0"
-      }
-    },
     "node_modules/@opentelemetry/instrumentation-tedious": {
       "version": "0.33.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.33.0.tgz",
@@ -3976,22 +3942,13 @@
         "@opentelemetry/api": ">=1.3.0 <1.10.0"
       }
     },
-    "node_modules/@opentelemetry/redis-common": {
-      "version": "0.38.3",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.3.tgz",
-      "integrity": "sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.19.0 || >=20.6.0"
-      }
-    },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.0.tgz",
-      "integrity": "sha512-K+oi0hNMv94EpZbnW3eyu2X6SGVpD3O5DhG2NIp65Hc7lhAj9brRXTAVzh3wB82+q3ThakEf7Zd7RsFUqcTc7A==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.0",
+        "@opentelemetry/core": "2.7.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -4109,13 +4066,13 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.0.tgz",
-      "integrity": "sha512-Yg9zEXJB50DLVLpsKPk7NmNqlPlS+OvqhJGh0A8oawIOTPOwlm4eXs9BMJV7L79lvEwI+dWtAj+YjTyddV336A==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.7.0",
-        "@opentelemetry/resources": "2.7.0",
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -6253,50 +6210,50 @@
       ]
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.50.0.tgz",
-      "integrity": "sha512-42bxyRTxnCmYlWnvz4CxikuQNanw8UNma2WJrtxJ0f1MAJV2GhQGSHDLnA+lvFlmiz6qct3pfen/NXGyOTegTA==",
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.53.1.tgz",
+      "integrity": "sha512-X4d6y8sBMjmNhcDW4eMBU3ASsNIMz8dqaFkhyIMN/dkYr/yZKnbRZPaVuVUGvHKjnlficPpIH0/HK9KBjrYxPw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.50.0"
+        "@sentry/core": "10.53.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.50.0.tgz",
-      "integrity": "sha512-0k9XZF0wn86f77mIO2U3gNNyDZooy139CnEanRzHinrN106vVzvBZ6TUEQoHtoO1fqQxr+nWWVrqV/PXUqk47w==",
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.53.1.tgz",
+      "integrity": "sha512-vVpTI/aEYN5d9IgZeYJWMqVaN0+iFgidSrYNAsZTh1US5sJUzF/wrl+68KdpmCtFROrN3jiAn1oPSwL5CKvEJA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.50.0"
+        "@sentry/core": "10.53.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.50.0.tgz",
-      "integrity": "sha512-51FYNfnvVLAWw1rrEWPFfwHuMRb9mkVCFGA4J9/un7SpeGBsQDziGB0Di4fsCxI7+EdSBpfLHPF0csKtCCw0oQ==",
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.53.1.tgz",
+      "integrity": "sha512-wZNzTBYkgGUPWMuUQv7L64+OJmoCnz7GQNiTrTFK6EVAjJXFBCSsPp/nhif0bLhbk8+0g4xz633uOhpXuQbFdw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.50.0",
-        "@sentry/core": "10.50.0"
+        "@sentry-internal/browser-utils": "10.53.1",
+        "@sentry/core": "10.53.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.50.0.tgz",
-      "integrity": "sha512-jx6RKBmcJSWdI92qDGS/sBv1w+7Cww879Z/moX7bw7ipHa/Ts3iDcB3rgZwvhmi17U+mvYsbJeL2DXkPo3TjPw==",
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.53.1.tgz",
+      "integrity": "sha512-aueLaf/2prExwA76BGU5/bOXCKWqtt6jQXWA6WJQNrmKpPEtZJB4ypnpsou0McXQCF8tur2Y8U0TEkwQP13yJQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "10.50.0",
-        "@sentry/core": "10.50.0"
+        "@sentry-internal/replay": "10.53.1",
+        "@sentry/core": "10.53.1"
       },
       "engines": {
         "node": ">=18"
@@ -6332,38 +6289,38 @@
       }
     },
     "node_modules/@sentry/babel-plugin-component-annotate": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.2.0.tgz",
-      "integrity": "sha512-8LbOI5Kzb5F0+7LVQPi2+zGz1iPiRRFhM+7uZ/ZQ33L9BmDOYNIy3xWxCfMw2JCuMXXaxF47XCjGmR22/B0WPg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.3.0.tgz",
+      "integrity": "sha512-p4q8gn8wcFqZGP/s2MnJCAAd8fTikaU6A0mM97RDHQgStcrYiaS0Sc5zUNfb1V+UOLPuvdEdL6MwyxfzjYJQTA==",
       "license": "MIT",
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.50.0.tgz",
-      "integrity": "sha512-1f6rAvET6myiTaSeYqvaaBwvq1LfxqWjAPIoAW/NVC9bPMkeEcuvgDajHrnZMrBeWoJ81NMyoLkyX+iOc7MoFA==",
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.53.1.tgz",
+      "integrity": "sha512-zXF373hzUOGzUOrqd8xb1U3LQi5uYC3mwv+z5OMKUUinQlu30tTWBs7ypy6YTchtix9QlYaHWlayUF8vBZ5UjA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.50.0",
-        "@sentry-internal/feedback": "10.50.0",
-        "@sentry-internal/replay": "10.50.0",
-        "@sentry-internal/replay-canvas": "10.50.0",
-        "@sentry/core": "10.50.0"
+        "@sentry-internal/browser-utils": "10.53.1",
+        "@sentry-internal/feedback": "10.53.1",
+        "@sentry-internal/replay": "10.53.1",
+        "@sentry-internal/replay-canvas": "10.53.1",
+        "@sentry/core": "10.53.1"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/bundler-plugin-core": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-5.2.0.tgz",
-      "integrity": "sha512-+C0x4gEIJRgoMwyRFGx+TFiJ1Po2BZlT1v61+PnouiaprKL5qtZG8n5PXx/5LPLDsVjSIcXjnDrTz9aSm8SJ3w==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/bundler-plugin-core/-/bundler-plugin-core-5.3.0.tgz",
+      "integrity": "sha512-L5T60sWdAI3qWwdg3Ptwek/0TY59PERrxyqp4XMUkroayQvGd9r5dIW9Q1kSeXX9iJ442nXbFZKAOyCKV4Z13Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.18.5",
-        "@sentry/babel-plugin-component-annotate": "5.2.0",
+        "@sentry/babel-plugin-component-annotate": "5.3.0",
         "@sentry/cli": "^2.58.5",
         "dotenv": "^16.3.1",
         "find-up": "^5.0.0",
@@ -6610,13 +6567,13 @@
       }
     },
     "node_modules/@sentry/cloudflare": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/cloudflare/-/cloudflare-10.50.0.tgz",
-      "integrity": "sha512-fgPp2aVdCcHKzgoWwZDFbP/DwjsPwXMQFHCKeeE4jp6r4i0HoRGbaP7z1KlIGGrw12KM2i9rvQfKsaZlhHc0gQ==",
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/cloudflare/-/cloudflare-10.53.1.tgz",
+      "integrity": "sha512-iSohVibGRAKg7zLUflfA2ePG69Uw6bqm6iCQLM18hoG2gT4DGigaKcjJmZLTfAtW1DInMCb0DYc/mltCznxMrQ==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
-        "@sentry/core": "10.50.0"
+        "@sentry/core": "10.53.1"
       },
       "engines": {
         "node": ">=18"
@@ -6631,9 +6588,9 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.50.0.tgz",
-      "integrity": "sha512-J4A+vzUO3adl0TkFCjaN1+4miamrjHiEIYuLHiuu1lmAjq5WIVw32ObvAh4yMwNtxyaEMosTrrh5M6f12XSJFg==",
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.53.1.tgz",
+      "integrity": "sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -6670,9 +6627,9 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.50.0.tgz",
-      "integrity": "sha512-TvwzFQu8MGKzMQ2/tqxcNzFA8UG2kKTB+GDmA4uOzx3+GT849YZRRSJzEXCmYhk1teVd2fbmgqyYY2nyLF5a+Q==",
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.53.1.tgz",
+      "integrity": "sha512-rxHVil0tJAmz+keFcZCj1LaUdgdkK66E/l0gqh2p1209PNCGoD3lnClFr6vusy1aF3zF8O9JPtuMEJzXOKhs+w==",
       "license": "MIT",
       "dependencies": {
         "@fastify/otel": "0.18.0",
@@ -6687,7 +6644,6 @@
         "@opentelemetry/instrumentation-graphql": "0.62.0",
         "@opentelemetry/instrumentation-hapi": "0.60.0",
         "@opentelemetry/instrumentation-http": "0.214.0",
-        "@opentelemetry/instrumentation-ioredis": "0.62.0",
         "@opentelemetry/instrumentation-kafkajs": "0.23.0",
         "@opentelemetry/instrumentation-knex": "0.58.0",
         "@opentelemetry/instrumentation-koa": "0.62.0",
@@ -6697,14 +6653,13 @@
         "@opentelemetry/instrumentation-mysql": "0.60.0",
         "@opentelemetry/instrumentation-mysql2": "0.60.0",
         "@opentelemetry/instrumentation-pg": "0.66.0",
-        "@opentelemetry/instrumentation-redis": "0.62.0",
         "@opentelemetry/instrumentation-tedious": "0.33.0",
         "@opentelemetry/sdk-trace-base": "^2.6.1",
         "@opentelemetry/semantic-conventions": "^1.40.0",
         "@prisma/instrumentation": "7.6.0",
-        "@sentry/core": "10.50.0",
-        "@sentry/node-core": "10.50.0",
-        "@sentry/opentelemetry": "10.50.0",
+        "@sentry/core": "10.53.1",
+        "@sentry/node-core": "10.53.1",
+        "@sentry/opentelemetry": "10.53.1",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -6712,13 +6667,13 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.50.0.tgz",
-      "integrity": "sha512-Eb1BYf4Lc7ZYmdX3acKP6SgyGikrBA370gbGHaWI5jRu7G7vig8sIu1ghPmY5AlvqBPOetado7GniXr6fAXbTw==",
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.53.1.tgz",
+      "integrity": "sha512-iH7SMcM/7jPbN+t7+7ussQOiIqI4BMOGt4VYWlV71/z7k0pY+YPaSvlfVkNXfISiDzFAKv0ecCY3BmsLMu1xDQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.50.0",
-        "@sentry/opentelemetry": "10.50.0",
+        "@sentry/core": "10.53.1",
+        "@sentry/opentelemetry": "10.53.1",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -6754,20 +6709,20 @@
       }
     },
     "node_modules/@sentry/nuxt": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/nuxt/-/nuxt-10.50.0.tgz",
-      "integrity": "sha512-xTC32033wSjvdwJDzNeK6c5FG4Q1eCV30zm1GPkPVQD2fUdu4NOF/fBkkC0rmjtI3adSOPLg2qBWQgxvtxU5ZA==",
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/nuxt/-/nuxt-10.53.1.tgz",
+      "integrity": "sha512-Q7cJHv5Nd8xlqqz62c2OoZjIfGzk6QWLEgvWDVb8kF+aH/fA/rKjtz3yDRvZDjaDXKSc/w5IgLNegBCJ7AANjQ==",
       "license": "MIT",
       "dependencies": {
         "@nuxt/kit": "^3.13.2",
-        "@sentry/browser": "10.50.0",
-        "@sentry/cloudflare": "10.50.0",
-        "@sentry/core": "10.50.0",
-        "@sentry/node": "10.50.0",
-        "@sentry/node-core": "10.50.0",
-        "@sentry/rollup-plugin": "^5.2.0",
-        "@sentry/vite-plugin": "^5.2.0",
-        "@sentry/vue": "10.50.0",
+        "@sentry/browser": "10.53.1",
+        "@sentry/cloudflare": "10.53.1",
+        "@sentry/core": "10.53.1",
+        "@sentry/node": "10.53.1",
+        "@sentry/node-core": "10.53.1",
+        "@sentry/rollup-plugin": "^5.3.0",
+        "@sentry/vite-plugin": "^5.3.0",
+        "@sentry/vue": "10.53.1",
         "local-pkg": "^1.1.2"
       },
       "engines": {
@@ -6784,12 +6739,12 @@
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.50.0.tgz",
-      "integrity": "sha512-axn3pgDPveGdaMUC0abMCmFN7ux2pA5ebPufCef4lMIsyg7BBQvaEJ+vE19wjstMaBCAJGsdZlL3eeP2rtgRMw==",
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.53.1.tgz",
+      "integrity": "sha512-Zok6UXla0mFOjd1YnVb1TZtQNOry9v93fXUqx8jmDaygwWM2BwvP8rBQabLz0/OZXo8+35oge+Vmw+QY5aesnA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.50.0"
+        "@sentry/core": "10.53.1"
       },
       "engines": {
         "node": ">=18"
@@ -6802,12 +6757,12 @@
       }
     },
     "node_modules/@sentry/rollup-plugin": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@sentry/rollup-plugin/-/rollup-plugin-5.2.0.tgz",
-      "integrity": "sha512-a8LfpvcYMFtFSroro5MpCcOoS528LeLfUHzxWURnpofOnY+Aso9Si4y4dFlna+RKqxCXjmFbn6CLnfI+YrHysQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/rollup-plugin/-/rollup-plugin-5.3.0.tgz",
+      "integrity": "sha512-hgPGPYdQJ/G1cGYOxAb7d4z3V+/k/E5/P/5TFPEEBLuIbFFk+JG0CISUDJdzXJjO382Lb99PBJuXGbueBmO79w==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/bundler-plugin-core": "5.2.0",
+        "@sentry/bundler-plugin-core": "5.3.0",
         "magic-string": "~0.30.8"
       },
       "engines": {
@@ -6846,26 +6801,26 @@
       }
     },
     "node_modules/@sentry/vite-plugin": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.2.0.tgz",
-      "integrity": "sha512-4Jo3ixBspso5HY81PDvZdRXkH9wYGVmcw/0a2IX9ejbyKBdHqkYg4IhAtNqGUAyGuHwwRS9Y1S+sCMvrXv6htw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vite-plugin/-/vite-plugin-5.3.0.tgz",
+      "integrity": "sha512-qcoSzo4n2MulVQ70UUPLq6dTleb2a2HwL2wuwvAgWhPChrYTuk6A6mDg6aQb9fairPAwFPiU9PzOANpoDJcz1A==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/bundler-plugin-core": "5.2.0",
-        "@sentry/rollup-plugin": "5.2.0"
+        "@sentry/bundler-plugin-core": "5.3.0",
+        "@sentry/rollup-plugin": "5.3.0"
       },
       "engines": {
         "node": ">= 18"
       }
     },
     "node_modules/@sentry/vue": {
-      "version": "10.50.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-10.50.0.tgz",
-      "integrity": "sha512-xo2Nq+74KRh3OuZBVnejDiRZaqbnuUKUi6h2hRefFLnbsN3aU76NR0CekWzaabpczWvQRhLn7DC0s0m+pXeDAQ==",
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/vue/-/vue-10.53.1.tgz",
+      "integrity": "sha512-s5TeBXpQogrjS+Oom3y2wfOrju4RV2+E4wQoFt/TQPyACqvQHIcmapHcxk4bAx8jggRetmM+KwpMNgl6HJB0tg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.50.0",
-        "@sentry/core": "10.50.0"
+        "@sentry/browser": "10.53.1",
+        "@sentry/core": "10.53.1"
       },
       "engines": {
         "node": ">=18"
@@ -17616,9 +17571,9 @@
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
-      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
+      "integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
       "license": "MIT"
     },
     "node_modules/pg-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "nuxt": "^3.21.2",
         "pinia": "^3.0.4",
         "postcss": "^8.5.10",
-        "posthog-js": "^1.372.1",
+        "posthog-js": "^1.374.2",
         "resend": "^6.12.1",
         "sanitize-html": "^2.17.2",
         "tailwindcss": "^4.3.0",
@@ -5577,18 +5577,18 @@
       "license": "MIT"
     },
     "node_modules/@posthog/core": {
-      "version": "1.27.5",
-      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.27.5.tgz",
-      "integrity": "sha512-sYCcUDuYKumYTjwGqGCPT8aUy086v9PKw5wD+UXCRSfCsxWy5R/ic6W13kGTn4O5B2cD1V19wJv19oIH5kHUiQ==",
+      "version": "1.29.5",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.29.5.tgz",
+      "integrity": "sha512-Jm5AE95EwBRqO6J8+skDufyf5rnEcmOvjYArCKCOzD4mWdH1xGpfcRXj5TEyZII3mD04Kr7pw9aP2ZbAHQGu2A==",
       "license": "MIT",
       "dependencies": {
-        "@posthog/types": "1.372.1"
+        "@posthog/types": "1.374.2"
       }
     },
     "node_modules/@posthog/types": {
-      "version": "1.372.1",
-      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.1.tgz",
-      "integrity": "sha512-yl2x2HgtdhFk8bvf6HuRSDzXnKmKGrzNxUahKvA/0mcwheweINvmWy5MsN55NevrcCrNXA6m8GPHS9o/y1mn4A==",
+      "version": "1.374.2",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.374.2.tgz",
+      "integrity": "sha512-ZghQSFMi+HFJNPvPjBoyY/jWQ+q6mSQVtWQxOHMSbBidUZjsyYbxYxBFbHy2qWLNe4mEpX+Wqir2Q4I/4AVvJQ==",
       "license": "MIT"
     },
     "node_modules/@prisma/instrumentation": {
@@ -18340,9 +18340,9 @@
       }
     },
     "node_modules/posthog-js": {
-      "version": "1.372.1",
-      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.372.1.tgz",
-      "integrity": "sha512-gP316wDc36YbieIEW48wfB6wq2ugBNQc+XwNkewN9QRPzhitX+9dG6lUjqHEhMx3A2Y41HjbZf5Vl0Ll0ju8UA==",
+      "version": "1.374.2",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.374.2.tgz",
+      "integrity": "sha512-6z1xGlVocd3NmSZlJNFfpedLIHLcejuuQPxvrpHDvtyVI9tN1NPqbM7T7coXw2It6gdZ/nAgDuZkNxfIut+Spw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
@@ -18350,8 +18350,8 @@
         "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
         "@opentelemetry/resources": "^2.2.0",
         "@opentelemetry/sdk-logs": "^0.208.0",
-        "@posthog/core": "1.27.5",
-        "@posthog/types": "1.372.1",
+        "@posthog/core": "1.29.5",
+        "@posthog/types": "1.374.2",
         "core-js": "^3.38.1",
         "dompurify": "^3.3.2",
         "fflate": "^0.4.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "chart.js": "^4.5.1",
         "chartjs-adapter-date-fns": "^3.0.0",
         "chartjs-plugin-annotation": "^3.1.0",
-        "date-fns": "^4.1.0",
+        "date-fns": "^4.2.1",
         "fuse.js": "^7.3.0",
         "html2canvas": "^1.4.1",
         "jspdf": "^4.2.1",
@@ -11563,9 +11563,9 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.2.1.tgz",
+      "integrity": "sha512-37RhSdxaG1suen6VDCza6rNrQfooyQh57HFVPwQGEq2QWliVLzPQZ8Oa017weOu+HZCnzI7N3Pf/wyoBKfEqrA==",
       "license": "MIT",
       "funding": {
         "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10155,9 +10155,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -22234,9 +22234,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "chart.js": "^4.5.1",
     "chartjs-adapter-date-fns": "^3.0.0",
     "chartjs-plugin-annotation": "^3.1.0",
-    "date-fns": "^4.1.0",
+    "date-fns": "^4.2.1",
     "fuse.js": "^7.3.0",
     "html2canvas": "^1.4.1",
     "jspdf": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@nuxt/ui": "^3.3.7",
     "@nuxtjs/supabase": "^2.0.5",
     "@pinia/nuxt": "^0.11.3",
-    "@sentry/nuxt": "^10.50.0",
+    "@sentry/nuxt": "^10.53.1",
     "@sindresorhus/is": "^7.1.1",
     "@supabase/supabase-js": "^2.104.1",
     "@types/leaflet": "^1.9.21",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "pa11y-ci": "^4.1.0",
     "prettier": "^3.8.3",
     "supabase": "^2.100.0",
-    "tsx": "^4.21.0",
+    "tsx": "^4.22.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.0",
     "vitest": "^4.0.17",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "nuxt": "^3.21.2",
     "pinia": "^3.0.4",
     "postcss": "^8.5.10",
-    "posthog-js": "^1.372.1",
+    "posthog-js": "^1.374.2",
     "resend": "^6.12.1",
     "sanitize-html": "^2.17.2",
     "tailwindcss": "^4.3.0",


### PR DESCRIPTION
## Summary

Brings develop's accumulated CI/CD and dependency changes to main:

- **#243** date-fns 4.1.0 → 4.2.1
- **#244** posthog-js 1.372.1 → 1.374.2
- **#245** @sentry/nuxt 10.50.0 → 10.53.1
- **#246** tsx 4.21.0 → 4.22.2
- **#248** `ci: skip Slack notify step when webhook secret is unavailable` (silences noise on every Dependabot PR)
- **#249** auto-security-patch workflow's first run (brace-expansion bump-superseded; also patches misc transitive deps)
- **#250** `fix(ci): trigger CI on auto-security-patch PRs via close+reopen` (so future runs actually validate the patch)
- **#251** `ci: align test.yml NODE_VERSION with rest of CI (20 → 24)`
- Plus the back-merge commit pulling main's brace-expansion patch into develop's history.

## Test plan

- [ ] CI passes (lint, type-check, unit tests, security scans, deps audit)
- [ ] E2E: now uses fail-loud globalSetup; should fail fast or pass, not 30m hang
- [ ] After merge, develop and main identical (modulo merge commit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies: Sentry SDK, date-fns, PostHog analytics library, and Node.js build tooling.

* **Tests**
  * Updated Node.js version from 20 to 24.
  * Modified security patch workflow automation.
  * Adjusted CI/CD notification configuration handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/candrikanich/recruiting-compass-web/pull/252?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->