### PR TITLE
fix(profile): stop wiping primary_position on load — restore web/iOS completeness parity

### DIFF
--- a/composables/usePlayerDetailsForm.ts
+++ b/composables/usePlayerDetailsForm.ts
@@ -3,7 +3,11 @@ import { usePreferenceManager } from "~/composables/usePreferenceManager";
 import { useAppToast } from "~/composables/useAppToast";
 import { useSportsPositionLookup } from "~/composables/useSportsPositionLookup";
 import { useAutoSave } from "~/composables/useAutoSave";
-import { normalizePositions } from "~/utils/positions";
+import {
+  normalizePositions,
+  shouldClearPositionOnSportChange,
+  reconcilePositionOptions,
+} from "~/utils/positions";
 import { normalizeHandle, type SocialPlatform } from "~/utils/social";
 import {
   calculateProfileCompleteness,
@@ -136,17 +140,26 @@ export function usePlayerDetailsForm() {
 
   watch(
     () => form.value.primary_sport,
-    (sport) => {
-      if (sport) {
-        availablePositions.value = getPositionsBySport(sport);
-        if (
-          !availablePositions.value.includes(form.value.primary_position || "")
-        ) {
-          form.value.primary_position = undefined;
-        }
-      } else {
-        availablePositions.value = [];
+    (sport, previousSport) => {
+      const canonical = sport ? getPositionsBySport(sport) : [];
+      // Only reset the position on a genuine USER sport change — never on the
+      // initial load (previousSport === undefined), which would silently wipe a
+      // stored value that isn't a canonical option (e.g. "Infielder" from iOS)
+      // and cost 10% of profile completeness.
+      if (
+        shouldClearPositionOnSportChange(
+          previousSport,
+          sport,
+          form.value.primary_position,
+          canonical,
+        )
+      ) {
+        form.value.primary_position = undefined;
       }
+      availablePositions.value = reconcilePositionOptions(
+        canonical,
+        form.value.primary_position,
+      );
     },
   );
 
@@ -293,8 +306,9 @@ export function usePlayerDetailsForm() {
       form.value.core_courses = playerDetails.core_courses ?? [];
       initializeHeight(playerDetails.height_inches);
       if (form.value.primary_sport) {
-        availablePositions.value = getPositionsBySport(
-          form.value.primary_sport,
+        availablePositions.value = reconcilePositionOptions(
+          getPositionsBySport(form.value.primary_sport),
+          form.value.primary_position,
         );
       }
     }

--- a/tests/unit/utils/positions.spec.ts
+++ b/tests/unit/utils/positions.spec.ts
@@ -5,6 +5,8 @@ import {
   normalizePositions,
   isValidPosition,
   getPositionFullName,
+  shouldClearPositionOnSportChange,
+  reconcilePositionOptions,
 } from "~/utils/positions";
 
 describe("utils/positions", () => {
@@ -336,6 +338,94 @@ describe("utils/positions", () => {
       expect(getPositionFullName("unknown")).toBe("unknown");
       expect(getPositionFullName("Pitcher")).toBe("Pitcher");
       expect(getPositionFullName("")).toBe("");
+    });
+  });
+
+  // Regression for the profile-completeness parity bug: the player-details sport
+  // watcher silently wiped a stored `primary_position` on every page load when
+  // the saved value ("Infielder", "Point Guard", …) wasn't one of the web
+  // dropdown's canonical abbreviations, dropping 10% off completeness (web 75 vs
+  // iOS 85). These pure helpers encode the fix.
+  describe("shouldClearPositionOnSportChange", () => {
+    const baseball = ["P", "C", "1B", "2B", "3B", "SS"];
+    const basketball = ["PG", "SG", "SF", "PF", "C"];
+
+    it("never clears on initial load (previousSport undefined), even with a non-canonical stored position", () => {
+      expect(
+        shouldClearPositionOnSportChange(
+          undefined,
+          "Baseball",
+          "Infielder",
+          baseball,
+        ),
+      ).toBe(false);
+    });
+
+    it("clears on a real user sport change when the position is invalid for the new sport", () => {
+      expect(
+        shouldClearPositionOnSportChange(
+          "Baseball",
+          "Basketball",
+          "Infielder",
+          basketball,
+        ),
+      ).toBe(true);
+    });
+
+    it("keeps the position on a sport change when it is still valid for the new sport", () => {
+      expect(
+        shouldClearPositionOnSportChange("Baseball", "Softball", "C", [
+          "C",
+          "P",
+        ]),
+      ).toBe(false);
+    });
+
+    it("does not clear when there is no stored position", () => {
+      expect(
+        shouldClearPositionOnSportChange(
+          "Baseball",
+          "Basketball",
+          "",
+          basketball,
+        ),
+      ).toBe(false);
+      expect(
+        shouldClearPositionOnSportChange(
+          "Baseball",
+          "Basketball",
+          null,
+          basketball,
+        ),
+      ).toBe(false);
+    });
+
+    it("does not clear when the sport is cleared (no new sport)", () => {
+      expect(
+        shouldClearPositionOnSportChange("Baseball", undefined, "SS", []),
+      ).toBe(false);
+    });
+  });
+
+  describe("reconcilePositionOptions", () => {
+    it("appends a stored non-canonical position so it stays selectable", () => {
+      expect(reconcilePositionOptions(["P", "SS"], "Infielder")).toEqual([
+        "P",
+        "SS",
+        "Infielder",
+      ]);
+    });
+
+    it("leaves options unchanged when the stored position is already canonical", () => {
+      expect(reconcilePositionOptions(["P", "SS"], "SS")).toEqual(["P", "SS"]);
+    });
+
+    it("leaves options unchanged when there is no stored position", () => {
+      expect(reconcilePositionOptions(["P", "SS"], null)).toEqual(["P", "SS"]);
+      expect(reconcilePositionOptions(["P", "SS"], undefined)).toEqual([
+        "P",
+        "SS",
+      ]);
     });
   });
 });

--- a/utils/positions.ts
+++ b/utils/positions.ts
@@ -163,3 +163,51 @@ export function getPositionFullName(position: string): string {
   const found = BASEBALL_POSITIONS.find((p) => p.value === position);
   return found ? found.fullName : position;
 }
+
+/**
+ * Whether a stored `primary_position` should be cleared because the athlete
+ * switched sports. Sport-agnostic.
+ *
+ * Guards against the load-time data-wipe bug: the position picker's sport
+ * watcher must only reset the position on a genuine USER sport change, never
+ * when the form is first populated from saved data. A stored value that isn't
+ * one of the newly-selected sport's canonical options (e.g. an iOS/onboarding
+ * label like "Infielder" or "Point Guard") would otherwise be silently deleted
+ * on every page load, dropping 10% off profile completeness.
+ *
+ * @param previousSport - The sport value before the change (`undefined` on the
+ *   initial population — the watcher's first fire — which must NOT clear)
+ * @param newSport - The sport value after the change
+ * @param currentPosition - The currently-stored primary position
+ * @param newSportPositions - Canonical options for `newSport`
+ * @returns True only on a real sport change to an incompatible position
+ */
+export function shouldClearPositionOnSportChange(
+  previousSport: string | undefined,
+  newSport: string | undefined,
+  currentPosition: string | undefined | null,
+  newSportPositions: string[],
+): boolean {
+  if (previousSport === undefined) return false; // initial load / first set
+  if (!newSport || !currentPosition) return false;
+  return !newSportPositions.includes(currentPosition);
+}
+
+/**
+ * Reconcile a sport's canonical position options with the athlete's stored
+ * value so a legacy/foreign label (e.g. "Infielder" from iOS) stays selectable
+ * in the dropdown instead of rendering as an empty selection. Sport-agnostic.
+ *
+ * @param sportPositions - Canonical options for the current sport
+ * @param currentPosition - The stored primary position
+ * @returns Options including `currentPosition` when it isn't already canonical
+ */
+export function reconcilePositionOptions(
+  sportPositions: string[],
+  currentPosition: string | undefined | null,
+): string[] {
+  if (currentPosition && !sportPositions.includes(currentPosition)) {
+    return [...sportPositions, currentPosition];
+  }
+  return sportPositions;
+}


### PR DESCRIPTION
## Problem

Profile completeness showed **web 75% vs iOS 85%** for the same complete athlete. Reported as a home-location bug; it is not — **home-location always counted**. The real cause is a **web form bug that silently deletes the athlete's `primary_position` on every page load**.

## Root cause

`composables/usePlayerDetailsForm.ts` watches `primary_sport` and clears `primary_position` when it isn't in the sport's canonical option list. The watcher **also fires on initial load** (sport goes `undefined → "Baseball"`), so a stored value that isn't one of the web dropdown's abbreviations gets wiped.

The web dropdowns use abbreviations (`P, C, 1B, 2B, 3B, SS, …` / `PG, SG, SF, …`), but the labels iOS and onboarding actually store are full/generic — real prod data:

| sport | stored `primary_position` |
|---|---|
| Baseball | `Infielder` |
| Basketball | `Point Guard`, `Small Forward` |

None match → wiped on load → completeness scores position 0 → **75**. iOS has no such watcher → **85**. An autosave after the wipe can also persist the loss to the DB.

## Reproduction (live, prod, player1)

| player blob | score |
|---|---|
| sparse (sport, phone, grad) + location | 40 (home ✅) |
| + gpa, height, weight | 65 (home ✅) |
| + `primary_position:"Infielder"` | **65** — position wiped (expected 75) |

## Fix

Two sport-agnostic pure helpers in `utils/positions.ts`:
- `shouldClearPositionOnSportChange` — only clears on a genuine **user** sport change (`previousSport` defined), never on initial load.
- `reconcilePositionOptions` — keeps a stored non-canonical value selectable so the dropdown shows it (non-destructive; no data migration; all sports).

Wired into the watcher + `load()`. Position survives load → completeness matches iOS (85).

## Tests

`tests/unit/utils/positions.spec.ts` — 8 new cases (73 total pass). Type-check + lint clean on changed files.

## Follow-up (not in this PR)

The dropdown-label mismatch (stored `Infielder` isn't a canonical option) is worked around here by keeping the value selectable. A proper reconciliation — normalizing stored labels to canonical across all sports, or a one-time backfill — is a separate cleanup.

https://claude.ai/code/session_01DCuzdXvTExkJSJSaBsEBTk