### PR TITLE
fix(deps): restore commander@13.1.0 node to lockfile (fixes Weekly Quality Sweep)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17696,6 +17696,17 @@
       "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "license": "MIT"
     },
+    "node_modules/nuxt/node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/nuxt/node_modules/entities": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",


### PR DESCRIPTION
## Problem

The **Weekly Quality Sweep** workflow on `main` failed (run 26384705584) at `npm ci`:

```
npm error `npm ci` can only install packages when your package.json and
package-lock.json or npm-shrinkwrap.json are in sync.
npm error Missing: commander@13.1.0 from lock file
```

## Root cause

Dependabot's `qs` bump (#256) surgically edited `package-lock.json` with a newer npm and dropped the resolved node for `commander@13.1.0` — an **optional peer** of `@bomb.sh/tab` (transitive via `nuxt`). Local npm 11.x tolerates the omission; CI's **npm 10.8.2** (bundled with node 20) is stricter and rejects it.

## Fix

Regenerated the lockfile with `npx npm@10.8.2 install --package-lock-only` (matching CI's npm) to add **only** the missing node. Diff is 11 lines — a single `node_modules/nuxt/node_modules/commander` entry.

## Verification

- ✅ `npx npm@10.8.2 ci --dry-run` passes (previously failed with EUSAGE)
- ✅ No package.json changes — lockfile-only fix
- ✅ No dependency version changes — only restores the dropped resolution node

## Notes

`develop` carries the same latent omission but is much further ahead on deps; this PR targets `main` only to unblock the scheduled workflow.