### PR TITLE
fix(profile): repair completeness formula — wire dead fields, match iOS

### DIFF
--- a/composables/usePlayerDetailsForm.ts
+++ b/composables/usePlayerDetailsForm.ts
@@ -5,7 +5,11 @@ import { useSportsPositionLookup } from "~/composables/useSportsPositionLookup";
 import { useAutoSave } from "~/composables/useAutoSave";
 import { normalizePositions } from "~/utils/positions";
 import { normalizeHandle, type SocialPlatform } from "~/utils/social";
-import { calculateProfileCompleteness } from "~/utils/profileCompletenessCalculation";
+import {
+  calculateProfileCompleteness,
+  isHomeLocationPresent,
+} from "~/utils/profileCompletenessCalculation";
+import { useVideoLinks } from "~/composables/useVideoLinks";
 import type { PlayerDetails } from "~/types/models";
 
 /**
@@ -13,8 +17,14 @@ import type { PlayerDetails } from "~/types/models";
  * player-details settings page (all tabs).
  */
 export function usePlayerDetailsForm() {
-  const { isLoading, getPlayerDetails, setPlayerDetails, loadAllPreferences } =
-    usePreferenceManager();
+  const {
+    isLoading,
+    getPlayerDetails,
+    setPlayerDetails,
+    loadAllPreferences,
+    getHomeLocation,
+  } = usePreferenceManager();
+  const { links: videoLinks, load: loadVideoLinks } = useVideoLinks();
   const { showToast } = useAppToast();
   const { commonSports, getPositionsBySport } = useSportsPositionLookup();
 
@@ -96,8 +106,17 @@ export function usePlayerDetailsForm() {
     );
   });
 
+  // Completeness signals that live outside the player-prefs form (video_links
+  // table, location store). Fetched once in load(); they don't change while the
+  // athlete edits player details, but the score stays reactive to form edits.
+  const hasHighlightVideo = computed(() => videoLinks.value.length > 0);
+  const hasHomeLocation = ref(false);
+
   const profileCompleteness = computed(() =>
-    calculateProfileCompleteness(form.value),
+    calculateProfileCompleteness(form.value, {
+      hasHighlightVideo: hasHighlightVideo.value,
+      hasHomeLocation: hasHomeLocation.value,
+    }),
   );
 
   const { isSaving, triggerSave } = useAutoSave({
@@ -259,7 +278,8 @@ export function usePlayerDetailsForm() {
   ] as const;
 
   const load = async () => {
-    await loadAllPreferences();
+    await Promise.all([loadAllPreferences(), loadVideoLinks()]);
+    hasHomeLocation.value = isHomeLocationPresent(getHomeLocation.value);
     const playerDetails = getPlayerDetails();
     if (playerDetails) {
       if (playerDetails.high_school && !playerDetails.school_name) {

--- a/composables/useProfileCompleteness.ts
+++ b/composables/useProfileCompleteness.ts
@@ -1,8 +1,12 @@
 import { ref } from "vue";
 import { useSupabase } from "./useSupabase";
 import { createClientLogger } from "~/utils/logger";
-import { calculateProfileCompleteness } from "~/utils/profileCompletenessCalculation";
+import {
+  calculateProfileCompleteness,
+  isHomeLocationPresent,
+} from "~/utils/profileCompletenessCalculation";
 import { usePreferenceManager } from "./usePreferenceManager";
+import { useVideoLinks } from "./useVideoLinks";
 
 export interface ContextualPrompt {
   id: string;
@@ -66,10 +70,16 @@ export const useProfileCompleteness = () => {
     error.value = null;
 
     try {
-      const { loadAllPreferences, getPlayerDetails } = usePreferenceManager();
-      await loadAllPreferences();
+      const { loadAllPreferences, getPlayerDetails, getHomeLocation } =
+        usePreferenceManager();
+      const { links, load: loadVideoLinks } = useVideoLinks();
+      await Promise.all([loadAllPreferences(), loadVideoLinks()]);
       const details = getPlayerDetails();
-      completeness.value = details ? calculateProfileCompleteness(details) : 0;
+      const signals = {
+        hasHighlightVideo: links.value.length > 0,
+        hasHomeLocation: isHomeLocationPresent(getHomeLocation.value),
+      };
+      completeness.value = calculateProfileCompleteness(details ?? {}, signals);
     } catch (err) {
       const message =
         err instanceof Error

--- a/tests/unit/composables/useProfileCompleteness.spec.ts
+++ b/tests/unit/composables/useProfileCompleteness.spec.ts
@@ -16,6 +16,15 @@ vi.mock("~/composables/usePreferenceManager", () => ({
   usePreferenceManager: vi.fn(() => ({
     loadAllPreferences: vi.fn().mockResolvedValue(undefined),
     getPlayerDetails: vi.fn().mockReturnValue(null),
+    getHomeLocation: { value: null },
+  })),
+}));
+
+// Mock VideoLinks (used by updateCompleteness for the highlight-video signal)
+vi.mock("~/composables/useVideoLinks", () => ({
+  useVideoLinks: vi.fn(() => ({
+    links: { value: [] },
+    load: vi.fn().mockResolvedValue(undefined),
   })),
 }));
 
@@ -98,6 +107,7 @@ describe("useProfileCompleteness", () => {
           .fn()
           .mockRejectedValue(new Error("Failed to load preferences")),
         getPlayerDetails: vi.fn().mockReturnValue(null),
+        getHomeLocation: { value: null },
       } as any);
 
       const completeness = useProfileCompleteness();
@@ -113,6 +123,7 @@ describe("useProfileCompleteness", () => {
       vi.mocked(usePreferenceManager).mockReturnValue({
         loadAllPreferences: vi.fn().mockResolvedValue(undefined),
         getPlayerDetails: vi.fn().mockReturnValue(null),
+        getHomeLocation: { value: null },
       } as any);
 
       const completeness = useProfileCompleteness();

--- a/tests/unit/utils/profileCompletenessCalculation.spec.ts
+++ b/tests/unit/utils/profileCompletenessCalculation.spec.ts
@@ -1,276 +1,128 @@
 import { describe, it, expect } from "vitest";
-import { calculateProfileCompleteness } from "~/utils/profileCompletenessCalculation";
-import type { PlayerProfile } from "~/types/onboarding";
+import {
+  calculateProfileCompleteness,
+  isHomeLocationPresent,
+  type ScorableProfile,
+  type ProfileCompletenessSignals,
+} from "~/utils/profileCompletenessCalculation";
+
+// Canonical weighted formula — must stay in lockstep with iOS
+// (PlayerDetails.completenessScore). See the iOS repo's
+// planning/2026-08-09-profile-completeness-canonical-spec.md.
+
+const SIGNALS_ON: ProfileCompletenessSignals = {
+  hasHighlightVideo: true,
+  hasHomeLocation: true,
+};
+
+// A profile with every player-prefs field filled (75% before signals).
+const fullProfile: ScorableProfile = {
+  graduation_year: 2028,
+  primary_sport: "soccer",
+  primary_position: "forward",
+  gpa: 3.8,
+  sat_score: 1500,
+  height_inches: 70,
+  weight_lbs: 160,
+  phone: "555-123-4567",
+};
 
 describe("utils/profileCompletenessCalculation", () => {
   describe("calculateProfileCompleteness", () => {
-    describe("Weight Distribution (sum = 100%)", () => {
-      const weightBreakdown = {
-        graduationYear: 10,
-        primarySport: 10,
-        primaryPosition: 10,
-        zipCode: 10,
-        gpa: 15,
-        testScores: 10,
-        highlightVideo: 15,
-        athleticStats: 10,
-        contactInfo: 10,
+    it("scores 100% when every field and both signals are present", () => {
+      expect(calculateProfileCompleteness(fullProfile, SIGNALS_ON)).toBe(100);
+    });
+
+    it("scores 0% for an empty profile with no signals", () => {
+      expect(calculateProfileCompleteness({})).toBe(0);
+    });
+
+    describe("per-field weights", () => {
+      const cases: Array<[string, ScorableProfile, ProfileCompletenessSignals, number]> = [
+        ["graduation year", { graduation_year: 2028 }, { hasHighlightVideo: false, hasHomeLocation: false }, 10],
+        ["primary sport", { primary_sport: "soccer" }, { hasHighlightVideo: false, hasHomeLocation: false }, 10],
+        ["primary position", { primary_position: "forward" }, { hasHighlightVideo: false, hasHomeLocation: false }, 10],
+        ["gpa", { gpa: 3.5 }, { hasHighlightVideo: false, hasHomeLocation: false }, 15],
+        ["sat", { sat_score: 1200 }, { hasHighlightVideo: false, hasHomeLocation: false }, 10],
+        ["act", { act_score: 28 }, { hasHighlightVideo: false, hasHomeLocation: false }, 10],
+        ["height", { height_inches: 70 }, { hasHighlightVideo: false, hasHomeLocation: false }, 5],
+        ["weight", { weight_lbs: 160 }, { hasHighlightVideo: false, hasHomeLocation: false }, 5],
+        ["phone", { phone: "555-1234" }, { hasHighlightVideo: false, hasHomeLocation: false }, 10],
+        ["highlight video", {}, { hasHighlightVideo: true, hasHomeLocation: false }, 15],
+        ["home location", {}, { hasHighlightVideo: false, hasHomeLocation: true }, 10],
+      ];
+
+      it.each(cases)("gives %s its weight", (_label, profile, signals, expected) => {
+        expect(calculateProfileCompleteness(profile, signals)).toBe(expected);
+      });
+    });
+
+    it("counts SAT or ACT as a single field (no double count)", () => {
+      const sat = calculateProfileCompleteness({ sat_score: 1300 });
+      const act = calculateProfileCompleteness({ act_score: 30 });
+      const both = calculateProfileCompleteness({ sat_score: 1300, act_score: 30 });
+      expect(sat).toBe(10);
+      expect(act).toBe(10);
+      expect(both).toBe(10);
+    });
+
+    it("defaults both signals to absent when omitted", () => {
+      // fullProfile is 75% from player-prefs fields alone.
+      expect(calculateProfileCompleteness(fullProfile)).toBe(75);
+    });
+
+    it("docks the video weight when only the video is missing", () => {
+      expect(
+        calculateProfileCompleteness(fullProfile, {
+          hasHighlightVideo: false,
+          hasHomeLocation: true,
+        }),
+      ).toBe(85);
+    });
+
+    it("docks the home-location weight when only location is missing", () => {
+      expect(
+        calculateProfileCompleteness(fullProfile, {
+          hasHighlightVideo: true,
+          hasHomeLocation: false,
+        }),
+      ).toBe(90);
+    });
+
+    it("treats blank/zero values as missing", () => {
+      const blank: ScorableProfile = {
+        primary_sport: "   ",
+        primary_position: "",
+        gpa: 0,
+        height_inches: 0,
+        phone: "  ",
       };
-
-      it("should sum all weights to 100%", () => {
-        const total = Object.values(weightBreakdown).reduce((a, b) => a + b, 0);
-        expect(total).toBe(100);
-      });
+      expect(calculateProfileCompleteness(blank)).toBe(0);
     });
 
-    describe("Happy Path - Complete Profile", () => {
-      it("should calculate 100% for fully complete profile", () => {
-        const profile: PlayerProfile = {
-          graduation_year: 2028,
-          primary_sport: "soccer",
-          primary_position: "forward",
-          zip_code: "60601",
-          gpa: 3.8,
-          sat_score: 1500,
-          act_score: 34,
-          highlight_video_url: "https://example.com/video.mp4",
-          athletic_stats: "5 goals in league play",
-          phone: "555-123-4567",
-        };
+    it("returns an integer between 0 and 100", () => {
+      const result = calculateProfileCompleteness(fullProfile, SIGNALS_ON);
+      expect(Number.isInteger(result)).toBe(true);
+      expect(result).toBeGreaterThanOrEqual(0);
+      expect(result).toBeLessThanOrEqual(100);
+    });
+  });
 
-        const result = calculateProfileCompleteness(profile);
-        expect(result).toBe(100);
-      });
-
-      it("should give credit for SAT OR ACT (not requiring both)", () => {
-        const profileWithSAT: PlayerProfile = {
-          graduation_year: 2028,
-          primary_sport: "soccer",
-          primary_position: "forward",
-          zip_code: "60601",
-          gpa: 3.8,
-          sat_score: 1500,
-          highlight_video_url: "https://example.com/video.mp4",
-          athletic_stats: "5 goals",
-          phone: "555-123-4567",
-        };
-
-        const resultSAT = calculateProfileCompleteness(profileWithSAT);
-        expect(resultSAT).toBe(100);
-
-        const profileWithACT: PlayerProfile = {
-          ...profileWithSAT,
-          sat_score: undefined,
-          act_score: 34,
-        };
-
-        const resultACT = calculateProfileCompleteness(profileWithACT);
-        expect(resultACT).toBe(100);
-      });
+  describe("isHomeLocationPresent", () => {
+    it("is false for null/undefined/empty", () => {
+      expect(isHomeLocationPresent(null)).toBe(false);
+      expect(isHomeLocationPresent(undefined)).toBe(false);
+      expect(isHomeLocationPresent({})).toBe(false);
     });
 
-    describe("Happy Path - Partial Completion", () => {
-      it("should calculate 40% for profile with basic info only", () => {
-        const profile: PlayerProfile = {
-          graduation_year: 2028,
-          primary_sport: "soccer",
-          primary_position: "forward",
-          zip_code: "60601",
-        };
-
-        const result = calculateProfileCompleteness(profile);
-        expect(result).toBe(40); // 10+10+10+10 = 40%
-      });
-
-      it("should calculate correctly with graduation year + sport + position + zip", () => {
-        const profile: PlayerProfile = {
-          graduation_year: 2028,
-          primary_sport: "basketball",
-          primary_position: "point guard",
-          zip_code: "10001",
-        };
-
-        const result = calculateProfileCompleteness(profile);
-        expect(result).toBe(40); // 10+10+10+10 = 40%
-      });
-
-      it("should calculate correctly with academic info added", () => {
-        const profile: PlayerProfile = {
-          graduation_year: 2028,
-          primary_sport: "soccer",
-          primary_position: "midfielder",
-          zip_code: "60601",
-          gpa: 3.5,
-          sat_score: 1200,
-        };
-
-        const result = calculateProfileCompleteness(profile);
-        expect(result).toBe(65); // 10+10+10+10+15+10 = 65%
-      });
+    it("is true when a non-blank zip is present", () => {
+      expect(isHomeLocationPresent({ zip: "60601" })).toBe(true);
+      expect(isHomeLocationPresent({ zip: "  " })).toBe(false);
     });
 
-    describe("Edge Cases - Missing Fields", () => {
-      it("should calculate 0% for empty profile", () => {
-        const profile: Partial<PlayerProfile> = {};
-        const result = calculateProfileCompleteness(profile as PlayerProfile);
-        expect(result).toBe(0);
-      });
-
-      it("should calculate with only graduation year", () => {
-        const profile: PlayerProfile = {
-          graduation_year: 2028,
-        };
-
-        const result = calculateProfileCompleteness(profile);
-        expect(result).toBe(10); // Just the graduation year weight
-      });
-
-      it("should not penalize missing secondary sport/position", () => {
-        const profile: PlayerProfile = {
-          graduation_year: 2028,
-          primary_sport: "soccer",
-          primary_position: "forward",
-          zip_code: "60601",
-          gpa: 3.8,
-          sat_score: 1400,
-          highlight_video_url: "https://example.com/video.mp4",
-          athletic_stats: "10 goals",
-          phone: "555-123-4567",
-        };
-
-        const result = calculateProfileCompleteness(profile);
-        expect(result).toBe(100); // No penalty for missing secondary
-      });
-    });
-
-    describe("Test Score Handling", () => {
-      it("should count SAT score as fulfilling test score requirement", () => {
-        const profile: PlayerProfile = {
-          graduation_year: 2028,
-          primary_sport: "soccer",
-          primary_position: "forward",
-          zip_code: "60601",
-          gpa: 3.8,
-          sat_score: 1300,
-        };
-
-        const result = calculateProfileCompleteness(profile);
-        expect(result).toBeGreaterThanOrEqual(65); // Should include SAT's 10%
-      });
-
-      it("should count ACT score as fulfilling test score requirement", () => {
-        const profile: PlayerProfile = {
-          graduation_year: 2028,
-          primary_sport: "soccer",
-          primary_position: "forward",
-          zip_code: "60601",
-          gpa: 3.8,
-          act_score: 33,
-        };
-
-        const result = calculateProfileCompleteness(profile);
-        expect(result).toBeGreaterThanOrEqual(65); // Should include ACT's 10%
-      });
-
-      it("should not double-count when both SAT and ACT are present", () => {
-        const profile1: PlayerProfile = {
-          graduation_year: 2028,
-          primary_sport: "soccer",
-          primary_position: "forward",
-          zip_code: "60601",
-          gpa: 3.8,
-          sat_score: 1300,
-        };
-
-        const profile2: PlayerProfile = {
-          ...profile1,
-          act_score: 33,
-        };
-
-        const result1 = calculateProfileCompleteness(profile1);
-        const result2 = calculateProfileCompleteness(profile2);
-
-        // Both should be the same (10% for tests, not 20%)
-        expect(result1).toBe(result2);
-      });
-    });
-
-    describe("Optional Fields", () => {
-      it("should handle missing highlight video without penalty when others complete", () => {
-        const profile: PlayerProfile = {
-          graduation_year: 2028,
-          primary_sport: "soccer",
-          primary_position: "forward",
-          zip_code: "60601",
-          gpa: 3.8,
-          sat_score: 1300,
-          athletic_stats: "10 goals, 5 assists",
-          phone: "555-123-4567",
-        };
-
-        const result = calculateProfileCompleteness(profile);
-        expect(result).toBe(85); // 100 - 15 (missing video)
-      });
-
-      it("should handle missing athletic stats gracefully", () => {
-        const profile: PlayerProfile = {
-          graduation_year: 2028,
-          primary_sport: "soccer",
-          primary_position: "forward",
-          zip_code: "60601",
-          gpa: 3.8,
-          sat_score: 1300,
-          highlight_video_url: "https://example.com/video.mp4",
-          phone: "555-123-4567",
-        };
-
-        const result = calculateProfileCompleteness(profile);
-        expect(result).toBe(90); // 100 - 10 (missing stats)
-      });
-
-      it("should handle missing contact info", () => {
-        const profile: PlayerProfile = {
-          graduation_year: 2028,
-          primary_sport: "soccer",
-          primary_position: "forward",
-          zip_code: "60601",
-          gpa: 3.8,
-          sat_score: 1300,
-          highlight_video_url: "https://example.com/video.mp4",
-          athletic_stats: "10 goals",
-        };
-
-        const result = calculateProfileCompleteness(profile);
-        expect(result).toBe(90); // 100 - 10 (missing contact info)
-      });
-    });
-
-    describe("Return Type", () => {
-      it("should return a number between 0 and 100", () => {
-        const profile: PlayerProfile = {
-          graduation_year: 2028,
-          primary_sport: "soccer",
-          primary_position: "forward",
-          zip_code: "60601",
-          gpa: 3.5,
-        };
-
-        const result = calculateProfileCompleteness(profile);
-        expect(typeof result).toBe("number");
-        expect(result).toBeGreaterThanOrEqual(0);
-        expect(result).toBeLessThanOrEqual(100);
-      });
-
-      it("should not return decimal places", () => {
-        const profile: PlayerProfile = {
-          graduation_year: 2028,
-          primary_sport: "soccer",
-          primary_position: "forward",
-        };
-
-        const result = calculateProfileCompleteness(profile);
-        expect(Number.isInteger(result)).toBe(true);
-      });
+    it("is true when a coordinate pair is present", () => {
+      expect(isHomeLocationPresent({ latitude: 41.8, longitude: -87.6 })).toBe(true);
+      expect(isHomeLocationPresent({ latitude: 41.8 })).toBe(false);
     });
   });
 });

--- a/utils/profileCompletenessCalculation.ts
+++ b/utils/profileCompletenessCalculation.ts
@@ -1,123 +1,134 @@
 /**
- * Profile completeness calculation for player onboarding
+ * Profile completeness calculation.
  *
- * Calculates what percentage of the player profile is complete
- * based on weighted field contributions.
+ * Canonical weighted formula shared with the iOS app
+ * (`PlayerDetails.completenessScore`) — see the iOS repo's
+ * `planning/2026-08-09-profile-completeness-canonical-spec.md`.
+ *
+ * `hasHighlightVideo` and `hasHomeLocation` live outside the player-prefs blob
+ * (the `video_links` table and the location store), so callers fetch them and
+ * pass them in as `signals` — keeping this function pure and unit-testable.
  */
 
-import type { PlayerProfile } from "~/types/onboarding";
 import { createClientLogger } from "~/utils/logger";
 
 const logger = createClientLogger("profileCompletenessCalculation");
 
-// Weight configuration: each field's contribution to total completion
+// Weight configuration: each field's contribution to total completion.
 const WEIGHTS = {
   graduationYear: 0.1, // 10%
   primarySport: 0.1, // 10%
   primaryPosition: 0.1, // 10%
-  zipCode: 0.1, // 10%
+  homeLocation: 0.1, // 10% (zip or coordinates — from the location store)
   gpa: 0.15, // 15%
   testScores: 0.1, // 10% (SAT or ACT, not both)
-  highlightVideo: 0.15, // 15%
-  athleticStats: 0.1, // 10%
-  contactInfo: 0.1, // 10%
+  highlightVideo: 0.15, // 15% (≥1 row in the video_links table)
+  height: 0.05, // 5%
+  weight: 0.05, // 5%
+  contactInfo: 0.1, // 10% (phone)
 } as const;
 
 // Verify weights sum to 1.0 (100%)
 const TOTAL_WEIGHT = Object.values(WEIGHTS).reduce((a, b) => a + b, 0);
 if (Math.abs(TOTAL_WEIGHT - 1) > 0.0001) {
-  logger.warn(
-    `Profile completeness weights do not sum to 1.0: ${TOTAL_WEIGHT}`,
-  );
+  logger.warn(`Profile completeness weights do not sum to 1.0: ${TOTAL_WEIGHT}`);
 }
 
 /**
- * Checks if a field value is considered "present"
+ * The player-prefs fields that feed completeness. A structural subset of
+ * `PlayerDetails` (types/models.ts) so callers can pass their form/blob directly.
+ */
+export interface ScorableProfile {
+  graduation_year?: number | null;
+  primary_sport?: string | null;
+  primary_position?: string | null;
+  gpa?: number | null;
+  sat_score?: number | null;
+  act_score?: number | null;
+  height_inches?: number | null;
+  weight_lbs?: number | null;
+  phone?: string | null;
+}
+
+/**
+ * Home location counts as "set" for completeness when a zip is present or a
+ * geocoded coordinate pair exists. Canonical rule shared with iOS
+ * (`HomeLocation.isSet`).
+ */
+export const isHomeLocationPresent = (
+  home?: {
+    zip?: string | null;
+    latitude?: number | null;
+    longitude?: number | null;
+  } | null,
+): boolean => {
+  if (!home) return false;
+  if (typeof home.zip === "string" && home.zip.trim().length > 0) return true;
+  return home.latitude != null && home.longitude != null;
+};
+
+/** Completeness signals sourced from outside the player-prefs blob. */
+export interface ProfileCompletenessSignals {
+  /** ≥1 row in the video_links table for this athlete. */
+  hasHighlightVideo: boolean;
+  /** Home location set: a zip or a geocoded coordinate pair. */
+  hasHomeLocation: boolean;
+}
+
+const NO_SIGNALS: ProfileCompletenessSignals = {
+  hasHighlightVideo: false,
+  hasHomeLocation: false,
+};
+
+/**
+ * Checks if a field value is considered "present".
  *
  * Empty strings, null, undefined, and 0 are considered missing.
- * Empty arrays are considered missing.
  */
 const isFieldPresent = (value: unknown): boolean => {
   if (value === null || value === undefined) return false;
   if (typeof value === "string") return value.trim().length > 0;
   if (typeof value === "number") return value !== 0;
-  if (Array.isArray(value)) return value.length > 0;
   return Boolean(value);
 };
 
 /**
  * Calculates the percentage of profile completion (0-100).
  *
- * Weights are distributed as follows:
+ * Weights:
  * - Graduation Year: 10%
  * - Primary Sport: 10%
  * - Primary Position: 10%
- * - Zip Code: 10%
+ * - Home Location (zip or coordinates): 10%
  * - GPA: 15%
- * - Test Scores (SAT or ACT): 10% (requires at least one, not both)
+ * - Test Scores (SAT or ACT): 10%
  * - Highlight Video: 15%
- * - Athletic Stats: 10%
+ * - Height: 5%
+ * - Weight: 5%
  * - Contact Info (phone): 10%
  *
- * Returns an integer (0-100) representing the percentage complete.
- *
- * @param profile - The player profile object to evaluate
+ * @param profile - The player-prefs object to evaluate
+ * @param signals - Presence of a highlight video and a home location
  * @returns Integer from 0 to 100 representing completion percentage
- *
- * @example
- * const profile = {
- *   graduation_year: 2028,
- *   primary_sport: "soccer",
- *   primary_position: "forward",
- *   zip_code: "60601",
- *   gpa: 3.8,
- *   sat_score: 1400,
- * };
- * calculateProfileCompleteness(profile); // Returns 65
  */
 export const calculateProfileCompleteness = (
-  profile: PlayerProfile,
+  profile: ScorableProfile,
+  signals: ProfileCompletenessSignals = NO_SIGNALS,
 ): number => {
-  let completionScore = 0;
+  let score = 0;
 
-  // Check each weighted field
-  if (isFieldPresent(profile.graduation_year)) {
-    completionScore += WEIGHTS.graduationYear;
-  }
-
-  if (isFieldPresent(profile.primary_sport)) {
-    completionScore += WEIGHTS.primarySport;
-  }
-
-  if (isFieldPresent(profile.primary_position)) {
-    completionScore += WEIGHTS.primaryPosition;
-  }
-
-  if (isFieldPresent(profile.zip_code)) {
-    completionScore += WEIGHTS.zipCode;
-  }
-
-  if (isFieldPresent(profile.gpa)) {
-    completionScore += WEIGHTS.gpa;
-  }
-
-  // Test scores: require at least one (SAT or ACT)
+  if (isFieldPresent(profile.graduation_year)) score += WEIGHTS.graduationYear;
+  if (isFieldPresent(profile.primary_sport)) score += WEIGHTS.primarySport;
+  if (isFieldPresent(profile.primary_position)) score += WEIGHTS.primaryPosition;
+  if (signals.hasHomeLocation) score += WEIGHTS.homeLocation;
+  if (isFieldPresent(profile.gpa)) score += WEIGHTS.gpa;
   if (isFieldPresent(profile.sat_score) || isFieldPresent(profile.act_score)) {
-    completionScore += WEIGHTS.testScores;
+    score += WEIGHTS.testScores;
   }
+  if (signals.hasHighlightVideo) score += WEIGHTS.highlightVideo;
+  if (isFieldPresent(profile.height_inches)) score += WEIGHTS.height;
+  if (isFieldPresent(profile.weight_lbs)) score += WEIGHTS.weight;
+  if (isFieldPresent(profile.phone)) score += WEIGHTS.contactInfo;
 
-  if (isFieldPresent(profile.highlight_video_url)) {
-    completionScore += WEIGHTS.highlightVideo;
-  }
-
-  if (isFieldPresent(profile.athletic_stats)) {
-    completionScore += WEIGHTS.athleticStats;
-  }
-
-  if (isFieldPresent(profile.phone)) {
-    completionScore += WEIGHTS.contactInfo;
-  }
-
-  // Convert to percentage and round to nearest integer
-  return Math.round(completionScore * 100);
+  return Math.round(score * 100);
 };


### PR DESCRIPTION
## Bug
Web profile completeness read **55%** while iOS read **92%** for the same athlete.

## Root cause
The weighted formula gave **35% of its weight** to three fields nothing populates:
- `zip_code` (10%) — onboarding saves zip to the location store, not the player-prefs blob the calc read.
- `highlight_video_url` (15%) — written nowhere; real video lives in the `video_links` table.
- `athletic_stats` (10%) — written nowhere.

Result: capped at ~65% and divergent from iOS.

## Fix
Re-wire to real data as the canonical weighted spec (shared with iOS; companion PR in recruiting-compass-ios):
- **Home location** (10%): `isHomeLocationPresent` (zip or coordinate pair) from the location store, passed as a signal.
- **Highlight video** (15%): ≥1 row in the `video_links` table, passed as a signal.
- **athletic_stats** (10%) → height 5% + weight 5% (real player-prefs fields).

`calculateProfileCompleteness(profile, signals)` stays pure; callers (`useProfileCompleteness`, `usePlayerDetailsForm`) fetch the two signals and pass them in.

Spec (iOS repo): `planning/2026-08-09-profile-completeness-canonical-spec.md`

## Test plan
- `vue-tsc --noEmit` clean.
- **48/48 pass** — `profileCompletenessCalculation.spec`, `useProfileCompleteness.spec`, `ProfileCompleteness.spec`, `Screen5Complete.spec`.

> Stacked on `feat/family-shared-player-profile` (unmerged). Retarget to `main` after the feature merges.

https://claude.ai/code/session_01R1HZvjzRQq3hWcKDmBBvre