### PR TITLE
fix(deps): pin @nuxt/ui to 3.x — v4 silently disables icons in production

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,13 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # @nuxt/ui 4.x requires Nuxt >=4.1; we run Nuxt 3. Nuxt disables an
+      # incompatible module with a WARN and still exits 0, so a 3.x -> 4.x bump
+      # ships a build with @nuxt/ui and @nuxt/icon silently missing. Security
+      # updates bypass the wildcard major ignore above and target the default
+      # branch, so this needs its own entry. Drop it when we move to Nuxt 4.
+      - dependency-name: "@nuxt/ui"
+        versions: [">=4.0.0"]
 
   # Enable GitHub Actions workflow updates
   - package-ecosystem: "github-actions"

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -26,6 +26,12 @@ export default defineNuxtConfig({
   // ships >=3.21.7 with the cherry-pick.
   experimental: {
     viteEnvironmentApi: true,
+
+    // A module declaring a Nuxt version range we don't satisfy is otherwise
+    // only a build WARN — Nuxt drops the module and exits 0. That is how
+    // @nuxt/ui 4.x (requires Nuxt >=4.1) silently took @nuxt/icon down with it
+    // and shipped a prod build with no bundled icons. Fail the build instead.
+    enforceModuleCompatibility: true,
   },
 
   css: ["~/assets/css/main.css"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "recruiting-compass",
       "version": "1.0.0",
       "dependencies": {
-        "@nuxt/ui": "^4.8.0",
+        "@nuxt/ui": "~3.3.7",
         "@nuxtjs/supabase": "^2.0.9",
         "@pinia/nuxt": "^0.11.3",
         "@sentry/nuxt": "^10.69.0",
@@ -95,6 +95,15 @@
         "package-manager-detector": "^1.3.0",
         "tinyexec": "^1.0.1"
       },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@antfu/utils": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-8.1.1.tgz",
+      "integrity": "sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
@@ -627,16 +636,21 @@
         }
       }
     },
+    "node_modules/@capsizecss/metrics": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@capsizecss/metrics/-/metrics-3.7.0.tgz",
+      "integrity": "sha512-NHdEMrl/zd2XgiSv2xHRF/FxGc2OTBKjhPzr9SgbHzqmoTVn8BbRK88Dtq0m65idX/RMD7ptyVdbGHFcvlErSw==",
+      "license": "MIT"
+    },
     "node_modules/@capsizecss/unpack": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-4.0.1.tgz",
-      "integrity": "sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@capsizecss/unpack/-/unpack-2.4.0.tgz",
+      "integrity": "sha512-GrSU71meACqcmIUxPYOJvGKF0yryjN/L1aCuE9DViCTJI7bfkjgYDPD1zbNDcINJwSSP6UaBZY9GAbYDO7re0Q==",
       "license": "MIT",
       "dependencies": {
-        "fontkitten": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=18"
+        "blob-to-buffer": "^1.2.8",
+        "cross-fetch": "^3.0.4",
+        "fontkit": "^2.0.2"
       }
     },
     "node_modules/@clack/core": {
@@ -1639,9 +1653,9 @@
       }
     },
     "node_modules/@iconify/collections": {
-      "version": "1.0.718",
-      "resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.718.tgz",
-      "integrity": "sha512-deWwDggvwVU8HaAsKeKQJijV/G1Lev5tHFNSUquwbJ01484fAytcizo1khAr7EGf29TGf3p/O1LRU8BvRjZYDA==",
+      "version": "1.0.719",
+      "resolved": "https://registry.npmjs.org/@iconify/collections/-/collections-1.0.719.tgz",
+      "integrity": "sha512-v3I7sBgR0UWOr6y4bXGiuNrOOl9d+tRDPg1d7vfQHofQ4nTt3AU15S2UsePjHztYAc7ptSPUTT74Io2M7Y1CZg==",
       "license": "MIT",
       "dependencies": {
         "@iconify/types": "*"
@@ -1654,14 +1668,31 @@
       "license": "MIT"
     },
     "node_modules/@iconify/utils": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
-      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.3.0.tgz",
+      "integrity": "sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA==",
       "license": "MIT",
       "dependencies": {
-        "@antfu/install-pkg": "^1.1.0",
+        "@antfu/install-pkg": "^1.0.0",
+        "@antfu/utils": "^8.1.0",
         "@iconify/types": "^2.0.0",
-        "import-meta-resolve": "^4.2.0"
+        "debug": "^4.4.0",
+        "globals": "^15.14.0",
+        "kolorist": "^1.8.0",
+        "local-pkg": "^1.0.0",
+        "mlly": "^1.7.4"
+      }
+    },
+    "node_modules/@iconify/utils/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@iconify/vue": {
@@ -2595,251 +2626,543 @@
       }
     },
     "node_modules/@nuxt/fonts": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/fonts/-/fonts-0.14.0.tgz",
-      "integrity": "sha512-4uXQl9fa5F4ibdgU8zomoOcyMdnwgdem+Pi8JEqeDYI5yPR32Kam6HnuRr47dTb97CstaepAvXPWQUUHMtjsFQ==",
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/@nuxt/fonts/-/fonts-0.11.4.tgz",
+      "integrity": "sha512-GbLavsC+9FejVwY+KU4/wonJsKhcwOZx/eo4EuV57C4osnF/AtEmev8xqI0DNlebMEhEGZbu1MGwDDDYbeR7Bw==",
       "license": "MIT",
       "dependencies": {
-        "@nuxt/devtools-kit": "^3.2.1",
-        "@nuxt/kit": "^4.2.2",
+        "@nuxt/devtools-kit": "^2.4.0",
+        "@nuxt/kit": "^3.17.3",
         "consola": "^3.4.2",
+        "css-tree": "^3.1.0",
         "defu": "^6.1.4",
-        "fontless": "^0.2.1",
-        "h3": "^1.15.5",
+        "esbuild": "^0.25.4",
+        "fontaine": "^0.6.0",
+        "h3": "^1.15.3",
+        "jiti": "^2.4.2",
         "magic-regexp": "^0.10.0",
-        "ofetch": "^1.5.1",
-        "pathe": "^2.0.3",
-        "sirv": "^3.0.2",
-        "tinyglobby": "^0.2.15",
-        "ufo": "^1.6.3",
-        "unifont": "^0.7.4",
-        "unplugin": "^3.0.0",
-        "unstorage": "^1.17.4"
-      }
-    },
-    "node_modules/@nuxt/fonts/node_modules/@nuxt/kit": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.1.tgz",
-      "integrity": "sha512-xDXQspE2blxaZwxwGknL/BqaIbkLizl85Ov+pbSlPPd/rw2KjJGx88RHU5SwoQNwCiSC5hWZBnVAznIsq1xNHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "c12": "^3.3.4",
-        "consola": "^3.4.2",
-        "defu": "^6.1.7",
-        "destr": "^2.0.5",
-        "errx": "^0.1.0",
-        "exsolve": "^1.1.0",
-        "ignore": "^7.0.6",
-        "jiti": "^2.7.0",
-        "klona": "^2.0.6",
-        "mlly": "^1.8.2",
-        "nostics": "^1.2.0",
+        "magic-string": "^0.30.17",
+        "node-fetch-native": "^1.6.6",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
-        "pkg-types": "^2.3.1",
-        "rc9": "^3.0.1",
-        "scule": "^1.3.0",
-        "tinyglobby": "^0.2.17",
-        "ufo": "^1.6.4",
-        "unctx": "^3.0.0",
-        "untyped": "^2.0.0",
-        "verkit": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=18.12.0"
+        "sirv": "^3.0.1",
+        "tinyglobby": "^0.2.13",
+        "ufo": "^1.6.1",
+        "unifont": "^0.4.1",
+        "unplugin": "^2.3.3",
+        "unstorage": "^1.16.0"
       }
     },
-    "node_modules/@nuxt/fonts/node_modules/tinyglobby": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/@nuxt/devtools-kit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-2.7.0.tgz",
+      "integrity": "sha512-MIJdah6CF6YOW2GhfKnb8Sivu6HpcQheqdjOlZqShBr+1DyjtKQbAKSCAyKPaoIzZP4QOo2SmTFV6aN8jBeEIQ==",
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/@nuxt/fonts/node_modules/unctx": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
-      "integrity": "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "magic-string": ">=0.30.21",
-        "oxc-parser": ">=0.140.0",
-        "rolldown": "^1.1.5",
-        "unplugin": "^3.3.0"
-      },
-      "peerDependenciesMeta": {
-        "magic-string": {
-          "optional": true
-        },
-        "oxc-parser": {
-          "optional": true
-        },
-        "rolldown": {
-          "optional": true
-        },
-        "unplugin": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@nuxt/fonts/node_modules/unplugin": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
-      "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/remapping": "^2.3.5",
-        "picomatch": "^4.0.4",
-        "webpack-virtual-modules": "^0.6.2"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "@nuxt/kit": "^3.19.3",
+        "execa": "^8.0.1"
       },
       "peerDependencies": {
-        "@farmfe/core": "*",
-        "@rspack/core": "*",
-        "bun-types-no-globals": "*",
-        "esbuild": "*",
-        "rolldown": "*",
-        "rollup": "*",
-        "unloader": "*",
-        "vite": "*",
-        "webpack": "*"
+        "vite": ">=6.0"
+      }
+    },
+    "node_modules/@nuxt/fonts/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
       },
-      "peerDependenciesMeta": {
-        "@farmfe/core": {
-          "optional": true
-        },
-        "@rspack/core": {
-          "optional": true
-        },
-        "bun-types-no-globals": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "rolldown": {
-          "optional": true
-        },
-        "rollup": {
-          "optional": true
-        },
-        "unloader": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
       }
     },
     "node_modules/@nuxt/icon": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/icon/-/icon-2.4.1.tgz",
-      "integrity": "sha512-fOY3kiT6OoL4bWXVmMLc1VgoCm1PxIGSBmsSaLO090NEgtd1ub441dZ7MEoOD5UIilWzba1kCWdwJcAkGCOwLg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/icon/-/icon-1.15.0.tgz",
+      "integrity": "sha512-kA0rxqr1B601zNJNcOXera8CyYcxUCEcT7dXEC7rwAz71PRCN5emf7G656eKEQgtqrD4JSj6NQqWDgrmFcf/GQ==",
       "license": "MIT",
       "dependencies": {
-        "@iconify/collections": "^1.0.715",
+        "@iconify/collections": "^1.0.563",
         "@iconify/types": "^2.0.0",
-        "@iconify/utils": "^3.1.4",
-        "@iconify/vue": "^5.0.1",
-        "@nuxt/devtools-kit": "^3.3.1",
-        "@nuxt/kit": "^4.5.0",
+        "@iconify/utils": "^2.3.0",
+        "@iconify/vue": "^5.0.0",
+        "@nuxt/devtools-kit": "^2.5.0",
+        "@nuxt/kit": "^3.17.5",
         "consola": "^3.4.2",
-        "local-pkg": "^1.2.1",
-        "mlly": "^1.8.2",
-        "ohash": "^2.0.11",
-        "picomatch": "^4.0.5",
-        "std-env": "^4.2.0",
-        "tinyglobby": "^0.2.17",
-        "ufo": "^1.6.4"
-      }
-    },
-    "node_modules/@nuxt/icon/node_modules/@nuxt/kit": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.1.tgz",
-      "integrity": "sha512-xDXQspE2blxaZwxwGknL/BqaIbkLizl85Ov+pbSlPPd/rw2KjJGx88RHU5SwoQNwCiSC5hWZBnVAznIsq1xNHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "c12": "^3.3.4",
-        "consola": "^3.4.2",
-        "defu": "^6.1.7",
-        "destr": "^2.0.5",
-        "errx": "^0.1.0",
-        "exsolve": "^1.1.0",
-        "ignore": "^7.0.6",
-        "jiti": "^2.7.0",
-        "klona": "^2.0.6",
-        "mlly": "^1.8.2",
-        "nostics": "^1.2.0",
+        "local-pkg": "^1.1.1",
+        "mlly": "^1.7.4",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
-        "pkg-types": "^2.3.1",
-        "rc9": "^3.0.1",
-        "scule": "^1.3.0",
-        "tinyglobby": "^0.2.17",
-        "ufo": "^1.6.4",
-        "unctx": "^3.0.0",
-        "untyped": "^2.0.0",
-        "verkit": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=18.12.0"
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinyglobby": "^0.2.14"
       }
     },
-    "node_modules/@nuxt/icon/node_modules/tinyglobby": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+    "node_modules/@nuxt/icon/node_modules/@nuxt/devtools-kit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@nuxt/devtools-kit/-/devtools-kit-2.7.0.tgz",
+      "integrity": "sha512-MIJdah6CF6YOW2GhfKnb8Sivu6HpcQheqdjOlZqShBr+1DyjtKQbAKSCAyKPaoIzZP4QOo2SmTFV6aN8jBeEIQ==",
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
+        "@nuxt/kit": "^3.19.3",
+        "execa": "^8.0.1"
       },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
+      "peerDependencies": {
+        "vite": ">=6.0"
       }
     },
-    "node_modules/@nuxt/icon/node_modules/unctx": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unctx/-/unctx-3.0.0.tgz",
-      "integrity": "sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "magic-string": ">=0.30.21",
-        "oxc-parser": ">=0.140.0",
-        "rolldown": "^1.1.5",
-        "unplugin": "^3.3.0"
-      },
-      "peerDependenciesMeta": {
-        "magic-string": {
-          "optional": true
-        },
-        "oxc-parser": {
-          "optional": true
-        },
-        "rolldown": {
-          "optional": true
-        },
-        "unplugin": {
-          "optional": true
-        }
-      }
+    "node_modules/@nuxt/icon/node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "license": "MIT"
     },
     "node_modules/@nuxt/kit": {
       "version": "3.21.10",
@@ -3006,49 +3329,29 @@
       "license": "MIT"
     },
     "node_modules/@nuxt/ui": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@nuxt/ui/-/ui-4.8.0.tgz",
-      "integrity": "sha512-ymnGxvMCYtPzuMGIK/fnd41/Arh9hxfmz9m5auaf51jg/zhSpAkIesTVSv0at+bGKXxwtQZoPS9GXs0+SzWfjg==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/@nuxt/ui/-/ui-3.3.7.tgz",
+      "integrity": "sha512-pTUb/Uk3J2XVWDFks7baTmq9hfp+T+nvnXP7/QypBIAZLdkSMgEsFmP7xgX5Gugc/LaThIkAifzfks4wiSGuVA==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.6",
-        "@iconify/vue": "^5.0.1",
-        "@internationalized/date": "^3.12.1",
-        "@internationalized/number": "^3.6.6",
-        "@nuxt/fonts": "^0.14.0",
-        "@nuxt/icon": "^2.2.2",
-        "@nuxt/kit": "^4.4.6",
-        "@nuxt/schema": "^4.4.6",
+        "@iconify/vue": "^5.0.0",
+        "@internationalized/date": "^3.10.0",
+        "@internationalized/number": "^3.6.5",
+        "@nuxt/fonts": "^0.11.4",
+        "@nuxt/icon": "^1.15.0",
+        "@nuxt/kit": "^4.1.2",
+        "@nuxt/schema": "^4.1.2",
         "@nuxtjs/color-mode": "^3.5.2",
-        "@standard-schema/spec": "^1.1.0",
-        "@tailwindcss/postcss": "^4.3.0",
-        "@tailwindcss/vite": "^4.3.0",
+        "@standard-schema/spec": "^1.0.0",
+        "@tailwindcss/postcss": "^4.1.16",
+        "@tailwindcss/vite": "^4.1.16",
         "@tanstack/vue-table": "^8.21.3",
-        "@tanstack/vue-virtual": "^3.13.24",
-        "@tiptap/core": "^3.22.4",
-        "@tiptap/extension-bubble-menu": "^3.22.4",
-        "@tiptap/extension-code": "^3.22.4",
-        "@tiptap/extension-collaboration": "^3.22.4",
-        "@tiptap/extension-drag-handle": "^3.22.4",
-        "@tiptap/extension-drag-handle-vue-3": "^3.22.4",
-        "@tiptap/extension-floating-menu": "^3.22.4",
-        "@tiptap/extension-horizontal-rule": "^3.22.4",
-        "@tiptap/extension-image": "^3.22.4",
-        "@tiptap/extension-mention": "^3.22.4",
-        "@tiptap/extension-node-range": "^3.22.4",
-        "@tiptap/extension-placeholder": "^3.22.4",
-        "@tiptap/markdown": "^3.22.4",
-        "@tiptap/pm": "^3.22.4",
-        "@tiptap/starter-kit": "^3.22.4",
-        "@tiptap/suggestion": "^3.22.4",
-        "@tiptap/vue-3": "^3.22.4",
-        "@unhead/vue": "^2.1.15",
-        "@vueuse/core": "^14.3.0",
-        "@vueuse/integrations": "^14.3.0",
-        "@vueuse/shared": "^14.3.0",
+        "@unhead/vue": "^2.0.19",
+        "@vueuse/core": "^13.9.0",
+        "@vueuse/integrations": "^13.9.0",
         "colortranslator": "^5.0.0",
         "consola": "^3.4.2",
-        "defu": "^6.1.7",
+        "defu": "^6.1.4",
         "embla-carousel-auto-height": "^8.6.0",
         "embla-carousel-auto-scroll": "^8.6.0",
         "embla-carousel-autoplay": "^8.6.0",
@@ -3056,58 +3359,40 @@
         "embla-carousel-fade": "^8.6.0",
         "embla-carousel-vue": "^8.6.0",
         "embla-carousel-wheel-gestures": "^8.1.0",
-        "fuse.js": "^7.3.0",
-        "hookable": "^6.1.1",
-        "knitwork": "^1.3.0",
-        "magic-string": "^0.30.21",
-        "mlly": "^1.8.2",
-        "motion-v": "^2.2.1",
+        "fuse.js": "^7.1.0",
+        "hookable": "^5.5.3",
+        "knitwork": "^1.2.0",
+        "magic-string": "^0.30.19",
+        "mlly": "^1.8.0",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
-        "reka-ui": "2.9.7",
+        "reka-ui": "2.6.0",
         "scule": "^1.3.0",
-        "tailwind-merge": "^3.6.0",
-        "tailwind-variants": "^3.2.2",
-        "tailwindcss": "^4.3.0",
-        "tinyglobby": "^0.2.16",
-        "ufo": "^1.6.4",
-        "unplugin": "^3.0.0",
-        "unplugin-auto-import": "^21.0.0",
-        "unplugin-vue-components": "^32.0.0",
+        "tailwind-merge": "^3.3.1",
+        "tailwind-variants": "^3.1.1",
+        "tailwindcss": "^4.1.16",
+        "tinyglobby": "^0.2.15",
+        "unplugin": "^2.3.10",
+        "unplugin-auto-import": "^20.2.0",
+        "unplugin-vue-components": "^30.0.0",
         "vaul-vue": "0.4.1",
-        "vue-component-type-helpers": "^3.3.0"
+        "vue-component-type-helpers": "^3.1.1"
       },
       "bin": {
         "nuxt-ui": "cli/index.mjs"
       },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
       "peerDependencies": {
-        "@inertiajs/vue3": "^2.0.7 || ^3.0.0",
-        "@internationalized/date": "^3.0.0",
-        "@internationalized/number": "^3.0.0",
-        "@nuxt/content": "^3.0.0",
-        "joi": "^18.0.0",
+        "@inertiajs/vue3": "^2.0.7",
+        "joi": "^17.13.0",
         "superstruct": "^2.0.0",
-        "tailwindcss": "^4.0.0",
-        "typescript": "^5.6.3 || ^6.0.0",
+        "typescript": "^5.6.3",
         "valibot": "^1.0.0",
-        "vue-router": "^4.5.0 || ^5.0.0",
-        "yup": "^1.7.0",
+        "vue-router": "^4.5.0",
+        "yup": "^1.6.0",
         "zod": "^3.24.0 || ^4.0.0"
       },
       "peerDependenciesMeta": {
         "@inertiajs/vue3": {
-          "optional": true
-        },
-        "@internationalized/date": {
-          "optional": true
-        },
-        "@internationalized/number": {
-          "optional": true
-        },
-        "@nuxt/content": {
           "optional": true
         },
         "joi": {
@@ -3149,17 +3434,17 @@
       }
     },
     "node_modules/@nuxt/ui/node_modules/@nuxt/kit": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.1.tgz",
-      "integrity": "sha512-xDXQspE2blxaZwxwGknL/BqaIbkLizl85Ov+pbSlPPd/rw2KjJGx88RHU5SwoQNwCiSC5hWZBnVAznIsq1xNHQ==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@nuxt/kit/-/kit-4.5.2.tgz",
+      "integrity": "sha512-l66LU9DcJYjmNwqwAj2I5UGRrUbnG2DOKGChnN70zIGtn0eq/z87gi/FRgha6eMb9/FmB1PFHgtx6PWVml1C2Q==",
       "license": "MIT",
       "dependencies": {
         "c12": "^3.3.4",
         "consola": "^3.4.2",
         "defu": "^6.1.7",
         "destr": "^2.0.5",
-        "errx": "^0.1.0",
-        "exsolve": "^1.1.0",
+        "errx": "^0.1.2",
+        "exsolve": "^1.1.1",
         "ignore": "^7.0.6",
         "jiti": "^2.7.0",
         "klona": "^2.0.6",
@@ -3174,7 +3459,7 @@
         "ufo": "^1.6.4",
         "unctx": "^3.0.0",
         "untyped": "^2.0.0",
-        "verkit": "^0.2.0"
+        "verkit": "^0.3.1"
       },
       "engines": {
         "node": ">=18.12.0"
@@ -3232,10 +3517,126 @@
         "vue": "^2.7.0 || ^3.0.0"
       }
     },
-    "node_modules/@nuxt/ui/node_modules/hookable": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
-      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
+    "node_modules/@nuxt/ui/node_modules/@vueuse/core": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.9.0.tgz",
+      "integrity": "sha512-ts3regBQyURfCE2BcytLqzm8+MmLlo5Ln/KLoxDVcsZ2gzIwVNnQpQOL/UKV8alUqjSZOlpFZcRNsLRqj+OzyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "13.9.0",
+        "@vueuse/shared": "13.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@nuxt/ui/node_modules/@vueuse/integrations": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-13.9.0.tgz",
+      "integrity": "sha512-SDobKBbPIOe0cVL7QxMzGkuUGHvWTdihi9zOrrWaWUgFKe15cwEcwfWmgrcNzjT6kHnNmWuTajPHoIzUjYNYYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "13.9.0",
+        "@vueuse/shared": "13.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7 || ^8",
+        "vue": "^3.5.0"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nuxt/ui/node_modules/@vueuse/metadata": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.9.0.tgz",
+      "integrity": "sha512-1AFRvuiGphfF7yWixZa0KwjYH8ulyjDCC0aFgrGRz8+P4kvDFSdXLVfTk5xAN9wEuD1J6z4/myMoYbnHoX07zg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@nuxt/ui/node_modules/@vueuse/shared": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.9.0.tgz",
+      "integrity": "sha512-e89uuTLMh0U5cZ9iDpEI2senqPGfbPRTHM/0AaQkcxnpqjkZqDYP8rpfm7edOz8s+pOCOROEy1PIveSW8+fL5g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@nuxt/ui/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@nuxt/ui/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "license": "MIT"
     },
     "node_modules/@nuxt/ui/node_modules/reka-ui": {
@@ -3301,6 +3702,18 @@
         "vue": "^3.5.0"
       }
     },
+    "node_modules/@nuxt/ui/node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/@nuxt/ui/node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -3317,75 +3730,46 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/@nuxt/ui/node_modules/unplugin": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
-      "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
+    "node_modules/@nuxt/ui/node_modules/unimport": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/unimport/-/unimport-5.7.0.tgz",
+      "integrity": "sha512-njnL6sp8lEA8QQbZrt+52p/g4X0rw3bnGGmUcJnt1jeG8+iiqO779aGz0PirCtydAIVcuTBRlJ52F0u46z309Q==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/remapping": "^2.3.5",
-        "picomatch": "^4.0.4",
-        "webpack-virtual-modules": "^0.6.2"
+        "acorn": "^8.16.0",
+        "escape-string-regexp": "^5.0.0",
+        "estree-walker": "^3.0.3",
+        "local-pkg": "^1.1.2",
+        "magic-string": "^0.30.21",
+        "mlly": "^1.8.0",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "pkg-types": "^2.3.0",
+        "scule": "^1.3.0",
+        "strip-literal": "^3.1.0",
+        "tinyglobby": "^0.2.15",
+        "unplugin": "^2.3.11",
+        "unplugin-utils": "^0.3.1"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "peerDependencies": {
-        "@farmfe/core": "*",
-        "@rspack/core": "*",
-        "bun-types-no-globals": "*",
-        "esbuild": "*",
-        "rolldown": "*",
-        "rollup": "*",
-        "unloader": "*",
-        "vite": "*",
-        "webpack": "*"
-      },
-      "peerDependenciesMeta": {
-        "@farmfe/core": {
-          "optional": true
-        },
-        "@rspack/core": {
-          "optional": true
-        },
-        "bun-types-no-globals": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "rolldown": {
-          "optional": true
-        },
-        "rollup": {
-          "optional": true
-        },
-        "unloader": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
+        "node": ">=18.12.0"
       }
     },
     "node_modules/@nuxt/ui/node_modules/unplugin-auto-import": {
-      "version": "21.1.0",
-      "resolved": "https://registry.npmjs.org/unplugin-auto-import/-/unplugin-auto-import-21.1.0.tgz",
-      "integrity": "sha512-EzrSqWIBulEqCuP7idADXH+tVKYrbwKlR5+r/lOWik0o+Ksny1kitmtryHGNSv7puzzORlcIwT/x2JStiszlHA==",
+      "version": "20.3.0",
+      "resolved": "https://registry.npmjs.org/unplugin-auto-import/-/unplugin-auto-import-20.3.0.tgz",
+      "integrity": "sha512-RcSEQiVv7g0mLMMXibYVKk8mpteKxvyffGuDKqZZiFr7Oq3PB1HwgHdK5O7H4AzbhzHoVKG0NnMnsk/1HIVYzQ==",
       "license": "MIT",
       "dependencies": {
-        "local-pkg": "^1.2.1",
-        "magic-string": "^1.1.0",
-        "picomatch": "^4.0.5",
-        "unimport": "^6.4.0",
-        "unplugin": "^3.3.0",
-        "unplugin-utils": "^0.3.2"
+        "local-pkg": "^1.1.2",
+        "magic-string": "^0.30.21",
+        "picomatch": "^4.0.3",
+        "unimport": "^5.5.0",
+        "unplugin": "^2.3.11",
+        "unplugin-utils": "^0.3.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -3403,13 +3787,16 @@
         }
       }
     },
-    "node_modules/@nuxt/ui/node_modules/unplugin-auto-import/node_modules/magic-string": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-1.1.0.tgz",
-      "integrity": "sha512-kS3VHe0nEPST2saQV4Rbkchcd3UBRkVTQHo1D3h/ZTwFDhai/mfKkmtPAtD129EOI7K3HlHIsFOt0WrI2/oU9g==",
+    "node_modules/@nuxt/ui/node_modules/verkit": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/verkit/-/verkit-0.3.2.tgz",
+      "integrity": "sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg==",
       "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.5"
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
       }
     },
     "node_modules/@nuxt/vite-builder": {
@@ -7100,587 +7487,6 @@
         "vue": "^2.7.0 || ^3.0.0"
       }
     },
-    "node_modules/@tiptap/core": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.29.2.tgz",
-      "integrity": "sha512-oKUkiPUB7noilVYxI9lNzUD4rX17sHub+PYjMfHMWHG9A3nvIy+FdePIVIIhThKWF7ijhr3eIqHY51Bn+GAFtw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/pm": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-blockquote": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.29.2.tgz",
-      "integrity": "sha512-ca4OzKDh0yaxg2+Z56bC2QnWsNsFp2YMRfVig1PDXyMVFMNJpLcnhxgq/9btn+xYAlYrj8RymOeCTYREOR6Zjg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-bold": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.29.2.tgz",
-      "integrity": "sha512-elYbGxJsYnBb4leqrcjdIJuiG380BcOgN+UUzvOv+qEjfGVzHodFOMBl3qnmD6urYHNu5/qQK2S0qSSRXKCLNQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-bubble-menu": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.29.2.tgz",
-      "integrity": "sha512-kzcWarcpr031rZu+R3Hzut5uxb3Qj/xxMDEYZIQ3uiq1yb5vEMXj8/SIyWautk6Nu8Rr1leV3rGdR4NzhzyFAA==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-bullet-list": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.29.2.tgz",
-      "integrity": "sha512-3bWcCUPbCHv0XttlMdnAtXLNYWx2pblByMgxmGsaP9FU0QnslGXty6A6gHCqI33ygRg1vrA6U5Wtpwbi5aKu5g==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-code": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.29.2.tgz",
-      "integrity": "sha512-c6W5UGuB7WNLpYocsgRzpO2OOTI4QjaI9jjHRMuty9z+s9DtaYM/HrRLNwVh6MopkHb+i/89Wkv8gCS34fftig==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-code-block": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.29.2.tgz",
-      "integrity": "sha512-w153ct8g6dLiPTdXQ6SOIMxX4SEo5Q50AmjdEEEcJ7ZcYUcde/ScSskLHfOYmyt5ZFAiyEwr121+pux+p3/oAQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-collaboration": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-3.29.2.tgz",
-      "integrity": "sha512-KVKwIofMzraf0MxCXUkYd6fNmz0oGKaHDkjhNT6HGHrVzTFDJlZTwHHwSndQS2xKGmZbhWe8C32hvUrFsZXTPw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2",
-        "@tiptap/y-tiptap": "^3.0.7",
-        "yjs": "^13"
-      }
-    },
-    "node_modules/@tiptap/extension-document": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.29.2.tgz",
-      "integrity": "sha512-YUamvefLnsqu6124GavVTI7nqcFlQJ12ROB0oSwG69eSBZYNjg1tIs05LFrBxkwf4Xgqd6YzfJ9+FeG428RvzQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-drag-handle": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle/-/extension-drag-handle-3.29.2.tgz",
-      "integrity": "sha512-5Y5ElfRnrWIr9IRODzGkqLgIIbdUXNstbs7hWskXQWTg532TJfMpZmQbQRv7th39IcH0uusT7Vs/QlFKXzKVkA==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.6.13"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/extension-collaboration": "3.29.2",
-        "@tiptap/extension-node-range": "3.29.2",
-        "@tiptap/pm": "3.29.2",
-        "@tiptap/y-tiptap": "^3.0.7"
-      }
-    },
-    "node_modules/@tiptap/extension-drag-handle-vue-3": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle-vue-3/-/extension-drag-handle-vue-3-3.29.2.tgz",
-      "integrity": "sha512-4u2CraVeMEeq2Xyi/9YmFBhL/uE/Lb5IViWKNfOM4PmnPDAgAj6hXA1s/QIdBKNIE6ohWCQRfAKX+b5Ff5LStQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-drag-handle": "3.29.2",
-        "@tiptap/pm": "3.29.2",
-        "@tiptap/vue-3": "3.29.2",
-        "vue": "^3.0.0"
-      }
-    },
-    "node_modules/@tiptap/extension-dropcursor": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.29.2.tgz",
-      "integrity": "sha512-KKno7cU9r1HdR48CRrsDu69/1UjZdoslq/UcE+Kx+tdhAv/aljXMkRSNzGMrBNOBDmHRgS1+58zm21WQWdQzwA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extensions": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-floating-menu": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.29.2.tgz",
-      "integrity": "sha512-CBTq4Xs5aGWr65uFCIkKBms796OhmirWf/ax//iJ4fl9IfwqjwFuc2vQs9PmuwpKn9ctDHo2sMTtvyeCvIt5LQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-gapcursor": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.29.2.tgz",
-      "integrity": "sha512-8Q39UR4/Tit759IeW9xZIe3NMwN11GsuA3FLheDyyGn7RrW02HD3HhUDlazE54Ki4HoosjFmChPlN4Ik2ubdRQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extensions": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-hard-break": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.29.2.tgz",
-      "integrity": "sha512-eUW3LN3fq8rXnjEUeI3D2QONYdLsU3yYQm4jxlErs2h4cfwrFjgf19VSUFVmm6LrFbbQ0OnDVPeVLL6iOwDw2w==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-heading": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.29.2.tgz",
-      "integrity": "sha512-6W4aIy70Mh7BNlbG9zZ5FBLhJhU2UUEzgZJ/jwYSCcB30o8McLxJSEjhtoHiX8R78Ah2/JzBGvIe5olZlbeE4A==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-horizontal-rule": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.29.2.tgz",
-      "integrity": "sha512-8/ZPzbB9X85Mc9/7xVLZupQKBr2UVcQTGr512xtqMW+XkCQRHCph46tRo828YE13IMWI5fWn/FaNCqXG9cULSw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-image": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-image/-/extension-image-3.29.2.tgz",
-      "integrity": "sha512-F+S4iru247mNVZdkNwNDZHeb281DkjsBJinaOGsOyJTvXY+KU5Uq7vY1LQTn493dTfU48Z0yMBUXwJffCT92Mg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-italic": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.29.2.tgz",
-      "integrity": "sha512-iH63V/5wsaMnY4Jz0+meaAGhaec4AiOzOduzl6ZZr5IyGhZ1kthyW84ELt0dyLI3hNceAUhaNWc+I7+vX0aoXA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-link": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.29.2.tgz",
-      "integrity": "sha512-DcVer5SqrexKCEP6Ip1UPxJUMvcRCCItSv0wxoGytanrimBh2smvcg6X0DWnjlsi5H0updhyl+atYCmmQXUIXA==",
-      "license": "MIT",
-      "dependencies": {
-        "linkifyjs": "^4.3.3"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-list": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.29.2.tgz",
-      "integrity": "sha512-WPZ9BHAPT6QeIm1vdVkuoOWvy9a8/EZeJwV2VhU8LXyTAttvzyj4rsbbHyJWvYWlUSTt/QF2AZ2zhKo7u1w3/A==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-list-item": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.29.2.tgz",
-      "integrity": "sha512-s8vBVHHFT0Qpu7CzAZ7S1kYmSiVaDvUNvMNcZUWnxj6VPfiwmx0eXd9FsjePrRCMoM5tFmPnhFTHDxY3D/eZeQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-list-keymap": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.29.2.tgz",
-      "integrity": "sha512-R+3k8OLnxdCH7Xy9ieOwUt5m2Je74u8mikothGmsYVO2Zyq48fIbmZ+X6RBPCu7DBOI2FIUhHEFbKQeDWvDNmA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-mention": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-mention/-/extension-mention-3.29.2.tgz",
-      "integrity": "sha512-WF8ugDa2IRbgyRW+PffPYg8ZI+Qp9azvIsNoyuf+VSg5Vp7ze2TuJXUTObSckyiN5Ann8bDNM9Hbu3TdoI0DFQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2",
-        "@tiptap/suggestion": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-node-range": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-node-range/-/extension-node-range-3.29.2.tgz",
-      "integrity": "sha512-7ipYCrGZvnOL0vR4E69m8PSKDg49hH5n8nVFRej3cRn/xAdAl+ytJmrLSE+SLPvw6TN44NWk3iug23IjOu3Nbw==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-ordered-list": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.29.2.tgz",
-      "integrity": "sha512-ndCunC+UsYOpkOtL7vGnDz21UNa45WUlcO9wMT1fbuYow2QnRhsuMlCWENXI52YPPARWuQ0RDgN7q6TaxPERBg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extension-list": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-paragraph": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.29.2.tgz",
-      "integrity": "sha512-7qJj5YTr11vvjNgjDN1ypOfwTovc0QOCYcit/rskeuVgnmQZOZQzC/BbyKLLG7UGnpRLemU/mEGbW9pAqjAXkQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-placeholder": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.29.2.tgz",
-      "integrity": "sha512-/BlpPIq2JZk6zLaeYVOXazi6dmd0iRriTymNEnFn1doManN1y5HED9LsMeb/AhNhauL5AgmcHgpvAjbsN9k4SA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/extensions": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-strike": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.29.2.tgz",
-      "integrity": "sha512-aEvLAbddUQZ+FukCreV3q4G2HfNI+odE7E9U+wbq6XsSWKyo8/pDu1muz+TFKNre4blSMOQ3JQmw5UeHDKy+fg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-text": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.29.2.tgz",
-      "integrity": "sha512-Ubko45JWWHe8glBt2PiGNF8hcbys/JNalFhiR7Y1X4iOOtAxAKJJxh3+eq+//NTlGuBPdWGp7zw8EEUp7anjKA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extension-underline": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.29.2.tgz",
-      "integrity": "sha512-K7XwH/xS/5AIREWQ00VTEf/W5U0olp7j6wwit7cdd/8nHv6h6AGr1+iEApHKoLXWQZLfGQKzJlT9W61LAl+fHA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/extensions": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.29.2.tgz",
-      "integrity": "sha512-BCz+FCAChSYtUe4BFj97HEO+nSK+J7GxbJgZG4Hg7DT/gI+hRyeNndU8efiQAx3WGdzsFi3UxRpcF1tTQM7iMQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/markdown": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/markdown/-/markdown-3.29.2.tgz",
-      "integrity": "sha512-Knf9YqG3fxOyFuS3pe3eapDz0ya9eqPGzmyMSd5PuHNmR9/Ir6i5qk5+Md6bCPgDNjYskztNm7DoBXPfbXbO/w==",
-      "license": "MIT",
-      "dependencies": {
-        "marked": "^17.0.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/pm": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.29.2.tgz",
-      "integrity": "sha512-GCOme7xHaS+DSoaA4CDcAD3l6JyBlvZhvCyfsy2Vp6j8tEoBkZWio7soYVosmlyn7zq8/64VeFZP5s47yfG7fQ==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-changeset": "^2.4.1",
-        "prosemirror-commands": "^1.7.1",
-        "prosemirror-dropcursor": "^1.8.2",
-        "prosemirror-gapcursor": "^1.4.1",
-        "prosemirror-history": "^1.5.0",
-        "prosemirror-inputrules": "^1.5.1",
-        "prosemirror-keymap": "^1.2.3",
-        "prosemirror-model": "^1.25.11",
-        "prosemirror-schema-list": "^1.5.1",
-        "prosemirror-state": "^1.4.4",
-        "prosemirror-tables": "^1.8.5",
-        "prosemirror-transform": "^1.12.0",
-        "prosemirror-view": "^1.41.9"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      }
-    },
-    "node_modules/@tiptap/starter-kit": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.29.2.tgz",
-      "integrity": "sha512-oTu0tysiqk4zgjEtxRHjAQgxUKaAevZwueOWwSWubHdokqp7SpcbE5n9USJv89HKuTUDm3GjnQH6q8HNn/2DsA==",
-      "license": "MIT",
-      "dependencies": {
-        "@tiptap/core": "^3.29.2",
-        "@tiptap/extension-blockquote": "^3.29.2",
-        "@tiptap/extension-bold": "^3.29.2",
-        "@tiptap/extension-bullet-list": "^3.29.2",
-        "@tiptap/extension-code": "^3.29.2",
-        "@tiptap/extension-code-block": "^3.29.2",
-        "@tiptap/extension-document": "^3.29.2",
-        "@tiptap/extension-dropcursor": "^3.29.2",
-        "@tiptap/extension-gapcursor": "^3.29.2",
-        "@tiptap/extension-hard-break": "^3.29.2",
-        "@tiptap/extension-heading": "^3.29.2",
-        "@tiptap/extension-horizontal-rule": "^3.29.2",
-        "@tiptap/extension-italic": "^3.29.2",
-        "@tiptap/extension-link": "^3.29.2",
-        "@tiptap/extension-list": "^3.29.2",
-        "@tiptap/extension-list-item": "^3.29.2",
-        "@tiptap/extension-list-keymap": "^3.29.2",
-        "@tiptap/extension-ordered-list": "^3.29.2",
-        "@tiptap/extension-paragraph": "^3.29.2",
-        "@tiptap/extension-strike": "^3.29.2",
-        "@tiptap/extension-text": "^3.29.2",
-        "@tiptap/extension-underline": "^3.29.2",
-        "@tiptap/extensions": "^3.29.2",
-        "@tiptap/pm": "^3.29.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      }
-    },
-    "node_modules/@tiptap/suggestion": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.29.2.tgz",
-      "integrity": "sha512-ZEhRm0gnRCwCScR9IrnIBhm9sr6U8vpR9oeznYk3hiedZ48zsgohqvgoIYpWcwYWrT2Pb0NrfhCT8IuSzdJHzQ==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2"
-      }
-    },
-    "node_modules/@tiptap/vue-3": {
-      "version": "3.29.2",
-      "resolved": "https://registry.npmjs.org/@tiptap/vue-3/-/vue-3-3.29.2.tgz",
-      "integrity": "sha512-rLX+V+HXbsVlk+My8mslvbnbVXZiQZHYtbOiRgxugsqZ9SK1mr1FpgZ/ZNcotJAjecT8FJmPa45ccDnVu66eGA==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "optionalDependencies": {
-        "@tiptap/extension-bubble-menu": "^3.29.2",
-        "@tiptap/extension-floating-menu": "^3.29.2"
-      },
-      "peerDependencies": {
-        "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "3.29.2",
-        "@tiptap/pm": "3.29.2",
-        "vue": "^3.0.0"
-      }
-    },
-    "node_modules/@tiptap/y-tiptap": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@tiptap/y-tiptap/-/y-tiptap-3.0.8.tgz",
-      "integrity": "sha512-+kndlSuoUK9sKVRuxbAHXNrbDvyydnG/Y0NFU9XXqaSkI9IRcrjpOf1RGd7NrC9jJXquDqZS96wOQf6eUpP9Dg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lib0": "^0.2.100"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "prosemirror-model": "^1.7.1",
-        "prosemirror-state": "^1.2.3",
-        "prosemirror-view": "^1.9.10",
-        "y-protocols": "^1.0.1",
-        "yjs": "^13.5.38"
-      }
-    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -9654,6 +9460,26 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/blob-to-buffer": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/blob-to-buffer/-/blob-to-buffer-1.2.9.tgz",
+      "integrity": "sha512-BF033y5fN6OCofD3vgHmNtwZWRcq9NLyyxyILx9hfMy1sXYy4ojFl765hJ2lP0YaN2fuxPaLO2Vzzoxy0FLFFA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/body-parser": {
       "version": "1.20.6",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
@@ -9733,6 +9559,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/brotli": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.3.tgz",
+      "integrity": "sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.1.2"
       }
     },
     "node_modules/browser-image-compression": {
@@ -10372,6 +10207,15 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/cluster-key-slot": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.1.tgz",
@@ -10897,6 +10741,15 @@
         "node": ">=18.0"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -11354,6 +11207,12 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==",
+      "license": "MIT"
+    },
     "node_modules/diff": {
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
@@ -11792,9 +11651,9 @@
       }
     },
     "node_modules/errx": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/errx/-/errx-0.1.0.tgz",
-      "integrity": "sha512-fZmsRiDNv07K6s2KkKFTiD2aIvECa7++PKyD5NC32tpRw46qZA3sOz+aM+/V9V0GDHxVTKLziveV4JhzBHDp9Q==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/errx/-/errx-0.1.2.tgz",
+      "integrity": "sha512-chfpPHmCerdo/rXr/nNvPZRkV4WwDRwzwnsJ0Uzz3tVi8Z41tDctRjduYy1138ii77AFlts1qvWtX3g/Acg91Q==",
       "license": "MIT"
     },
     "node_modules/es-define-property": {
@@ -12483,7 +12342,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-fifo": {
@@ -12757,65 +12615,36 @@
       "license": "ISC"
     },
     "node_modules/fontaine": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/fontaine/-/fontaine-0.8.0.tgz",
-      "integrity": "sha512-eek1GbzOdWIj9FyQH/emqW1aEdfC3lYRCHepzwlFCm5T77fBSRSyNRKE6/antF1/B1M+SfJXVRQTY9GAr7lnDg==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/fontaine/-/fontaine-0.6.0.tgz",
+      "integrity": "sha512-cfKqzB62GmztJhwJ0YXtzNsmpqKAcFzTqsakJ//5COTzbou90LU7So18U+4D8z+lDXr4uztaAUZBonSoPDcj1w==",
       "license": "MIT",
       "dependencies": {
-        "@capsizecss/unpack": "^4.0.0",
+        "@capsizecss/metrics": "^3.5.0",
+        "@capsizecss/unpack": "^2.4.0",
         "css-tree": "^3.1.0",
         "magic-regexp": "^0.10.0",
-        "magic-string": "^0.30.21",
+        "magic-string": "^0.30.17",
         "pathe": "^2.0.3",
         "ufo": "^1.6.1",
-        "unplugin": "^2.3.10"
-      },
-      "engines": {
-        "node": ">=18.12.0"
+        "unplugin": "^2.3.2"
       }
     },
-    "node_modules/fontkitten": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fontkitten/-/fontkitten-1.0.3.tgz",
-      "integrity": "sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==",
+    "node_modules/fontkit": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-2.0.4.tgz",
+      "integrity": "sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==",
       "license": "MIT",
       "dependencies": {
-        "tiny-inflate": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/fontless": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/fontless/-/fontless-0.2.1.tgz",
-      "integrity": "sha512-mUWZ8w91/mw2KEcZ6gHNoNNmsAq9Wiw2IypIux5lM03nhXm+WSloXGUNuRETNTLqZexMgpt7Aj/v63qqrsWraQ==",
-      "license": "MIT",
-      "dependencies": {
-        "consola": "^3.4.2",
-        "css-tree": "^3.1.0",
-        "defu": "^6.1.4",
-        "esbuild": "^0.27.0",
-        "fontaine": "0.8.0",
-        "jiti": "^2.6.1",
-        "lightningcss": "^1.30.2",
-        "magic-string": "^0.30.21",
-        "ohash": "^2.0.11",
-        "pathe": "^2.0.3",
-        "ufo": "^1.6.1",
-        "unifont": "^0.7.4",
-        "unstorage": "^1.17.1"
-      },
-      "engines": {
-        "node": ">=18.12.0"
-      },
-      "peerDependencies": {
-        "vite": "*"
-      },
-      "peerDependenciesMeta": {
-        "vite": {
-          "optional": true
-        }
+        "@swc/helpers": "^0.5.12",
+        "brotli": "^1.3.2",
+        "clone": "^2.1.2",
+        "dfa": "^1.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "restructure": "^3.0.0",
+        "tiny-inflate": "^1.0.3",
+        "unicode-properties": "^1.4.0",
+        "unicode-trie": "^2.0.0"
       }
     },
     "node_modules/foreground-child": {
@@ -12855,33 +12684,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
-      }
-    },
-    "node_modules/framer-motion": {
-      "version": "12.43.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.43.0.tgz",
-      "integrity": "sha512-1eaL3RvR/kAlbG7UYcpMptEyzPoENO0c6w7ZnB3/hh2vSAz/6uGAFn6fdoqTBguNstf3MsFhJHsD/0DHiclG+g==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^12.43.0",
-        "motion-utils": "^12.39.0",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/fresh": {
@@ -13269,12 +13071,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/hey-listen": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==",
-      "license": "MIT"
-    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -13525,16 +13321,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/impound": {
@@ -14138,17 +13924,6 @@
         "whatwg-fetch": "^3.4.1"
       }
     },
-    "node_modules/isomorphic.js": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
-      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
-    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
@@ -14430,6 +14205,12 @@
       "integrity": "sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw==",
       "license": "MIT"
     },
+    "node_modules/kolorist": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+      "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
+      "license": "MIT"
+    },
     "node_modules/launch-editor": {
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
@@ -14486,28 +14267,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/lib0": {
-      "version": "0.2.117",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
-      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "isomorphic.js": "^0.2.4"
-      },
-      "bin": {
-        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
-        "0gentesthtml": "bin/gentesthtml.js",
-        "0serve": "bin/0serve.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/lie": {
@@ -14756,267 +14515,6 @@
         }
       }
     },
-    "node_modules/lightningcss": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
-      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
-      "license": "MPL-2.0",
-      "dependencies": {
-        "detect-libc": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      },
-      "optionalDependencies": {
-        "lightningcss-android-arm64": "1.33.0",
-        "lightningcss-darwin-arm64": "1.33.0",
-        "lightningcss-darwin-x64": "1.33.0",
-        "lightningcss-freebsd-x64": "1.33.0",
-        "lightningcss-linux-arm-gnueabihf": "1.33.0",
-        "lightningcss-linux-arm64-gnu": "1.33.0",
-        "lightningcss-linux-arm64-musl": "1.33.0",
-        "lightningcss-linux-x64-gnu": "1.33.0",
-        "lightningcss-linux-x64-musl": "1.33.0",
-        "lightningcss-win32-arm64-msvc": "1.33.0",
-        "lightningcss-win32-x64-msvc": "1.33.0"
-      }
-    },
-    "node_modules/lightningcss-android-arm64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
-      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
-      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-darwin-x64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
-      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
-      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
-      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
-      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
-      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
-      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
-      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
-      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
-      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
-    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -15034,12 +14532,6 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/linkifyjs": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
-      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg==",
       "license": "MIT"
     },
     "node_modules/listhen": {
@@ -15271,18 +14763,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/marked": {
-      "version": "17.0.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
-      "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/marky": {
@@ -15561,37 +15041,6 @@
       "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
       "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
       "license": "MIT"
-    },
-    "node_modules/motion-dom": {
-      "version": "12.43.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.43.0.tgz",
-      "integrity": "sha512-azKON4d9S65PEoFUiQTMTgPheEmzf2QngdRc50AKfJp9Q9mmcBVw22c8eMq9k8kxOFHdL7+WZY7N/5F/lwiDag==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^12.39.0"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "12.39.0",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
-      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
-      "license": "MIT"
-    },
-    "node_modules/motion-v": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/motion-v/-/motion-v-2.3.0.tgz",
-      "integrity": "sha512-J0CCfXtICCni9RjotDUBOs57xNpYI9yyBSohEOxaRHrmjwOtlw291fhRu/mdgEdSasys96R028YDDOAtWBbRaA==",
-      "license": "MIT",
-      "dependencies": {
-        "framer-motion": "^12.40.0",
-        "hey-listen": "^1.0.8",
-        "motion-dom": "^12.40.0",
-        "motion-utils": "^12.39.0"
-      },
-      "peerDependencies": {
-        "@vueuse/core": ">=10.0.0",
-        "vue": ">=3.0.0"
-      }
     },
     "node_modules/mrmime": {
       "version": "2.0.1",
@@ -16800,12 +16249,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/orderedmap": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
-      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
-      "license": "MIT"
     },
     "node_modules/oxc-minify": {
       "version": "0.141.0",
@@ -18156,145 +17599,6 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
     },
-    "node_modules/prosemirror-changeset": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
-      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/prosemirror-commands": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
-      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.10.2"
-      }
-    },
-    "node_modules/prosemirror-dropcursor": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.3.tgz",
-      "integrity": "sha512-FoYbsJR8gK+DGlqhNoE29Loa38eIZPzQRIb1VMaDNBoo4OLP6vVof/jR8qFY/6XvUd6Dhug8MDCHl2a/h8RTfQ==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.1.0",
-        "prosemirror-view": "^1.1.0"
-      }
-    },
-    "node_modules/prosemirror-gapcursor": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
-      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-keymap": "^1.0.0",
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-view": "^1.0.0"
-      }
-    },
-    "node_modules/prosemirror-history": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
-      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-state": "^1.2.2",
-        "prosemirror-transform": "^1.0.0",
-        "prosemirror-view": "^1.31.0",
-        "rope-sequence": "^1.3.0"
-      }
-    },
-    "node_modules/prosemirror-inputrules": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.1.tgz",
-      "integrity": "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.0.0"
-      }
-    },
-    "node_modules/prosemirror-keymap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
-      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-state": "^1.0.0",
-        "w3c-keyname": "^2.2.0"
-      }
-    },
-    "node_modules/prosemirror-model": {
-      "version": "1.25.11",
-      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.11.tgz",
-      "integrity": "sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "orderedmap": "^2.0.0"
-      }
-    },
-    "node_modules/prosemirror-schema-list": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
-      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.7.3"
-      }
-    },
-    "node_modules/prosemirror-state": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
-      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-model": "^1.0.0",
-        "prosemirror-transform": "^1.0.0",
-        "prosemirror-view": "^1.27.0"
-      }
-    },
-    "node_modules/prosemirror-tables": {
-      "version": "1.8.5",
-      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
-      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-keymap": "^1.2.3",
-        "prosemirror-model": "^1.25.4",
-        "prosemirror-state": "^1.4.4",
-        "prosemirror-transform": "^1.10.5",
-        "prosemirror-view": "^1.41.4"
-      }
-    },
-    "node_modules/prosemirror-transform": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
-      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-model": "^1.21.0"
-      }
-    },
-    "node_modules/prosemirror-view": {
-      "version": "1.42.2",
-      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.2.tgz",
-      "integrity": "sha512-Pdg0l5kXm8aLDquFAnQFTCITg0q44sLqBlHlpsVLD9segdOao8TOfQdAhCrCXyVgPSRr6UDDROOIWA3bIrN9YQ==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-model": "^1.25.8",
-        "prosemirror-state": "^1.0.0",
-        "prosemirror-transform": "^1.1.0"
-      }
-    },
     "node_modules/proto-list": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
@@ -18751,6 +18055,12 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/restructure": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-3.0.2.tgz",
+      "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
+      "license": "MIT"
+    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
@@ -19042,12 +18352,6 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=23"
       }
-    },
-    "node_modules/rope-sequence": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
-      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
-      "license": "MIT"
     },
     "node_modules/rou3": {
       "version": "0.9.1",
@@ -21049,6 +20353,32 @@
       "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
       "license": "MIT"
     },
+    "node_modules/unicode-properties": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.4.1.tgz",
+      "integrity": "sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicode-trie/node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+      "license": "MIT"
+    },
     "node_modules/unicorn-magic": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
@@ -21062,14 +20392,13 @@
       }
     },
     "node_modules/unifont": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.7.4.tgz",
-      "integrity": "sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/unifont/-/unifont-0.4.1.tgz",
+      "integrity": "sha512-zKSY9qO8svWYns+FGKjyVdLvpGPwqmsCjeJLN1xndMiqxHWBAhoWDMYMG960MxeV48clBmG+fDP59dHY1VoZvg==",
       "license": "MIT",
       "dependencies": {
-        "css-tree": "^3.1.0",
-        "ofetch": "^1.5.1",
-        "ohash": "^2.0.11"
+        "css-tree": "^3.0.0",
+        "ohash": "^2.0.0"
       }
     },
     "node_modules/unimport": {
@@ -21255,105 +20584,66 @@
       }
     },
     "node_modules/unplugin-vue-components": {
-      "version": "32.1.0",
-      "resolved": "https://registry.npmjs.org/unplugin-vue-components/-/unplugin-vue-components-32.1.0.tgz",
-      "integrity": "sha512-YiUkSxuRjab18XFOrX5VsIxXzccrfmHVGsGeJgSgklb829DQmCy9E4vvDUE4tuvZZdxyFJZX0Oc4TPnnxiiMyg==",
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/unplugin-vue-components/-/unplugin-vue-components-30.0.0.tgz",
+      "integrity": "sha512-4qVE/lwCgmdPTp6h0qsRN2u642tt4boBQtcpn4wQcWZAsr8TQwq+SPT3NDu/6kBFxzo/sSEK4ioXhOOBrXc3iw==",
       "license": "MIT",
       "dependencies": {
-        "chokidar": "^5.0.0",
-        "local-pkg": "^1.2.0",
-        "magic-string": "^0.30.21",
-        "mlly": "^1.8.2",
-        "obug": "^2.1.1",
-        "picomatch": "^4.0.4",
-        "tinyglobby": "^0.2.16",
-        "unplugin": "^3.0.0",
+        "chokidar": "^4.0.3",
+        "debug": "^4.4.3",
+        "local-pkg": "^1.1.2",
+        "magic-string": "^0.30.19",
+        "mlly": "^1.8.0",
+        "tinyglobby": "^0.2.15",
+        "unplugin": "^2.3.10",
         "unplugin-utils": "^0.3.1"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       },
       "peerDependencies": {
+        "@babel/parser": "^7.15.8",
         "@nuxt/kit": "^3.2.2 || ^4.0.0",
-        "vue": "^3.0.0"
+        "vue": "2 || 3"
       },
       "peerDependenciesMeta": {
+        "@babel/parser": {
+          "optional": true
+        },
         "@nuxt/kit": {
           "optional": true
         }
       }
     },
-    "node_modules/unplugin-vue-components/node_modules/tinyglobby": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
-      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+    "node_modules/unplugin-vue-components/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
+        "readdirp": "^4.0.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">= 14.16.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
+        "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/unplugin-vue-components/node_modules/unplugin": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.3.0.tgz",
-      "integrity": "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==",
+    "node_modules/unplugin-vue-components/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "license": "MIT",
-      "dependencies": {
-        "@jridgewell/remapping": "^2.3.5",
-        "picomatch": "^4.0.4",
-        "webpack-virtual-modules": "^0.6.2"
-      },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": ">= 14.18.0"
       },
-      "peerDependencies": {
-        "@farmfe/core": "*",
-        "@rspack/core": "*",
-        "bun-types-no-globals": "*",
-        "esbuild": "*",
-        "rolldown": "*",
-        "rollup": "*",
-        "unloader": "*",
-        "vite": "*",
-        "webpack": "*"
-      },
-      "peerDependenciesMeta": {
-        "@farmfe/core": {
-          "optional": true
-        },
-        "@rspack/core": {
-          "optional": true
-        },
-        "bun-types-no-globals": {
-          "optional": true
-        },
-        "esbuild": {
-          "optional": true
-        },
-        "rolldown": {
-          "optional": true
-        },
-        "rollup": {
-          "optional": true
-        },
-        "unloader": {
-          "optional": true
-        },
-        "vite": {
-          "optional": true
-        },
-        "webpack": {
-          "optional": true
-        }
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/unplugin-vue-router": {
@@ -22304,12 +21594,6 @@
         "typescript": ">=5.0.0"
       }
     },
-    "node_modules/w3c-keyname": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
-      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-      "license": "MIT"
-    },
     "node_modules/web-vitals": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
@@ -22589,27 +21873,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/y-protocols": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
-      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lib0": "^0.2.85"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      },
-      "peerDependencies": {
-        "yjs": "^13.0.0"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -22739,24 +22002,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/yjs": {
-      "version": "13.6.31",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.31.tgz",
-      "integrity": "sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "lib0": "^0.2.99"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "audit:tokens:ci": "node scripts/token-audit.mjs --errors-only"
   },
   "dependencies": {
-    "@nuxt/ui": "^4.8.0",
+    "@nuxt/ui": "~3.3.7",
     "@nuxtjs/supabase": "^2.0.9",
     "@pinia/nuxt": "^0.11.3",
     "@sentry/nuxt": "^10.69.0",

--- a/planning/lessons.md
+++ b/planning/lessons.md
@@ -16,6 +16,31 @@ Tracks mistake patterns (with recurrence counts) and process insights.
 
 ## Bug & Mistake Patterns
 
+### Nuxt Silently Disables Incompatible Modules (and Their Dependents)
+
+**Times seen:** 1 | **Last seen:** 2026-08-06
+**Context:** All dashboard tile/button icons blank in production. Prod bundle `entry-CP9JRFg7.js` contained zero heroicon data; `UIcon` wasn't registered at all.
+**Root Cause:** Dependabot bumped `@nuxt/ui` 3.3.7 → 4.8.0 (`96a2d29f`). v4 declares `compatibility.nuxt: ">=4.1.0"`; we run Nuxt 3.21.10. Nuxt disabled `@nuxt/ui` with only a `WARN [NUXT_B8013]` and **exit code 0**. `@nuxt/icon` is registered as a `moduleDependency` of `@nuxt/ui`, so it was disabled too — taking `clientBundle` icon bundling with it. Build "succeeded," prod shipped broken.
+**Prevention:**
+- `experimental.enforceModuleCompatibility: true` in `nuxt.config.ts` — turns the WARN into a fatal ERROR. Verified it fails the build under `@nuxt/ui` 4.8.0.
+- A module bump can break things the module doesn't own. Check `moduleDependencies` in the module's `dist/module.mjs` before accepting a major.
+- Grep the built bundle, not the source, when prod-only rendering breaks: `grep '"icon-name":{' .vercel/output/static/_nuxt/entry-*.js`. Source having the name proves nothing.
+- Reproduce prod by building the exact deployed SHA in a worktree — the delta vs. local main is the answer.
+
+---
+
+### Dependabot Security Updates Bypass Major-Version Ignores
+
+**Times seen:** 1 | **Last seen:** 2026-08-06
+**Context:** `.github/dependabot.yml` ignores `dependency-name: "*"` for `version-update:semver-major` and sets `target-branch: develop`. A major still landed directly on `main` and deployed to prod.
+**Root Cause:** Dependabot **security** updates are a separate mechanism from version updates. They ignore `target-branch` (always the default branch) and are not filtered by `update-types` ignores. So a security advisory can push a breaking major straight to prod, skipping `develop` and review entirely.
+**Prevention:**
+- Version-range ignores DO apply to security updates: `- dependency-name: "@nuxt/ui"` + `versions: [">=4.0.0"]`. Use these to fence packages that can't cross a major.
+- Per-package fencing is whack-a-mole — the real fix is not auto-merging security PRs onto `main`. Review branch protection on the default branch.
+- Before accepting a security bump, check whether the advisory even applies. Ours was `UAuthForm`/`UForm` SSR markup omitting `method`; we use neither component and run `ssr: false`. Zero exposure, real breakage.
+
+---
+
 ### Teleport Components Must Be Client-Only in Nuxt SSR
 
 **Times seen:** 1 | **Last seen:** 2026-02-16


### PR DESCRIPTION
## Summary

- **Production is currently shipping with every icon missing.** `@nuxt/ui` 4.x declares `compatibility.nuxt: ">=4.1.0"`; this project runs Nuxt 3.21.10. Nuxt disables the incompatible module with only a `WARN [NUXT_B8013]` and **exit code 0** — and because `@nuxt/icon` is registered as a `moduleDependency` of `@nuxt/ui`, it gets disabled too, taking `clientBundle` icon bundling with it. The build "succeeds" and prod renders blank tiles and buttons.
- Pins `@nuxt/ui` back to `~3.3.7` (the Nuxt 3-compatible line), reverting the Dependabot security bump in 96a2d29f.
- Adds two guards so this can't recur silently: `experimental.enforceModuleCompatibility: true` (fatal build error instead of a warning) and a Dependabot `versions: [">=4.0.0"]` fence on `@nuxt/ui`.

### Root cause timeline

| commit | `@nuxt/ui` | icons |
|---|---|---|
| `ecd48fc3` | 3.3.7 | working |
| `96a2d29f` (Dependabot, PR #334) | 4.8.0 | **broken** |
| `300397b1` (live prod) | 4.8.1 | **broken** |
| this PR | 3.3.7 | working |

### Why this reached prod unreviewed

`.github/dependabot.yml` ignores all `version-update:semver-major` and sets `target-branch: develop`. Dependabot **security** updates honor neither — they always target the default branch and aren't filtered by `update-types`. So a breaking major went straight onto `main`, skipping `develop` and review. Version-range ignores *do* bind security updates, hence the explicit `@nuxt/ui >=4.0.0` fence added here.

### On the advisory being reverted past

GHSA covers `UAuthForm` / `UForm` emitting SSR markup without `method`, leaking credentials via GET if submitted pre-hydration. **Not applicable here:** neither component is used anywhere in the app (`grep` returns zero hits), and we run `ssr: false`, so there is no SSR markup at all. Dependabot alert 141 will re-open on merge — it should be dismissed as "not affected" rather than allowed to push 4.x back onto `main`.

### Why not just move to @nuxt/ui 4?

It hard-requires Nuxt >= 4.1, so "upgrade the UI lib" is really "migrate Nuxt 3 → 4," which also pulls in Tailwind 4 (`@nuxt/ui` 4 peer-requires `tailwindcss ^4.0.0`) and the Nuxt 4 `app/` directory layout. Worth planning separately; the component surface itself is small (314 `U*` usages, 286 of them `UIcon`).

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [x] Docs / content
- [ ] Tests
- [x] Chore / dependency update

## Test plan

- [x] `npm run type-check` passes (exit 0)
- [x] `npm run test` passes (7785 passed, 66 skipped)
- [x] `npm run lint` passes (exit 0)
- [ ] Tested in browser (dev server)

Verified at the bundle level rather than in a browser, since this is a build-time module failure that no test or type-check can observe:

- **Live prod bundle** (`entry-CP9JRFg7.js`, deploy `300397b1`) — 8/8 sampled heroicons `MISSING`, and no `api.iconify.design` fallback either.
- **Reproduced** by checking out `300397b1` in a worktree, `npm ci`, `npm run build` — same 8/8 `MISSING`, plus the two `NUXT_B8013` warnings naming `@nuxt/ui` and `@nuxt/icon`.
- **Fixed build on this branch** — 8/8 `BUNDLED`; module reports `Nuxt Icon client bundle consist of 86 icons with 34.00KB`.
- **Guard proven** — re-ran the 4.8.0 worktree build with `enforceModuleCompatibility: true`: `ERROR Module @nuxt/ui is disabled due to incompatibility issues`, non-zero exit. It fails loudly now.

## Docs checklist

- [x] No user-facing behavior change beyond restoring icons; `planning/lessons.md` records both patterns

## Security checklist

- [x] No secrets or credentials in code
- [x] User input validated with Zod — n/a, no input paths touched
- [x] Auth enforced on new API routes (`requireAuth`) — n/a, no API routes touched
- [x] No raw `error.message` exposed in API responses — n/a

https://claude.ai/code/session_01K5XrgK8vgYiKUg2VzxK2q1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incompatible framework upgrades from being selected automatically.
  * Builds now fail clearly when installed modules are incompatible, rather than continuing with warnings.

* **Documentation**
  * Added guidance for preventing incompatible module configurations and unintended dependency upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->