### PR TITLE
Promote develop → main: canonical positions + handoff correction

### DIFF
--- a/composables/usePlayerDetailsForm.ts
+++ b/composables/usePlayerDetailsForm.ts
@@ -4,10 +4,13 @@ import { useAppToast } from "~/composables/useAppToast";
 import { useSportsPositionLookup } from "~/composables/useSportsPositionLookup";
 import { useAutoSave } from "~/composables/useAutoSave";
 import {
-  normalizePositions,
   shouldClearPositionOnSportChange,
   reconcilePositionOptions,
 } from "~/utils/positions";
+import {
+  normalizePosition as normalizePositionForSport,
+  normalizePositions as normalizePositionsForSport,
+} from "~/utils/positions/canonical";
 import { normalizeHandle, type SocialPlatform } from "~/utils/social";
 import {
   calculateProfileCompleteness,
@@ -132,7 +135,10 @@ export function usePlayerDetailsForm() {
     onSave: async () => {
       const detailsToSave = {
         ...form.value,
-        positions: normalizePositions(form.value.positions),
+        positions: normalizePositionsForSport(
+          form.value.primary_sport,
+          form.value.positions,
+        ),
       };
       await setPlayerDetails(detailsToSave);
     },
@@ -298,10 +304,23 @@ export function usePlayerDetailsForm() {
       if (playerDetails.high_school && !playerDetails.school_name) {
         playerDetails.school_name = playerDetails.high_school;
       }
+      // Canonicalize stored positions (legacy abbreviations / coarse buckets
+      // like "Infielder" → real full-name positions) so the dropdown, the
+      // multi-select, and completeness all agree. Preserve an unresolved value
+      // so nothing is silently dropped.
+      const canonicalPrimary = normalizePositionForSport(
+        playerDetails.primary_sport,
+        playerDetails.primary_position,
+      );
       form.value = {
         ...form.value,
         ...playerDetails,
-        positions: normalizePositions(playerDetails.positions),
+        primary_position:
+          canonicalPrimary ?? playerDetails.primary_position ?? undefined,
+        positions: normalizePositionsForSport(
+          playerDetails.primary_sport,
+          playerDetails.positions,
+        ),
       };
       form.value.core_courses = playerDetails.core_courses ?? [];
       initializeHeight(playerDetails.height_inches);

--- a/composables/useSportsPositionLookup.ts
+++ b/composables/useSportsPositionLookup.ts
@@ -1,53 +1,19 @@
 // composables/useSportsPositionLookup.ts
+//
+// Thin wrapper over the canonical position source (utils/positions/canonical).
+// Kept as a composable so existing call sites (usePlayerDetailsForm) don't
+// change, but the vocabulary is now the single canonical full-name set shared
+// with onboarding — no more abbreviations, no coarse "Infielder"/"Outfielder".
+import {
+  SPORT_POSITIONS,
+  getCanonicalPositions,
+} from "~/utils/positions/canonical";
+
 export const useSportsPositionLookup = () => {
-  // Map of sport -> positions
-  const sportPositions: Record<string, string[]> = {
-    Baseball: [
-      "P",
-      "C",
-      "1B",
-      "2B",
-      "3B",
-      "SS",
-      "LF",
-      "CF",
-      "RF",
-      "DH",
-      "UTIL",
-    ],
-    Softball: [
-      "P",
-      "C",
-      "1B",
-      "2B",
-      "3B",
-      "SS",
-      "LF",
-      "CF",
-      "RF",
-      "DH",
-      "UTIL",
-    ],
-    Basketball: ["PG", "SG", "SF", "PF", "C"],
-    Football: ["QB", "RB", "WR", "TE", "OL", "DL", "LB", "DB", "K"],
-    Soccer: ["GK", "DEF", "MID", "FWD"],
-    Lacrosse: ["G", "D", "M", "A"],
-    "Ice Hockey": ["G", "D", "LW", "C", "RW"],
-    Volleyball: ["S", "MB", "OH", "OP", "L"],
-    "Track & Field": ["Distance", "Sprints", "Jumps", "Throws", "Hurdles"],
-    "Cross Country": ["Runner"],
-    Swimming: ["Distance", "Sprint", "IM", "Dive"],
-    Tennis: ["Singles", "Doubles"],
-    Golf: ["Player"],
-  };
+  const commonSports = Object.keys(SPORT_POSITIONS);
 
-  // Common sports list (what's available in onboarding)
-  const commonSports = Object.keys(sportPositions);
-
-  // Get positions for a given sport
-  const getPositionsBySport = (sport: string): string[] => {
-    return sportPositions[sport] || [];
-  };
+  const getPositionsBySport = (sport: string): string[] =>
+    getCanonicalPositions(sport);
 
   return {
     commonSports,

--- a/pages/onboarding/index.vue
+++ b/pages/onboarding/index.vue
@@ -373,6 +373,7 @@ import { useFamilyCode } from "~/composables/useFamilyCode";
 import { useFamilyInvite } from "~/composables/useFamilyInvite";
 import { useAppToast } from "~/composables/useAppToast";
 import { createClientLogger } from "~/utils/logger";
+import { getCanonicalPositions } from "~/utils/positions/canonical";
 
 const logger = createClientLogger("Onboarding");
 
@@ -436,69 +437,9 @@ const commonSports = [
   "Water Polo",
 ];
 
-const sportPositions: Record<string, string[]> = {
-  Baseball: [
-    "Pitcher",
-    "Catcher",
-    "Infielder",
-    "Outfielder",
-    "Designated Hitter",
-  ],
-  Basketball: [
-    "Point Guard",
-    "Shooting Guard",
-    "Small Forward",
-    "Power Forward",
-    "Center",
-  ],
-  Football: [
-    "Quarterback",
-    "Running Back",
-    "Wide Receiver",
-    "Tight End",
-    "Offensive Line",
-    "Linebacker",
-    "Defensive Back",
-    "Defensive Line",
-  ],
-  Soccer: ["Goalkeeper", "Defender", "Midfielder", "Forward"],
-  Volleyball: [
-    "Outside Hitter",
-    "Middle Blocker",
-    "Setter",
-    "Libero",
-    "Opposite Hitter",
-  ],
-  Softball: [
-    "Pitcher",
-    "Catcher",
-    "Infielder",
-    "Outfielder",
-    "Designated Hitter",
-  ],
-  "Track & Field": ["Sprinter", "Distance Runner", "Jumper", "Thrower"],
-  Swimming: [
-    "Freestyle",
-    "Backstroke",
-    "Breaststroke",
-    "Butterfly",
-    "Individual Medley",
-  ],
-  "Cross Country": ["Runner"],
-  Tennis: ["Singles", "Doubles"],
-  Golf: ["Golfer"],
-  Lacrosse: ["Attackman", "Midfielder", "Defenseman", "Goalie"],
-  "Field Hockey": ["Forward", "Midfielder", "Defender", "Goalkeeper"],
-  "Ice Hockey": ["Forward", "Defenseman", "Goalie"],
-  Wrestling: ["Wrestler"],
-  Rowing: ["Rower"],
-  "Water Polo": ["Field Player", "Goalkeeper"],
-};
-
-const positions = computed(() => {
-  const sport = onboardingData.value.primary_sport as string;
-  return sport && sportPositions[sport] ? sportPositions[sport] : [];
-});
+const positions = computed(() =>
+  getCanonicalPositions(onboardingData.value.primary_sport as string),
+);
 
 const graduationYears = computed(() => {
   const years = [];

--- a/pages/onboarding/parent.vue
+++ b/pages/onboarding/parent.vue
@@ -286,6 +286,7 @@ import { useAuthFetch } from "~/composables/useAuthFetch";
 import { useFamilyCode } from "~/composables/useFamilyCode";
 import { useFamilyInvite } from "~/composables/useFamilyInvite";
 import type { UseActiveFamilyReturn } from "~/composables/useActiveFamily";
+import { getCanonicalPositions } from "~/utils/positions/canonical";
 
 definePageMeta({ layout: "default", middleware: "auth" });
 
@@ -334,67 +335,8 @@ const commonSports = [
   "Water Polo",
 ];
 
-const sportPositions: Record<string, string[]> = {
-  Baseball: [
-    "Pitcher",
-    "Catcher",
-    "Infielder",
-    "Outfielder",
-    "Designated Hitter",
-  ],
-  Basketball: [
-    "Point Guard",
-    "Shooting Guard",
-    "Small Forward",
-    "Power Forward",
-    "Center",
-  ],
-  Football: [
-    "Quarterback",
-    "Running Back",
-    "Wide Receiver",
-    "Tight End",
-    "Offensive Line",
-    "Linebacker",
-    "Defensive Back",
-    "Defensive Line",
-  ],
-  Soccer: ["Goalkeeper", "Defender", "Midfielder", "Forward"],
-  Volleyball: [
-    "Outside Hitter",
-    "Middle Blocker",
-    "Setter",
-    "Libero",
-    "Opposite Hitter",
-  ],
-  Softball: [
-    "Pitcher",
-    "Catcher",
-    "Infielder",
-    "Outfielder",
-    "Designated Hitter",
-  ],
-  "Track & Field": ["Sprinter", "Distance Runner", "Jumper", "Thrower"],
-  Swimming: [
-    "Freestyle",
-    "Backstroke",
-    "Breaststroke",
-    "Butterfly",
-    "Individual Medley",
-  ],
-  "Cross Country": ["Runner"],
-  Tennis: ["Singles", "Doubles"],
-  Golf: ["Golfer"],
-  Lacrosse: ["Attackman", "Midfielder", "Defenseman", "Goalie"],
-  "Field Hockey": ["Forward", "Midfielder", "Defender", "Goalkeeper"],
-  "Ice Hockey": ["Forward", "Defenseman", "Goalie"],
-  Wrestling: ["Wrestler"],
-  Rowing: ["Rower"],
-  "Water Polo": ["Field Player", "Goalkeeper"],
-};
-
 const availablePositions = computed(() =>
-  sport.value ? (sportPositions[sport.value] ?? []) : [],
+  getCanonicalPositions(sport.value),
 );
 
 const graduationYears = computed(() => {

--- a/planning/2026-08-09-position-vocabulary-normalization.md
+++ b/planning/2026-08-09-position-vocabulary-normalization.md
@@ -1,0 +1,102 @@
+# Position Vocabulary Normalization — Plan
+
+**Date:** 2026-08-09
+**Owner:** web (source of truth) + iOS follow-up
+**Origin:** profile-completeness parity bug (#352). Root disease = many conflicting
+position vocabularies; "Infielder" (a category, not a real position) is offered in
+onboarding but never matches the edit form.
+
+## Decisions (locked with Chris)
+
+1. **Canonical vocabulary = full-name, granular**, one source of truth used by
+   onboarding, the edit form, and iOS. No abbreviations in stored data.
+2. **Migrate ambiguous legacy values → `Utility`** (`Infielder`/`Outfielder`/`Infield`/`Outfield` → `Utility`); clean values (`Point Guard`, `Shortstop`) stay; abbreviations expand (`P`→`Pitcher`, `1B`→`First Base`, …). Keep any unknown value selectable (never silently drop).
+
+## Current state — SIX vocabularies + two storage locations
+
+| # | Source | Vocabulary | Used by |
+|---|---|---|---|
+| 1 | `pages/onboarding/index.vue` (inline `sportPositions`) | full names, coarse (Infielder/Outfielder), 17 sports | player onboarding `<option>` list |
+| 2 | `pages/onboarding/parent.vue` (inline) | identical to #1 | parent onboarding |
+| 3 | `composables/useSportsPositionLookup.ts` | **abbreviations** (P,1B,SS,PG…), 12 sports | settings edit form (`usePlayerDetailsForm`) |
+| 4 | `utils/sportsPositionLookup.ts` | `{id,name}` objects, full names, 10 sports (baseball has "Outfield", no LF/CF/RF/UTIL) | `components/Onboarding/Screen2BasicInfo.vue` |
+| 5 | `utils/positions.ts` | baseball abbreviations only + `normalizePosition` | `positions[]` array normalization, completeness helpers |
+| 6 | DB `positions` table + `users.primary_position_id`/`primary_position_custom` | DB rows | `useTemplateResolver`, `seed-demo-families` |
+
+**Two storage locations for "position":**
+- `user_preferences.data.primary_position` (free string) — read by completeness, edit form, public profile.
+- `users.primary_position_id` / `primary_position_custom` (FK to `positions` table) — read by templates/seed.
+
+**No Zod enum** constrains `primary_position` or `positions[]` — any string passes. Only runtime `normalizePosition` (baseball-only) enforces anything.
+
+**Collision:** `C` = Catcher (baseball) AND Center (basketball) → normalization MUST be sport-scoped.
+
+## Canonical position map (full names, granular)
+
+```
+Baseball / Softball: Pitcher, Catcher, First Base, Second Base, Third Base,
+  Shortstop, Left Field, Center Field, Right Field, Designated Hitter, Utility
+Basketball: Point Guard, Shooting Guard, Small Forward, Power Forward, Center
+Football: Quarterback, Running Back, Wide Receiver, Tight End, Offensive Line,
+  Defensive Line, Linebacker, Defensive Back, Kicker, Punter
+Soccer: Goalkeeper, Defender, Midfielder, Forward
+Volleyball: Outside Hitter, Middle Blocker, Setter, Libero, Opposite Hitter, Defensive Specialist
+Track & Field: Sprinter, Distance Runner, Jumper, Thrower, Hurdler
+Swimming: Freestyle, Backstroke, Breaststroke, Butterfly, Individual Medley, Diver
+Cross Country: Runner
+Tennis: Singles, Doubles
+Golf: Golfer
+Lacrosse: Attackman, Midfielder, Defenseman, Goalie
+Field Hockey: Forward, Midfielder, Defender, Goalkeeper
+Ice Hockey: Forward, Defenseman, Goalie
+Wrestling: Wrestler
+Rowing: Rower
+Water Polo: Field Player, Goalkeeper
+```
+
+Legacy → canonical (sport-scoped) migration map covers: abbreviations
+(P→Pitcher, 1B→First Base, PG→Point Guard, …) and coarse (Infielder/Outfielder→Utility).
+
+## Phased approach
+
+### Phase 1 — DONE (2026-08-09)
+
+- `utils/positions/canonical.ts` — `SPORT_POSITIONS` (full-name granular, 17 sports)
+  + sport-scoped `normalizePosition`/`normalizePositions` (preserve unknowns, no
+  data loss) + `getCanonicalPositions`. 14 tests.
+- Onboarding `index.vue` + `parent.vue` and `useSportsPositionLookup` now read the
+  canonical module → **no "Infielder"/"Outfielder" offered anywhere live**.
+- `validatePlayerDetails` + `usePlayerDetailsForm` canonicalize `primary_position`
+  + `positions[]` on read/load/save.
+- DB backfill applied (live): `primary_position` (Infielder→Utility, P→Pitcher, …)
+  and `positions[]` → canonical full names. 0 abbrev/coarse values remain.
+- **Data-loss recovery:** owen's `primary_position` had been wiped to null by the
+  OLD buggy bundle + autosave during diagnosis; restored to `Utility` (canonical
+  of his original "Infielder"; his `positions[]` = Second/Third Base, Shortstop,
+  Pitcher survived). Chris to refine to a specific spot in the fixed UI if wanted.
+- Tests: 248 across affected specs green; type-check 0.
+
+Screen2BasicInfo.vue is dead (rendered nowhere) → its object lookup
+`utils/sportsPositionLookup.ts` (still has softball "infield"/"outfield") deferred
+to Phase 2, not user-facing.
+
+### (original) Phase 1 — canonical module + user-facing fix (this session, bounded)
+Goal: remove "Infielder" everywhere it's offered, one full-name vocabulary for
+onboarding + edit form, permanent completeness fix, backfill stored strings.
+
+0. **Verify which onboarding is live** (`/onboarding` index.vue vs Screen2BasicInfo) — grep routes/components; don't edit a dead path.
+1. New `utils/positions/canonical.ts`: `SPORT_POSITIONS` (the map above) + `normalizePosition(sport, value)` (sport-scoped) + `getCanonicalPositions(sport)`.
+2. Repoint onboarding #1, #2 and edit-form lookup #3 at the canonical module (full names; Infielder/Outfielder gone → real positions).
+3. `usePlayerDetailsForm` + `preferenceValidation` normalize `primary_position` + `positions[]` to canonical on load/save (keep-unknown-selectable retained from #352).
+4. DB backfill (idempotent): normalize `user_preferences.data.primary_position` + `positions[]` to canonical (single-digit rows today).
+5. Tests (sport-scoped normalize incl. C collision; onboarding offers no Infielder) + live verify (owen/player1 = 85; onboarding dropdown shows real positions).
+
+### Phase 2 — deeper unification (separate session)
+- Fold object lookup #4 (`utils/sportsPositionLookup.ts` + Screen2BasicInfo) into the canonical module; retire the object shape or derive it from canonical.
+- Reconcile the DB `positions` table (#6) vs the `primary_position` string — decide one storage location; migrate templates/seed.
+- iOS: align `OnboardingConstants`/`FamilyConstants` to the canonical labels (web is source of truth) — handoff spec.
+
+## Open questions
+- Which onboarding flow is live (Phase 1 step 0)?
+- Utility for `Outfielder`, or a new coarse-but-valid "Outfield"? (Decision: Utility, to stay granular-only.)
+- DB `positions` table (#6): unify now or Phase 2? (Proposed: Phase 2 — it's a different store, not user-facing in the completeness path.)

--- a/planning/2026-08-09-web-completeness-home-location-parity.md
+++ b/planning/2026-08-09-web-completeness-home-location-parity.md
@@ -104,3 +104,23 @@ platforms jump to **100%**.
 - iOS — no change. iOS is arithmetically correct.
 - `video_links` table creation — separate cross-platform work
   (`video-links-cross-platform`). Both platforms already score video 0 until it lands.
+
+---
+
+## RESOLUTION (2026-08-09, later) — home-location was a MISDIAGNOSIS
+
+This handoff's premise (web undercounts because it reads home-location from a
+dead source) was **wrong**. Live bisection on prod (player1) proved
+home-location always counted. The real 10% gap was **`primary_position` being
+silently wiped on every page load**:
+
+`usePlayerDetailsForm.ts` watches `primary_sport` and cleared `primary_position`
+when it wasn't in the sport's canonical option list — and it fired on the
+INITIAL load too. Stored labels like `Infielder` (baseball) / `Point Guard`
+(basketball) aren't in the web dropdown's abbreviations (`SS`,`PG`,…) → wiped →
+completeness scored position 0 → web 75 vs iOS 85.
+
+Fixed in **#352** (`shouldClearPositionOnSportChange` + `reconcilePositionOptions`
+in `utils/positions.ts`); promoted to prod via **#353**. Verified live: player1
+40→50 after the fix. Home-location parity (#349) was real and already correct —
+just not the cause of the 75.

--- a/tests/unit/composables/useSportsPositionLookup.spec.ts
+++ b/tests/unit/composables/useSportsPositionLookup.spec.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { useSportsPositionLookup } from "~/composables/useSportsPositionLookup";
 
+// useSportsPositionLookup now delegates to the canonical position source
+// (utils/positions/canonical): one full-name, granular vocabulary shared with
+// onboarding. No abbreviations, no coarse "Infielder"/"Outfielder".
 describe("useSportsPositionLookup", () => {
   it("should return list of common sports", () => {
     const { commonSports } = useSportsPositionLookup();
@@ -11,15 +14,18 @@ describe("useSportsPositionLookup", () => {
     expect(commonSports.length).toBeGreaterThan(0);
   });
 
-  it("should return baseball positions for Baseball sport", () => {
+  it("should return canonical full-name baseball positions", () => {
     const { getPositionsBySport } = useSportsPositionLookup();
     const positions = getPositionsBySport("Baseball");
 
-    expect(positions).toContain("P");
-    expect(positions).toContain("C");
-    expect(positions).toContain("1B");
-    expect(positions).toContain("SS");
-    expect(positions).toContain("LF");
+    expect(positions).toContain("Pitcher");
+    expect(positions).toContain("Catcher");
+    expect(positions).toContain("First Base");
+    expect(positions).toContain("Shortstop");
+    expect(positions).toContain("Left Field");
+    expect(positions).toContain("Utility");
+    expect(positions).not.toContain("Infielder");
+    expect(positions).not.toContain("Outfielder");
     expect(positions.length).toBe(11);
   });
 
@@ -27,11 +33,11 @@ describe("useSportsPositionLookup", () => {
     const { getPositionsBySport } = useSportsPositionLookup();
     const positions = getPositionsBySport("Basketball");
 
-    expect(positions).toContain("PG");
-    expect(positions).toContain("SG");
-    expect(positions).toContain("SF");
-    expect(positions).toContain("PF");
-    expect(positions).toContain("C");
+    expect(positions).toContain("Point Guard");
+    expect(positions).toContain("Shooting Guard");
+    expect(positions).toContain("Small Forward");
+    expect(positions).toContain("Power Forward");
+    expect(positions).toContain("Center");
     expect(positions.length).toBe(5);
   });
 
@@ -39,10 +45,10 @@ describe("useSportsPositionLookup", () => {
     const { getPositionsBySport } = useSportsPositionLookup();
     const positions = getPositionsBySport("Soccer");
 
-    expect(positions).toContain("GK");
-    expect(positions).toContain("DEF");
-    expect(positions).toContain("MID");
-    expect(positions).toContain("FWD");
+    expect(positions).toContain("Goalkeeper");
+    expect(positions).toContain("Defender");
+    expect(positions).toContain("Midfielder");
+    expect(positions).toContain("Forward");
     expect(positions.length).toBe(4);
   });
 
@@ -50,18 +56,16 @@ describe("useSportsPositionLookup", () => {
     const { getPositionsBySport } = useSportsPositionLookup();
     const positions = getPositionsBySport("Football");
 
-    expect(positions).toContain("QB");
-    expect(positions).toContain("RB");
-    expect(positions).toContain("WR");
-    expect(positions).toContain("TE");
+    expect(positions).toContain("Quarterback");
+    expect(positions).toContain("Running Back");
+    expect(positions).toContain("Wide Receiver");
+    expect(positions).toContain("Tight End");
     expect(positions).toBeInstanceOf(Array);
   });
 
   it("should return empty array for unknown sport", () => {
     const { getPositionsBySport } = useSportsPositionLookup();
-    const positions = getPositionsBySport("UnknownSport");
-
-    expect(positions).toEqual([]);
+    expect(getPositionsBySport("UnknownSport")).toEqual([]);
   });
 
   it("should return positions for all sports in commonSports", () => {
@@ -76,10 +80,9 @@ describe("useSportsPositionLookup", () => {
 
   it("should include Softball with same positions as Baseball", () => {
     const { getPositionsBySport } = useSportsPositionLookup();
-    const baseballPositions = getPositionsBySport("Baseball");
-    const softballPositions = getPositionsBySport("Softball");
-
-    expect(softballPositions).toEqual(baseballPositions);
+    expect(getPositionsBySport("Softball")).toEqual(
+      getPositionsBySport("Baseball"),
+    );
   });
 
   it("should include Track & Field sport", () => {
@@ -87,8 +90,8 @@ describe("useSportsPositionLookup", () => {
 
     expect(commonSports).toContain("Track & Field");
     const positions = getPositionsBySport("Track & Field");
-    expect(positions).toContain("Distance");
-    expect(positions).toContain("Sprints");
+    expect(positions).toContain("Sprinter");
+    expect(positions).toContain("Distance Runner");
   });
 
   it("should include Ice Hockey sport", () => {
@@ -96,11 +99,9 @@ describe("useSportsPositionLookup", () => {
 
     expect(commonSports).toContain("Ice Hockey");
     const positions = getPositionsBySport("Ice Hockey");
-    expect(positions).toContain("G");
-    expect(positions).toContain("D");
-    expect(positions).toContain("LW");
-    expect(positions).toContain("C");
-    expect(positions).toContain("RW");
+    expect(positions).toContain("Forward");
+    expect(positions).toContain("Defenseman");
+    expect(positions).toContain("Goalie");
   });
 
   it("should include Volleyball sport", () => {
@@ -108,9 +109,9 @@ describe("useSportsPositionLookup", () => {
 
     expect(commonSports).toContain("Volleyball");
     const positions = getPositionsBySport("Volleyball");
-    expect(positions).toContain("S");
-    expect(positions).toContain("MB");
-    expect(positions).toContain("OH");
+    expect(positions).toContain("Outside Hitter");
+    expect(positions).toContain("Middle Blocker");
+    expect(positions).toContain("Setter");
   });
 
   it("should include Lacrosse sport", () => {
@@ -118,10 +119,10 @@ describe("useSportsPositionLookup", () => {
 
     expect(commonSports).toContain("Lacrosse");
     const positions = getPositionsBySport("Lacrosse");
-    expect(positions).toContain("G");
-    expect(positions).toContain("D");
-    expect(positions).toContain("M");
-    expect(positions).toContain("A");
+    expect(positions).toContain("Attackman");
+    expect(positions).toContain("Midfielder");
+    expect(positions).toContain("Defenseman");
+    expect(positions).toContain("Goalie");
   });
 
   it("should include Swimming sport", () => {
@@ -129,10 +130,9 @@ describe("useSportsPositionLookup", () => {
 
     expect(commonSports).toContain("Swimming");
     const positions = getPositionsBySport("Swimming");
-    expect(positions).toContain("Distance");
-    expect(positions).toContain("Sprint");
-    expect(positions).toContain("IM");
-    expect(positions).toContain("Dive");
+    expect(positions).toContain("Freestyle");
+    expect(positions).toContain("Individual Medley");
+    expect(positions).toContain("Diver");
   });
 
   it("should include Tennis sport", () => {
@@ -148,22 +148,18 @@ describe("useSportsPositionLookup", () => {
     const { commonSports, getPositionsBySport } = useSportsPositionLookup();
 
     expect(commonSports).toContain("Golf");
-    const positions = getPositionsBySport("Golf");
-    expect(positions).toEqual(["Player"]);
+    expect(getPositionsBySport("Golf")).toEqual(["Golfer"]);
   });
 
   it("should include Cross Country sport", () => {
     const { commonSports, getPositionsBySport } = useSportsPositionLookup();
 
     expect(commonSports).toContain("Cross Country");
-    const positions = getPositionsBySport("Cross Country");
-    expect(positions).toEqual(["Runner"]);
+    expect(getPositionsBySport("Cross Country")).toEqual(["Runner"]);
   });
 
   it("should have consistent sport names case", () => {
     const { commonSports } = useSportsPositionLookup();
-
-    // All sports should be properly capitalized strings
     commonSports.forEach((sport) => {
       expect(typeof sport).toBe("string");
       expect(sport.length).toBeGreaterThan(0);
@@ -172,10 +168,7 @@ describe("useSportsPositionLookup", () => {
 
   it("should handle case sensitivity correctly", () => {
     const { getPositionsBySport } = useSportsPositionLookup();
-
-    // Lowercase should return empty
     expect(getPositionsBySport("baseball")).toEqual([]);
-    // Correct case should return positions
     expect(getPositionsBySport("Baseball").length).toBeGreaterThan(0);
   });
 });

--- a/tests/unit/utils/canonicalPositions.spec.ts
+++ b/tests/unit/utils/canonicalPositions.spec.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import {
+  SPORT_POSITIONS,
+  getCanonicalPositions,
+  normalizePosition,
+  normalizePositions,
+  isCanonicalPosition,
+} from "~/utils/positions/canonical";
+
+describe("canonical positions", () => {
+  describe("SPORT_POSITIONS / getCanonicalPositions", () => {
+    it("offers real granular baseball positions and NOT the coarse 'Infielder'/'Outfielder'", () => {
+      const baseball = getCanonicalPositions("Baseball");
+      expect(baseball).toContain("Shortstop");
+      expect(baseball).toContain("Second Base");
+      expect(baseball).toContain("Center Field");
+      expect(baseball).toContain("Utility");
+      expect(baseball).not.toContain("Infielder");
+      expect(baseball).not.toContain("Outfielder");
+    });
+
+    it("returns [] for an unknown sport", () => {
+      expect(getCanonicalPositions("Quidditch")).toEqual([]);
+      expect(getCanonicalPositions(null)).toEqual([]);
+    });
+
+    it("returns a copy (callers can't mutate the source)", () => {
+      const a = getCanonicalPositions("Soccer");
+      a.push("Sweeper");
+      expect(getCanonicalPositions("Soccer")).not.toContain("Sweeper");
+    });
+  });
+
+  describe("normalizePosition (sport-scoped)", () => {
+    it("maps the coarse legacy 'Infielder'/'Outfielder' to Utility", () => {
+      expect(normalizePosition("Baseball", "Infielder")).toBe("Utility");
+      expect(normalizePosition("Baseball", "Outfielder")).toBe("Utility");
+      expect(normalizePosition("Softball", "Infielder")).toBe("Utility");
+    });
+
+    it("expands baseball abbreviations to full names", () => {
+      expect(normalizePosition("Baseball", "P")).toBe("Pitcher");
+      expect(normalizePosition("Baseball", "1B")).toBe("First Base");
+      expect(normalizePosition("Baseball", "SS")).toBe("Shortstop");
+      expect(normalizePosition("Baseball", "CF")).toBe("Center Field");
+    });
+
+    it("passes through values that are already canonical (case-insensitive)", () => {
+      expect(normalizePosition("Baseball", "Shortstop")).toBe("Shortstop");
+      expect(normalizePosition("Baseball", "second base")).toBe("Second Base");
+      expect(normalizePosition("Basketball", "Point Guard")).toBe("Point Guard");
+    });
+
+    it("resolves the C collision by sport: Catcher (baseball) vs Center (basketball)", () => {
+      expect(normalizePosition("Baseball", "C")).toBe("Catcher");
+      expect(normalizePosition("Basketball", "C")).toBe("Center");
+    });
+
+    it("resolves the P collision by sport: Pitcher (baseball) vs Punter (football)", () => {
+      expect(normalizePosition("Baseball", "P")).toBe("Pitcher");
+      expect(normalizePosition("Football", "P")).toBe("Punter");
+    });
+
+    it("maps common basketball/football/soccer abbreviations", () => {
+      expect(normalizePosition("Basketball", "PG")).toBe("Point Guard");
+      expect(normalizePosition("Football", "WR")).toBe("Wide Receiver");
+      expect(normalizePosition("Soccer", "GK")).toBe("Goalkeeper");
+    });
+
+    it("returns null for unknown values or unknown sport", () => {
+      expect(normalizePosition("Baseball", "Rover")).toBeNull();
+      expect(normalizePosition("Quidditch", "Seeker")).toBeNull();
+      expect(normalizePosition("Baseball", "")).toBeNull();
+      expect(normalizePosition(null, "SS")).toBeNull();
+    });
+  });
+
+  describe("normalizePositions (array)", () => {
+    it("canonicalizes a mixed-vocabulary array, de-duplicating", () => {
+      // Real prod data had both abbreviations and full names in one array.
+      expect(
+        normalizePositions("Baseball", ["P", "Pitcher", "SS", "Shortstop", "1B"]),
+      ).toEqual(["Pitcher", "Shortstop", "First Base"]);
+    });
+
+    it("preserves unresolved entries instead of dropping them (no data loss)", () => {
+      expect(normalizePositions("Baseball", ["SS", "Rover", "2B"])).toEqual([
+        "Shortstop",
+        "Rover",
+        "Second Base",
+      ]);
+    });
+
+    it("preserves values as-is when the sport is unknown/missing", () => {
+      expect(normalizePositions(undefined, ["P", "SS"])).toEqual(["P", "SS"]);
+    });
+
+    it("returns [] for non-arrays", () => {
+      expect(normalizePositions("Baseball", null)).toEqual([]);
+      expect(normalizePositions("Baseball", undefined)).toEqual([]);
+    });
+  });
+
+  describe("isCanonicalPosition", () => {
+    it("is true only for canonical values of that sport", () => {
+      expect(isCanonicalPosition("Baseball", "Shortstop")).toBe(true);
+      expect(isCanonicalPosition("Baseball", "SS")).toBe(false);
+      expect(isCanonicalPosition("Baseball", "Infielder")).toBe(false);
+      expect(isCanonicalPosition("Basketball", "Center")).toBe(true);
+    });
+  });
+});

--- a/tests/unit/utils/preferenceValidation.spec.ts
+++ b/tests/unit/utils/preferenceValidation.spec.ts
@@ -234,15 +234,20 @@ describe("validatePlayerDetails", () => {
     expect(result!.allow_share_email).toBe(false);
   });
 
-  it("maps positions as a string array, normalizing to canonical values", () => {
-    // normalizePositions only accepts canonical baseball position values
-    const result = validatePlayerDetails({ positions: ["P", "SS"] });
-    expect(result!.positions).toEqual(["P", "SS"]);
+  it("canonicalizes positions against the sport (abbreviations → full names)", () => {
+    const result = validatePlayerDetails({
+      primary_sport: "Baseball",
+      positions: ["P", "SS", "1B"],
+    });
+    expect(result!.positions).toEqual(["Pitcher", "Shortstop", "First Base"]);
   });
 
-  it("returns empty positions array for unrecognized position codes", () => {
-    const result = validatePlayerDetails({ positions: ["SP", "RP"] });
-    expect(result!.positions).toEqual([]);
+  it("preserves unrecognized position values instead of dropping them (no data loss)", () => {
+    const result = validatePlayerDetails({
+      primary_sport: "Baseball",
+      positions: ["SP", "RP"],
+    });
+    expect(result!.positions).toEqual(["SP", "RP"]);
   });
 
   it("maps high-school grade team fields", () => {

--- a/utils/positions/canonical.ts
+++ b/utils/positions/canonical.ts
@@ -1,0 +1,219 @@
+/**
+ * Canonical athlete positions — the single source of truth.
+ *
+ * One full-name, granular vocabulary per sport, used by onboarding, the
+ * player-details edit form, and (via handoff) iOS. Stored `primary_position`
+ * and `positions[]` values are normalized to these labels so completeness,
+ * dropdowns, and recruiting output all agree.
+ *
+ * Normalization is SPORT-SCOPED because labels collide across sports
+ * (e.g. "C" = Catcher in baseball but Center in basketball; "P" = Pitcher vs
+ * Punter). Never resolve a position without its sport.
+ */
+
+/** Canonical positions per sport (full names, granular). */
+export const SPORT_POSITIONS: Record<string, readonly string[]> = {
+  Baseball: [
+    "Pitcher",
+    "Catcher",
+    "First Base",
+    "Second Base",
+    "Third Base",
+    "Shortstop",
+    "Left Field",
+    "Center Field",
+    "Right Field",
+    "Designated Hitter",
+    "Utility",
+  ],
+  Softball: [
+    "Pitcher",
+    "Catcher",
+    "First Base",
+    "Second Base",
+    "Third Base",
+    "Shortstop",
+    "Left Field",
+    "Center Field",
+    "Right Field",
+    "Designated Hitter",
+    "Utility",
+  ],
+  Basketball: [
+    "Point Guard",
+    "Shooting Guard",
+    "Small Forward",
+    "Power Forward",
+    "Center",
+  ],
+  Football: [
+    "Quarterback",
+    "Running Back",
+    "Wide Receiver",
+    "Tight End",
+    "Offensive Line",
+    "Defensive Line",
+    "Linebacker",
+    "Defensive Back",
+    "Kicker",
+    "Punter",
+  ],
+  Soccer: ["Goalkeeper", "Defender", "Midfielder", "Forward"],
+  Volleyball: [
+    "Outside Hitter",
+    "Middle Blocker",
+    "Setter",
+    "Libero",
+    "Opposite Hitter",
+    "Defensive Specialist",
+  ],
+  "Track & Field": [
+    "Sprinter",
+    "Distance Runner",
+    "Jumper",
+    "Thrower",
+    "Hurdler",
+  ],
+  Swimming: [
+    "Freestyle",
+    "Backstroke",
+    "Breaststroke",
+    "Butterfly",
+    "Individual Medley",
+    "Diver",
+  ],
+  "Cross Country": ["Runner"],
+  Tennis: ["Singles", "Doubles"],
+  Golf: ["Golfer"],
+  Lacrosse: ["Attackman", "Midfielder", "Defenseman", "Goalie"],
+  "Field Hockey": ["Forward", "Midfielder", "Defender", "Goalkeeper"],
+  "Ice Hockey": ["Forward", "Defenseman", "Goalie"],
+  Wrestling: ["Wrestler"],
+  Rowing: ["Rower"],
+  "Water Polo": ["Field Player", "Goalkeeper"],
+} as const;
+
+/**
+ * Sport-scoped aliases mapping every known legacy value (abbreviations, coarse
+ * buckets, common variants) to its canonical label. Keys are matched
+ * case-insensitively. Coarse/ambiguous baseball buckets (Infielder/Outfielder)
+ * resolve to "Utility" — a real, valid position — per the migration decision.
+ */
+const SPORT_ALIASES: Record<string, Record<string, string>> = {
+  Baseball: {
+    p: "Pitcher",
+    c: "Catcher",
+    "1b": "First Base",
+    "1st base": "First Base",
+    "2b": "Second Base",
+    "2nd base": "Second Base",
+    "3b": "Third Base",
+    "3rd base": "Third Base",
+    ss: "Shortstop",
+    "short stop": "Shortstop",
+    lf: "Left Field",
+    leftfield: "Left Field",
+    cf: "Center Field",
+    centerfield: "Center Field",
+    rf: "Right Field",
+    rightfield: "Right Field",
+    dh: "Designated Hitter",
+    util: "Utility",
+    infielder: "Utility",
+    infield: "Utility",
+    if: "Utility",
+    outfielder: "Utility",
+    outfield: "Utility",
+    of: "Utility",
+  },
+  Basketball: {
+    pg: "Point Guard",
+    sg: "Shooting Guard",
+    sf: "Small Forward",
+    pf: "Power Forward",
+    c: "Center",
+  },
+  Football: {
+    qb: "Quarterback",
+    rb: "Running Back",
+    wr: "Wide Receiver",
+    te: "Tight End",
+    ol: "Offensive Line",
+    dl: "Defensive Line",
+    lb: "Linebacker",
+    db: "Defensive Back",
+    k: "Kicker",
+    p: "Punter",
+  },
+  Soccer: {
+    gk: "Goalkeeper",
+    def: "Defender",
+    mid: "Midfielder",
+    fwd: "Forward",
+  },
+};
+// Softball shares Baseball's aliases.
+SPORT_ALIASES.Softball = SPORT_ALIASES.Baseball;
+
+/** Canonical position list for a sport (empty array for unknown sports). */
+export function getCanonicalPositions(sport: string | null | undefined): string[] {
+  if (!sport) return [];
+  return [...(SPORT_POSITIONS[sport] ?? [])];
+}
+
+/**
+ * Normalize a single position value to its canonical label for the given sport.
+ * Returns the canonical string, or `null` when the value can't be resolved
+ * (unknown label / unknown sport) so callers can decide whether to preserve it.
+ */
+export function normalizePosition(
+  sport: string | null | undefined,
+  value: string | null | undefined,
+): string | null {
+  if (!sport || !value || typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const canonical = SPORT_POSITIONS[sport];
+  if (!canonical) return null;
+
+  // Already canonical (case-insensitive).
+  const lower = trimmed.toLowerCase();
+  const direct = canonical.find((p) => p.toLowerCase() === lower);
+  if (direct) return direct;
+
+  // Known alias.
+  const alias = SPORT_ALIASES[sport]?.[lower];
+  return alias ?? null;
+}
+
+/**
+ * Normalize an array of position values for a sport: canonicalize what we can,
+ * PRESERVE anything unresolved (unknown label, missing/unknown sport) rather
+ * than dropping it — never lose an athlete's data on a read. De-duplicates and
+ * preserves order; only empty/blank entries are removed.
+ */
+export function normalizePositions(
+  sport: string | null | undefined,
+  values: string[] | null | undefined,
+): string[] {
+  if (!Array.isArray(values)) return [];
+  const out: string[] = [];
+  for (const v of values) {
+    if (typeof v !== "string") continue;
+    const resolved = normalizePosition(sport, v) ?? v.trim();
+    if (resolved && !out.includes(resolved)) out.push(resolved);
+  }
+  return out;
+}
+
+/** Whether a value is already a canonical position for the sport. */
+export function isCanonicalPosition(
+  sport: string | null | undefined,
+  value: string | null | undefined,
+): boolean {
+  if (!sport || !value) return false;
+  const canonical = SPORT_POSITIONS[sport];
+  if (!canonical) return false;
+  return canonical.some((p) => p.toLowerCase() === value.trim().toLowerCase());
+}

--- a/utils/preferenceValidation.ts
+++ b/utils/preferenceValidation.ts
@@ -15,7 +15,10 @@ import type {
   WidgetId,
 } from "~/types/models";
 import { WIDGET_SIZES } from "~/types/models";
-import { normalizePositions } from "./positions";
+import {
+  normalizePosition as normalizePositionForSport,
+  normalizePositions as normalizePositionsForSport,
+} from "./positions/canonical";
 
 /**
  * Validates and extracts notification settings
@@ -88,13 +91,22 @@ export function validatePlayerDetails(data: unknown): PlayerDetails | null {
   // Check if player has any meaningful data
   if (Object.keys(obj).length === 0) return null;
 
+  // Canonicalize positions against the sport so legacy abbreviations and coarse
+  // buckets (e.g. "Infielder" → "Utility", "SS" → "Shortstop") read as the one
+  // canonical vocabulary. Preserve an unresolved primary_position rather than
+  // dropping it.
+  const sport = toString(obj.primary_sport);
+  const rawPrimaryPosition = toString(obj.primary_position);
+
   return {
     graduation_year: toNumber(obj.graduation_year),
-    primary_sport: toString(obj.primary_sport),
-    primary_position: toString(obj.primary_position),
+    primary_sport: sport,
+    primary_position:
+      normalizePositionForSport(sport, rawPrimaryPosition) ??
+      rawPrimaryPosition,
     high_school: toString(obj.high_school),
     club_team: toString(obj.club_team),
-    positions: normalizePositions(toStringArray(obj.positions)),
+    positions: normalizePositionsForSport(sport, toStringArray(obj.positions)),
     bats: toOption<"L" | "R" | "S">(obj.bats, ["L", "R", "S"]),
     throws: toOption<"L" | "R">(obj.throws, ["L", "R"]),
     height_inches: toNumber(obj.height_inches),


### PR DESCRIPTION
Promotes to production:
- **#354** feat(positions): one canonical full-name position vocabulary — removes "Infielder"/"Outfielder" from onboarding, unifies onboarding + edit form, canonicalizes stored data (DB backfilled live).
- Handoff-doc correction (position-wipe root cause).

Detail in #354.

https://claude.ai/code/session_01DCuzdXvTExkJSJSaBsEBTk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sport-specific canonical position names across onboarding, player details, and preference validation.
  * Common position abbreviations and legacy variants are automatically normalized.
  * Unrecognized position values are preserved during loading and saving.

* **Bug Fixes**
  * Prevented saved primary positions from being cleared when they are not listed in current sport options.
  * Restored accurate profile completeness scoring for affected players.

* **Documentation**
  * Added documentation covering position vocabulary normalization and home-location completeness findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->