### PR TITLE
feat(profile): reorganize Player Details tabs (Contact/Social → Basics, High School → Academics)

### DIFF
--- a/components/Settings/PlayerDetailsAcademicsTab.vue
+++ b/components/Settings/PlayerDetailsAcademicsTab.vue
@@ -1,5 +1,64 @@
 <template>
   <div class="space-y-6">
+    <!-- School Info -->
+    <div class="bg-white rounded-2xl border border-slate-200 shadow-sm p-6">
+      <h2 class="text-base font-bold text-slate-900 mb-6">High School</h2>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div class="md:col-span-2">
+          <label
+            class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
+            >High School Name</label
+          >
+          <SharedHighSchoolSearchInput
+            data-testid="hs-name"
+            :model-value="{
+              name: form.school_name ?? '',
+              nces_school_id: form.nces_school_id || null,
+            }"
+            :state-hint="form.school_state || ''"
+            :disabled="isParentRole"
+            @update:model-value="
+              (v: HighSchoolSelection) => {
+                form.school_name = v.name;
+                form.high_school = v.name;
+                form.nces_school_id = v.nces_school_id ?? '';
+                triggerSave();
+              }
+            "
+          />
+        </div>
+        <div>
+          <label
+            class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
+            >School City</label
+          >
+          <input
+            v-model="form.school_city"
+            :disabled="isParentRole"
+            type="text"
+            placeholder="Atlanta"
+            @blur="triggerSave"
+            class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-blue-500 transition font-medium text-slate-700"
+          />
+        </div>
+        <div>
+          <label
+            class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
+            >School State</label
+          >
+          <input
+            v-model="form.school_state"
+            :disabled="isParentRole"
+            type="text"
+            placeholder="GA"
+            maxlength="2"
+            @blur="triggerSave"
+            class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-blue-500 uppercase transition font-medium text-slate-700"
+          />
+        </div>
+      </div>
+    </div>
+
     <!-- Academics -->
     <div class="bg-white rounded-2xl border border-slate-200 shadow-sm p-6">
       <h2
@@ -111,135 +170,17 @@
         </p>
       </div>
     </div>
-
-    <!-- Social Media -->
-    <div class="bg-white rounded-2xl border border-slate-200 shadow-sm p-6">
-      <h2 class="text-base font-bold text-slate-900 mb-6">Social Handles</h2>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div v-for="social in socialInputs" :key="social.key" class="relative">
-          <label
-            class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
-            >{{ social.label }}</label
-          >
-          <div class="flex items-center">
-            <span
-              v-if="social.prefix"
-              class="absolute left-4 text-slate-400 font-bold"
-              >{{ social.prefix }}</span
-            >
-            <input
-              v-model="form[social.key]"
-              type="text"
-              @blur="
-                (e) =>
-                  handleSocialBlur(
-                    String(social.key),
-                    (e.target as HTMLInputElement).value,
-                  )
-              "
-              :placeholder="social.placeholder"
-              :class="[
-                'w-full py-3 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-blue-500 transition font-medium text-slate-700',
-                social.prefix ? 'pl-9 pr-4' : 'px-4',
-              ]"
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Contact -->
-    <div class="bg-white rounded-2xl border border-slate-200 shadow-sm p-6">
-      <h2 class="text-base font-bold text-slate-900 mb-6">
-        Contact &amp; Privacy
-      </h2>
-      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-        <div>
-          <label
-            class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
-            >Phone Number</label
-          >
-          <input
-            v-model="form.phone"
-            type="tel"
-            autocomplete="tel"
-            @blur="triggerSave"
-            placeholder="(555) 000-0000"
-            class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl font-medium"
-          />
-        </div>
-        <div>
-          <label
-            class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
-            >Public Email</label
-          >
-          <input
-            v-model="form.email"
-            type="email"
-            autocomplete="email"
-            @blur="triggerSave"
-            placeholder="athlete@example.com"
-            class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl font-medium"
-          />
-        </div>
-      </div>
-
-      <div class="bg-slate-50 rounded-2xl p-4 space-y-4">
-        <label class="flex items-center gap-3 cursor-pointer group">
-          <div class="relative flex items-center">
-            <input
-              v-model="form.allow_share_phone"
-              type="checkbox"
-              @change="triggerSave"
-              class="peer h-6 w-6 cursor-pointer appearance-none rounded-lg border border-slate-300 bg-white checked:bg-blue-600 checked:border-blue-600 transition-all shadow-sm"
-            />
-            <UIcon
-              name="i-heroicons-check"
-              class="absolute h-4 w-4 text-white opacity-0 peer-checked:opacity-100 left-1 top-1 pointer-events-none stroke-[3]"
-            />
-          </div>
-          <span
-            class="text-sm font-bold text-slate-600 group-hover:text-slate-900 transition"
-            >Show phone number to verified coaches</span
-          >
-        </label>
-        <label class="flex items-center gap-3 cursor-pointer group">
-          <div class="relative flex items-center">
-            <input
-              v-model="form.allow_share_email"
-              type="checkbox"
-              @change="triggerSave"
-              class="peer h-6 w-6 cursor-pointer appearance-none rounded-lg border border-slate-300 bg-white checked:bg-blue-600 checked:border-blue-600 transition-all shadow-sm"
-            />
-            <UIcon
-              name="i-heroicons-check"
-              class="absolute h-4 w-4 text-white opacity-0 peer-checked:opacity-100 left-1 top-1 pointer-events-none stroke-[3]"
-            />
-          </div>
-          <span
-            class="text-sm font-bold text-slate-600 group-hover:text-slate-900 transition"
-            >Show email to verified coaches</span
-          >
-        </label>
-      </div>
-    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import type { PlayerDetails } from "~/types/models";
+import type { HighSchoolSelection } from "~/composables/useHighSchoolSearch";
 
 defineProps<{
   form: PlayerDetails;
   isParentRole: boolean;
   triggerSave: () => void;
-  socialInputs: {
-    key: keyof PlayerDetails;
-    label: string;
-    prefix?: string;
-    placeholder: string;
-  }[];
-  handleSocialBlur: (key: string, value: string) => void;
   addCourse: () => void;
   removeCourse: (idx: number) => void;
 }>();

--- a/components/Settings/PlayerDetailsBasicsTab.vue
+++ b/components/Settings/PlayerDetailsBasicsTab.vue
@@ -64,63 +64,6 @@
         </div>
       </div>
 
-      <!-- School Info -->
-      <div
-        class="grid grid-cols-1 md:grid-cols-2 gap-6 pt-8 border-t border-slate-100"
-      >
-        <div class="md:col-span-2">
-          <label
-            class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
-            >High School Name</label
-          >
-          <SharedHighSchoolSearchInput
-            :model-value="{
-              name: form.school_name ?? '',
-              nces_school_id: form.nces_school_id || null,
-            }"
-            :state-hint="form.school_state || ''"
-            :disabled="isParentRole"
-            @update:model-value="
-              (v: HighSchoolSelection) => {
-                form.school_name = v.name;
-                form.high_school = v.name;
-                form.nces_school_id = v.nces_school_id ?? '';
-                triggerSave();
-              }
-            "
-          />
-        </div>
-        <div>
-          <label
-            class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
-            >School City</label
-          >
-          <input
-            v-model="form.school_city"
-            :disabled="isParentRole"
-            type="text"
-            placeholder="Atlanta"
-            @blur="triggerSave"
-            class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-blue-500 transition font-medium text-slate-700"
-          />
-        </div>
-        <div>
-          <label
-            class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
-            >School State</label
-          >
-          <input
-            v-model="form.school_state"
-            :disabled="isParentRole"
-            type="text"
-            placeholder="GA"
-            maxlength="2"
-            @blur="triggerSave"
-            class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-blue-500 uppercase transition font-medium text-slate-700"
-          />
-        </div>
-      </div>
-
       <!-- Recruiting Contact (separate from login credentials) -->
       <div
         class="grid grid-cols-1 md:grid-cols-2 gap-6 pt-8 border-t border-slate-100"
@@ -135,6 +78,7 @@
             :disabled="isParentRole"
             type="email"
             placeholder="you@example.com"
+            data-testid="contact-email"
             @blur="triggerSave"
             class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-blue-500 transition font-medium text-slate-700"
           />
@@ -152,12 +96,97 @@
             :disabled="isParentRole"
             type="tel"
             placeholder="440-555-0134"
+            data-testid="contact-phone"
             @blur="triggerSave"
             class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-blue-500 transition font-medium text-slate-700"
           />
           <p class="text-xs text-slate-400 mt-1.5 ml-1">
             The number coaches can text.
           </p>
+        </div>
+
+        <div class="md:col-span-2 bg-slate-50 rounded-2xl p-4 space-y-4">
+          <label class="flex items-center gap-3 cursor-pointer group">
+            <div class="relative flex items-center">
+              <input
+                v-model="form.allow_share_phone"
+                type="checkbox"
+                data-testid="share-phone"
+                @change="triggerSave"
+                class="peer h-6 w-6 cursor-pointer appearance-none rounded-lg border border-slate-300 bg-white checked:bg-blue-600 checked:border-blue-600 transition-all shadow-sm"
+              />
+              <UIcon
+                name="i-heroicons-check"
+                class="absolute h-4 w-4 text-white opacity-0 peer-checked:opacity-100 left-1 top-1 pointer-events-none stroke-[3]"
+              />
+            </div>
+            <span
+              class="text-sm font-bold text-slate-600 group-hover:text-slate-900 transition"
+              >Show phone number to verified coaches</span
+            >
+          </label>
+          <label class="flex items-center gap-3 cursor-pointer group">
+            <div class="relative flex items-center">
+              <input
+                v-model="form.allow_share_email"
+                type="checkbox"
+                data-testid="share-email"
+                @change="triggerSave"
+                class="peer h-6 w-6 cursor-pointer appearance-none rounded-lg border border-slate-300 bg-white checked:bg-blue-600 checked:border-blue-600 transition-all shadow-sm"
+              />
+              <UIcon
+                name="i-heroicons-check"
+                class="absolute h-4 w-4 text-white opacity-0 peer-checked:opacity-100 left-1 top-1 pointer-events-none stroke-[3]"
+              />
+            </div>
+            <span
+              class="text-sm font-bold text-slate-600 group-hover:text-slate-900 transition"
+              >Show email to verified coaches</span
+            >
+          </label>
+        </div>
+      </div>
+
+      <!-- Social Media -->
+      <div
+        class="pt-8 border-t border-slate-100"
+      >
+        <h2 class="text-base font-bold text-slate-900 mb-6">Social Handles</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div
+            v-for="social in socialInputs"
+            :key="social.key"
+            class="relative"
+            :data-testid="`social-${social.key}`"
+          >
+            <label
+              class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
+              >{{ social.label }}</label
+            >
+            <div class="flex items-center">
+              <span
+                v-if="social.prefix"
+                class="absolute left-4 text-slate-400 font-bold"
+                >{{ social.prefix }}</span
+              >
+              <input
+                v-model="form[social.key]"
+                type="text"
+                @blur="
+                  (e) =>
+                    handleSocialBlur(
+                      String(social.key),
+                      (e.target as HTMLInputElement).value,
+                    )
+                "
+                :placeholder="social.placeholder"
+                :class="[
+                  'w-full py-3 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-blue-500 transition font-medium text-slate-700',
+                  social.prefix ? 'pl-9 pr-4' : 'px-4',
+                ]"
+              />
+            </div>
+          </div>
         </div>
       </div>
 
@@ -232,7 +261,6 @@
 
 <script setup lang="ts">
 import type { PlayerDetails } from "~/types/models";
-import type { HighSchoolSelection } from "~/composables/useHighSchoolSearch";
 import { useFamilyCtx } from "~/composables/useFamilyCtx";
 
 // Photo targets the athlete being viewed (self for a player, the linked athlete for a parent).
@@ -249,5 +277,12 @@ defineProps<{
     label: string;
   }[];
   triggerSave: () => void;
+  socialInputs: {
+    key: keyof PlayerDetails;
+    label: string;
+    prefix?: string;
+    placeholder: string;
+  }[];
+  handleSocialBlur: (key: string, value: string) => void;
 }>();
 </script>

--- a/pages/settings/player-details.vue
+++ b/pages/settings/player-details.vue
@@ -128,6 +128,8 @@
             :campus-size-options="CAMPUS_SIZE_OPTIONS"
             :cost-sensitivity-options="COST_SENSITIVITY_OPTIONS"
             :trigger-save="triggerSave"
+            :social-inputs="socialInputs"
+            :handle-social-blur="handleSocialBlur"
           />
         </div>
 
@@ -151,7 +153,7 @@
           />
         </div>
 
-        <!-- TAB: ACADEMICS & SOCIAL -->
+        <!-- TAB: ACADEMICS -->
         <div
           v-show="currentTab === 'academics'"
           class="space-y-6 animate-in fade-in slide-in-from-bottom-2 duration-300"
@@ -160,8 +162,6 @@
             :form="form"
             :is-parent-role="isReadOnly"
             :trigger-save="triggerSave"
-            :social-inputs="socialInputs"
-            :handle-social-blur="handleSocialBlur"
             :add-course="addCourse"
             :remove-course="removeCourse"
             v-model:new-course-input="newCourseInput"
@@ -335,7 +335,7 @@ const tabs = [
   { id: "athletics", name: "Athletics", icon: "i-heroicons-bolt" },
   {
     id: "academics",
-    name: "Academics & Social",
+    name: "Academics",
     icon: "i-heroicons-academic-cap",
   },
   { id: "history", name: "History", icon: "i-heroicons-clock" },

--- a/tests/e2e/player-details-autosave.spec.ts
+++ b/tests/e2e/player-details-autosave.spec.ts
@@ -25,7 +25,7 @@ test.describe("Player Details Auto-Save", () => {
 
     // Check that major tab sections exist (tabs appear twice - desktop + mobile, use first)
     await expect(page.locator("text=Athletics").first()).toBeVisible();
-    await expect(page.locator("text=Academics & Social").first()).toBeVisible();
+    await expect(page.locator("text=Academics").first()).toBeVisible();
   });
 
   test("should show primary sport and position fields", async ({ page }) => {

--- a/tests/e2e/profile-edit-restrictions.spec.ts
+++ b/tests/e2e/profile-edit-restrictions.spec.ts
@@ -10,8 +10,8 @@ import { resolve } from "path";
  * - No read-only banner: the whole family can edit.
  * - Inputs are enabled for parents and players alike.
  * - Page uses auto-save (no explicit save button)
- * - Tabs: Basics, Athletics, Academics & Social, History, Public Profile
- * - GPA input is on the Academics & Social tab
+ * - Tabs: Basics, Athletics, Academics, History, Public Profile
+ * - GPA input is on the Academics tab
  */
 
 test.describe("Profile Edit Restrictions (User Story 2.2)", () => {
@@ -117,10 +117,10 @@ test.describe("Profile Edit Restrictions (User Story 2.2)", () => {
       await page.goto("/settings/player-details");
       await page.waitForLoadState("domcontentloaded");
 
-      // Switch to Academics & Social tab
+      // Switch to Academics tab
       const academicsTab = page
         .locator("button", {
-          hasText: "Academics & Social",
+          hasText: "Academics",
         })
         .first();
       await academicsTab.click();
@@ -152,7 +152,7 @@ test.describe("Profile Edit Restrictions (User Story 2.2)", () => {
         page.locator("button", { hasText: "Athletics" }).first(),
       ).toBeVisible();
       await expect(
-        page.locator("button", { hasText: "Academics & Social" }).first(),
+        page.locator("button", { hasText: "Academics" }).first(),
       ).toBeVisible();
       await expect(
         page.locator("button", { hasText: "History" }).first(),
@@ -180,7 +180,7 @@ test.describe("Profile Edit Restrictions (User Story 2.2)", () => {
 
       const academicsTab = page
         .locator("button", {
-          hasText: "Academics & Social",
+          hasText: "Academics",
         })
         .first();
       await academicsTab.click();

--- a/tests/e2e/smart-inputs.spec.ts
+++ b/tests/e2e/smart-inputs.spec.ts
@@ -25,6 +25,12 @@ test.describe("Smart Inputs — High School Search", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto("/settings/player-details");
+    // High School search lives under the "Academics" tab (v-show gates each
+    // tab's section). Click the tab button to make it visible.
+    await page
+      .locator("button", { hasText: "Academics" })
+      .first()
+      .click();
     await page.waitForLoadState("networkidle");
     // Wait for the search input to be present AND enabled before any test fills
     // it — a blind timeout let .fill() fire before Vue hydrated the debounced

--- a/tests/e2e/smart-inputs.spec.ts
+++ b/tests/e2e/smart-inputs.spec.ts
@@ -168,10 +168,10 @@ test.describe("Smart Inputs — Social Handle Normalization", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto("/settings/player-details");
     await page.waitForLoadState("load");
-    // Social inputs live under the "Academics & Social" tab (v-show gates
-    // each tab's section). Click the tab button to make them visible.
+    // Social inputs live under the "Basics" tab (v-show gates each tab's
+    // section). Click the tab button to make them visible.
     await page
-      .locator("button", { hasText: "Academics & Social" })
+      .locator("button", { hasText: "Basics" })
       .first()
       .click();
     await page.waitForTimeout(200);

--- a/tests/e2e/tier2-important/settings.spec.ts
+++ b/tests/e2e/tier2-important/settings.spec.ts
@@ -103,7 +103,7 @@ test.describe("/settings/player-details — Player Details", () => {
   test("shows tab navigation", async ({ page }) => {
     // Tabs render twice (desktop + mobile) — use .first().
     await expect(page.locator("text=Athletics").first()).toBeVisible();
-    await expect(page.locator("text=Academics & Social").first()).toBeVisible();
+    await expect(page.locator("text=Academics").first()).toBeVisible();
   });
 });
 

--- a/tests/unit/components/Settings/PlayerDetailsAcademicsTab.spec.ts
+++ b/tests/unit/components/Settings/PlayerDetailsAcademicsTab.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import PlayerDetailsAcademicsTab from "~/components/Settings/PlayerDetailsAcademicsTab.vue";
+import type { PlayerDetails } from "~/types/models";
+
+const stubs = {
+  SharedHighSchoolSearchInput: {
+    name: "SharedHighSchoolSearchInput",
+    props: ["modelValue", "stateHint", "disabled"],
+    template: '<div data-testid="hs-name">HS Search</div>',
+  },
+};
+
+const createForm = (overrides: Partial<PlayerDetails> = {}): PlayerDetails => ({
+  school_name: "",
+  school_city: "",
+  school_state: "",
+  gpa: undefined,
+  sat_score: undefined,
+  act_score: undefined,
+  core_courses: [],
+  ...overrides,
+});
+
+const defaultProps = {
+  form: createForm(),
+  isParentRole: false,
+  triggerSave: vi.fn(),
+  addCourse: vi.fn(),
+  removeCourse: vi.fn(),
+  newCourseInput: "",
+  "onUpdate:newCourseInput": vi.fn(),
+};
+
+describe("PlayerDetailsAcademicsTab", () => {
+  it("renders the High School field", () => {
+    const wrapper = mount(PlayerDetailsAcademicsTab, {
+      props: defaultProps,
+      global: { stubs },
+    });
+    expect(wrapper.find('[data-testid="hs-name"]').exists()).toBe(true);
+  });
+
+  it("does not render social handle inputs", () => {
+    const wrapper = mount(PlayerDetailsAcademicsTab, {
+      props: defaultProps,
+      global: { stubs },
+    });
+    expect(
+      wrapper.find('[data-testid="social-twitter_handle"]').exists(),
+    ).toBe(false);
+  });
+
+  it("does not render the Contact/Privacy fields", () => {
+    const wrapper = mount(PlayerDetailsAcademicsTab, {
+      props: defaultProps,
+      global: { stubs },
+    });
+    expect(wrapper.find('[data-testid="contact-phone"]').exists()).toBe(
+      false,
+    );
+  });
+});

--- a/tests/unit/components/Settings/PlayerDetailsBasicsTab.spec.ts
+++ b/tests/unit/components/Settings/PlayerDetailsBasicsTab.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import PlayerDetailsBasicsTab from "~/components/Settings/PlayerDetailsBasicsTab.vue";
+import type { PlayerDetails } from "~/types/models";
+
+vi.mock("~/composables/useFamilyCtx", () => ({
+  useFamilyCtx: () => ({ activeAthleteId: { value: null } }),
+}));
+
+const stubs = {
+  SettingsProfilePhotoUpload: {
+    name: "SettingsProfilePhotoUpload",
+    template: "<div>Photo</div>",
+  },
+};
+
+const createForm = (overrides: Partial<PlayerDetails> = {}): PlayerDetails => ({
+  graduation_year: 2027,
+  primary_sport: "Baseball",
+  email: "athlete@example.com",
+  phone: "440-555-0134",
+  allow_share_phone: false,
+  allow_share_email: false,
+  twitter_handle: "",
+  campus_size_preference: undefined,
+  cost_sensitivity: undefined,
+  ...overrides,
+});
+
+const defaultProps = {
+  form: createForm(),
+  isParentRole: false,
+  graduationYears: [2026, 2027, 2028],
+  commonSports: ["Baseball", "Softball"],
+  campusSizeOptions: [
+    { value: "small" as const, label: "Small" },
+    { value: "medium" as const, label: "Medium" },
+    { value: "large" as const, label: "Large" },
+  ],
+  costSensitivityOptions: [
+    { value: "high" as const, label: "High" },
+    { value: "medium" as const, label: "Medium" },
+    { value: "low" as const, label: "Low" },
+  ],
+  triggerSave: vi.fn(),
+  socialInputs: [
+    { key: "twitter_handle" as const, label: "X", placeholder: "@handle" },
+  ],
+  handleSocialBlur: vi.fn(),
+};
+
+describe("PlayerDetailsBasicsTab", () => {
+  it("renders contact email and phone inputs", () => {
+    const wrapper = mount(PlayerDetailsBasicsTab, {
+      props: defaultProps,
+      global: { stubs },
+    });
+    expect(wrapper.find('[data-testid="contact-email"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="contact-phone"]').exists()).toBe(true);
+  });
+
+  it("renders the phone and email privacy toggles", () => {
+    const wrapper = mount(PlayerDetailsBasicsTab, {
+      props: defaultProps,
+      global: { stubs },
+    });
+    expect(wrapper.find('[data-testid="share-phone"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="share-email"]').exists()).toBe(true);
+  });
+
+  it("renders social handle inputs from the socialInputs prop", () => {
+    const wrapper = mount(PlayerDetailsBasicsTab, {
+      props: defaultProps,
+      global: { stubs },
+    });
+    expect(
+      wrapper.find('[data-testid="social-twitter_handle"]').exists(),
+    ).toBe(true);
+  });
+
+  it("does not render the High School field", () => {
+    const wrapper = mount(PlayerDetailsBasicsTab, {
+      props: defaultProps,
+      global: { stubs },
+    });
+    expect(wrapper.find('[data-testid="hs-name"]').exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Reorganize the Player Details settings tabs so fields group by purpose, and collapse the duplicate contact fields to a single home. iOS parity companion — the same reorg shipped for iOS in `recruiting-compass-ios#35`.

### Changes
- **Basics** is now the single home for **Contact** (email, phone, + "share with coaches" privacy toggles) and **Social handles** — both moved out of Academics.
- **Academics** now holds **High School** (name/city/state, moved from Basics), GPA/SAT/ACT, and Core Courses. Social + Contact/Privacy blocks removed.
- Tab renamed **"Academics & Social" → "Academics"** (tab `id` unchanged, routes stable).
- **Fixed a real duplication:** phone/email were previously editable in *both* Basics ("Recruiting") and Academics ("Contact & Privacy"), bound to the same `form.phone`/`form.email`. Now editable in exactly one place (Basics).
- Props rethreaded: `PlayerDetailsBasicsTab` gains `socialInputs`/`handleSocialBlur`; `PlayerDetailsAcademicsTab` loses them; `player-details.vue` moves the bindings accordingly.

### Data
No DB/migration change — every relocated `v-model` keeps its exact `form.*` key. Persisted blob shape unchanged.

## Test plan
- New unit specs: `PlayerDetailsBasicsTab.spec.ts`, `PlayerDetailsAcademicsTab.spec.ts` — assert each field's new-home presence and old-home absence.
- Full unit suite: **7856 passed / 0 failed / 66 skipped**.
- e2e selectors realigned: tab-name "Academics & Social" → "Academics" (`player-details-autosave`, `profile-edit-restrictions`, `tier2-important/settings`); `smart-inputs` now clicks the correct tab before filling social handles **and** High School search (both fields moved off the default Basics view).

## Notes
- Athletics / History / Public Profile tabs untouched.
- Repo eslint does not parse `.vue` files (pre-existing config), so lint is not a meaningful gate here; correctness verified by unit mounts + review.

Design + plan: `recruiting-compass-ios/docs/superpowers/specs/2026-08-10-player-profile-tab-reorg-design.md`.

https://claude.ai/code/session_01AFmKmQxRdpfnKzLbsLRLjP
