### PR TITLE
Promote develop→main: ship what-matters-now endpoint + status/phase parity (fixes iOS timeline card)

### DIFF
--- a/planning/iOS_SPEC_timeline-sync-shared-endpoints-2026-08-11.md
+++ b/planning/iOS_SPEC_timeline-sync-shared-endpoints-2026-08-11.md
@@ -1,0 +1,125 @@
+# iOS Spec — Dashboard Timeline: consume shared web endpoints (stop local recompute)
+
+**Date:** 2026-08-11
+**Source of truth:** web app (`recruiting-compass-web`)
+**Type:** bug fix + architecture (single source of truth)
+
+## Problem
+
+The dashboard timeline (phase / `X/100` score / current-task) is computed **independently** on
+web and iOS. iOS reimplements the web logic in native Swift services and has drifted. Observed:
+
+| Surface | Phase | Score | Current task |
+|---|---|---|---|
+| Web (player) | Junior Year | **20**/100 | "take official SAT or ACT" |
+| iOS (parent) | Junior Year | **0**/100 | "Increase Coach Communications Cadence" |
+
+Same athlete, same family unit — must be identical. Two confirmed divergences:
+
+1. **Score formula.** Web computes a 4-factor weighted composite (`utils/statusScoreCalculation.ts`:
+   taskCompletion 0.35 + interactionFrequency 0.25 + coachInterest 0.25 + academicStanding 0.15,
+   sub-scores from the `get_athlete_status` Postgres RPC). iOS `TimelineStatusService` computes
+   **task-completion only** and hardcodes the other three components to `0` (`TimelineStatusService.swift:12`).
+   → iOS can never match web. This alone explains 20 vs 0.
+
+2. **Current task.** Selection logic is identical on both sides, so a different result means iOS is
+   fed a different task/completion set (independent Supabase read + local derivation). iOS also uses
+   mismatched status-label thresholds (75/50 in `TimelineStatusService` vs 70/50 in
+   `DashboardTimelineSummaryCard.swift`).
+
+## Fix
+
+iOS stops deriving phase / score / current-task locally and **consumes the web endpoints** as the
+single source of truth. Web already computes all three server-side; parent→player resolution and
+grade/phase derivation live in one place.
+
+Three endpoints (all require the existing Supabase bearer token; iOS is already authenticated):
+
+### 1. `GET /api/athlete/phase` (exists)
+```jsonc
+{
+  "phase": "junior",                 // freshman|sophomore|junior|senior|committed
+  "milestoneProgress": {
+    "phase": "junior",
+    "required": ["<taskId>", "..."],
+    "completed": ["<taskId>"],
+    "remaining": ["<taskId>"],
+    "percentComplete": 33
+  },
+  "canAdvance": false
+}
+```
+Use `phase` for the phase label. (`committed` → "Committed"; others → "Freshman/Sophomore/Junior/Senior Year".)
+
+### 2. `GET /api/athlete/status` (exists) — the real score
+```jsonc
+{
+  "score": 20,                       // the X in X/100
+  "label": "at_risk",                // on_track|slightly_behind|at_risk
+  "color": "red",                    // green|yellow|red
+  "breakdown": {
+    "taskCompletionRate": 40,
+    "interactionFrequencyScore": 10,
+    "coachInterestScore": 0,
+    "academicStandingScore": 50
+  }
+}
+```
+Use `score` for `X/100`. Use server `label`/`color` for the status dot — **do not** re-threshold on iOS
+(kills the 75/50-vs-70/50 mismatch).
+
+### 3. `GET /api/athlete/what-matters-now` (**new — this change**) — the current task
+Returns up to 5 prioritized items, highest priority first. **Take `[0]` for the timeline card.**
+```jsonc
+[
+  {
+    "taskId": "9c9c6c80-...",
+    "title": "Maintain Strong Grades (College-Ready)",
+    "whyItMatters": "Colleges rescind offers for grade drops.",
+    "category": "academic",
+    "priority": 5,
+    "isRequired": true
+  }
+]
+```
+Empty array → no current task (render the card's empty/nil state). `title` → task title,
+`whyItMatters` → subtitle.
+
+## iOS changes (from code investigation)
+
+Replace local computation with API reads in `TimelineViewModel` and retire the mirror services:
+
+| File | Action |
+|---|---|
+| `Features/Timeline/ViewModels/TimelineViewModel.swift` | In `load()`, fetch the 3 endpoints. Set `statusScore`/`label`/`color` from `/status`; `currentPhase`/`milestoneProgress` from `/phase`; `nextRecommendedTask` from `/what-matters-now[0]`. Remove calls to the local phase/status/what-matters services. |
+| `Features/Timeline/Services/TimelineStatusService.swift` | Delete or gut — replaced by `/api/athlete/status`. Its stubbed 3/4-factor formula is the 20-vs-0 bug. |
+| `Features/Timeline/Utilities/WhatMattersNow.swift` | Delete or gut — replaced by `/api/athlete/what-matters-now`. |
+| `Features/Timeline/Services/TimelinePhaseService.swift` | Delete or gut — replaced by `/api/athlete/phase` (already returns `milestoneProgress`). |
+| `Features/Dashboard/Components/DashboardTimelineSummaryCard.swift` | Bind score-dot color to server `color`; drop the local 70/50 threshold. Bind task title/why from `/what-matters-now[0]`. |
+
+Decodable structs to add (match JSON above): `AthletePhaseResponse`, `AthleteStatusResponse`
+(with `breakdown`), `WhatMattersItem`.
+
+## Parity verification (web, done 2026-08-11)
+
+Verified live against demo family (player1 / parent1 @compassdemo.app), same family unit:
+
+- `/api/athlete/what-matters-now` top item **identical** for parent and player (same `taskId`) — parent→player resolution works.
+- Endpoint result **matches** the rendered web `DashboardTimelineCard` ("Maintain Strong Grades", Senior Year, 54/100).
+- Unauthenticated → 401.
+
+## iOS build-time checks
+
+1. Confirm iOS auth layer attaches the Supabase bearer token to these GETs (same as other authed calls).
+2. After wiring, log in as a parent and the linked player on iOS — both dashboards must show identical
+   phase / score / current-task, and match the web dashboard for that athlete.
+3. Handle empty `what-matters-now` array and non-200 responses gracefully (nil card, no crash).
+
+## Notes
+
+- Selection/score logic is **not** duplicated by the new endpoint — it reuses the same pure
+  `getWhatMattersNow` util the web card uses. Moving iOS onto the endpoint removes the last
+  independent implementation.
+- `category` values in live data are the plain forms (`"academic"`, `"communication"`, …); the
+  priority map keys some as hyphenated (`"academic-standing"`) and falls back to 5 otherwise. This is
+  a pre-existing web quirk, out of scope here — iOS just renders what the endpoint returns.

--- a/planning/lessons.md
+++ b/planning/lessons.md
@@ -16,6 +16,17 @@ Tracks mistake patterns (with recurrence counts) and process insights.
 
 ## Bug & Mistake Patterns
 
+### Searching for Existing Tests Must Cover Both .spec.ts AND .test.ts
+
+**Times seen:** 1 | **Last seen:** 2026-08-11
+**Context:** Hardening the three `deletion-blockers` endpoints, I wrote three "new" spec files with `Write` — silently overwriting existing suites (`schools` 16 tests, `coaches` 8, `interactions` 5). My discovery grep used `find ... -name '*.test.ts'`, which does not match `.spec.ts`; a subagent also reported "no existing tests." First commit was net **−651 lines** (destroyed coverage). Caught it only in the `git show --stat` diff, recovered old versions from `HEAD~1`, merged old + new, amended.
+**Root Cause:** This repo uses `.spec.ts` for unit tests, not `.test.ts`. A single-extension search returns zero hits and reads as "no tests exist." `Write` on an existing file replaces it wholesale with no merge.
+**Prevention:**
+- Search for existing tests with BOTH extensions: `find ... \( -name '*.spec.ts' -o -name '*.test.ts' \)` or `grep -rl <symbol> tests/`.
+- A "fix" commit whose `git show --stat` shows large **deletions** in files you meant to *add* to is a red flag — inspect before trusting the commit.
+- Before `Write` on a path that may exist, `ls`/Read it first; prefer `Edit` (append) over `Write` (replace) when augmenting a file.
+- Don't trust a subagent's "no existing X" when its search method is unverified — confirm the glob it used.
+
 ### Pre-Push Gate Runs Lint + Type-Check but NOT Tests — Run npm test Yourself
 
 **Times seen:** 1 | **Last seen:** 2026-08-08

--- a/planning/lessons.md
+++ b/planning/lessons.md
@@ -258,3 +258,17 @@ Source: https://blog.sentry.io/structure-a-log/
 - **`domain.action` event names vs free text**: Sentry's convention is stable low-cardinality names like `payment.capture` with dynamic values pushed into attributes. Our messages are English sentences ("Feedback submitted", "Failed to cascade delete interaction") — fine for human reading, worse for aggregation/alerting by event type since the same logical event has slightly different phrasing per callsite.
 - **What we already do right**: `sanitizeLogData`/`sanitizeData` (`server/utils/logger.ts:167`, `utils/logger.ts:19`) already flatten+redact by `SENSITIVE_FIELDS`, matching the article's "no raw request/response bodies, PII, or nested payment data" rule. `eslint.config.js:182` bans raw `console.*` outside the logger files, matching their "lint to enforce" recommendation — we already have the enforcement layer they suggest.
 - **No snake_case/dot-notation key convention enforced**: article wants `payment.failure.reason_code` style scoped snake_case keys; our data objects use plain camelCase (`{ feedbackType, userId }`) with no scoping convention. Low priority — matters more once we're querying logs in an aggregator, not just grepping.
+
+---
+
+## How to Design URLs: Routing, Query Parameters, and Fragments — 2026-08-10
+Source: https://www.jstools.space/blog/url-design-routing-query-parameters-fragments/
+
+- **Path = identity, query = optional state**: Never encode transient UI state (sort, view mode, open panel) in the Nuxt path. Example: prefer `/schools?sort=fit&view=grid` over `/schools/sort/fit/view/grid` — path stays a stable, linkable resource.
+- **Hybrid slug+ID route params**: For renameable resources use `/[id]-[slug]` and extract the canonical ID with a regex, redirecting stale slugs. Example: `const m = /^(\d+)(?:-|$)/.exec(route.params.segment)` — title can change without breaking the link.
+- **SPA fallback must not 200 real 404s**: Nuxt/Nitro catch-all shell fallback should exclude asset files, `/api/**`, and genuinely-missing resources — otherwise broken URLs return `200 OK` instead of a useful 404 (hurts crawlers + monitoring).
+- **Parse query values, never trust them**: Every query value is a string and is user input even when our own UI generated it — validate/convert at the boundary (Zod or a `readPositiveInteger` helper with `Number.isSafeInteger(v) && v > 0`), and clamp caps like `Math.min(limit, 100)`.
+- **Presence vs empty: use `!== null`, not truthiness**: `URLSearchParams.get()` returns `""` for `?sort=` and `null` for a missing key; both `?preview` and `?preview=` yield `""`. Gate on `params.get('sort') !== null` so an explicitly-empty value isn't silently dropped.
+- **Repeated keys for array params**: Prefer `?tag=a&tag=b` (native `params.getAll('tag')`) over comma-joined values — avoids ambiguity when a value itself contains a comma; document the chosen format so client and Nitro parse it identically.
+- **Use the `URL`/`URLSearchParams` API, never string-split**: Splitting on `/`, `?`, `&` breaks on encoded values, credentials, IPv6 hosts, and nested URLs — construct with `new URL(...)` and read `.pathname`/`.searchParams`.
+- **Fragments never reach the server, and aren't secret**: `#...` is stripped from the HTTP request, so it's useless for SSR-required state; and despite not being sent, it still leaks via history, copied links, extensions, and screenshots — never put tokens there.

--- a/planning/lessons.md
+++ b/planning/lessons.md
@@ -16,6 +16,16 @@ Tracks mistake patterns (with recurrence counts) and process insights.
 
 ## Bug & Mistake Patterns
 
+### Forked web-to-ios-handoff Latches Onto Stale planning/iOS_SPEC_* Instead of the Current Task
+
+**Times seen:** 1 | **Last seen:** 2026-08-11
+**Context:** Fixing the web/iOS dashboard-timeline desync, I dispatched the `web-to-ios-handoff` skill (forked, general-purpose) to write an iOS spec for consuming the new shared endpoints. It instead found an unrelated existing spec (`iOS_SPEC_player-details-tab-reorg`) and produced a parity *grade* of that, never writing the timeline spec I needed. Wasted a 92s fork; I wrote the correct spec myself.
+**Root Cause:** The skill's discovery step + `CLAUDE.md`'s "ls planning/iOS_SPEC_* before generating" nudge biases it toward the newest existing spec. With no explicit feature name pinned, it treated the most recent `iOS_SPEC_*` as the subject.
+**Prevention:**
+- When dispatching the handoff skill, name the feature and the target spec filename explicitly in the prompt ("write NEW spec at planning/iOS_SPEC_<slug>-<date>.md for <feature>; do not grade existing specs").
+- For a spec I can write from context already in-session, writing it directly is faster than forking.
+- Verify a forked skill's output is about the task I gave it before trusting it — a "READY TO BUILD" verdict on the wrong feature is worse than an error.
+
 ### Searching for Existing Tests Must Cover Both .spec.ts AND .test.ts
 
 **Times seen:** 1 | **Last seen:** 2026-08-11

--- a/server/api/athlete/what-matters-now.get.ts
+++ b/server/api/athlete/what-matters-now.get.ts
@@ -1,0 +1,139 @@
+/**
+ * GET /api/athlete/what-matters-now
+ * Returns the athlete's prioritized "what matters now" tasks for the current
+ * phase — the single source of truth for the dashboard timeline's current-task.
+ *
+ * Shared by web (DashboardTimelineCard.vue) and iOS so both render the SAME
+ * top-priority task instead of re-deriving it independently. Selection logic
+ * lives in the pure `getWhatMattersNow` util; this endpoint only resolves the
+ * athlete, derives the phase, and feeds it that athlete's tasks-with-status.
+ */
+
+import { defineEventHandler } from "h3";
+import { createServerSupabaseClient } from "~/server/utils/supabase";
+import { requireAuth } from "~/server/utils/auth";
+import { resolveViewerAthleteId } from "~/server/utils/athleteAccess";
+import { computePhaseFromGraduationYear } from "~/server/utils/athletePhase";
+import { useLogger } from "~/server/utils/logger";
+import { getWhatMattersNow, type WhatMattersItem } from "~/utils/whatMattersNow";
+import type { Phase, TaskWithStatus } from "~/types/timeline";
+
+// Grade level for each phase — mirrors the mapping inside getWhatMattersNow so
+// we fetch only the relevant grade's tasks (avoids the /api/tasks 100-row cap).
+const PHASE_GRADES: Record<Phase, number> = {
+  freshman: 9,
+  sophomore: 10,
+  junior: 11,
+  senior: 12,
+  committed: 12,
+};
+
+export default defineEventHandler(async (event): Promise<WhatMattersItem[]> => {
+  const logger = useLogger(event, "athlete/what-matters-now");
+  const user = await requireAuth(event);
+  const supabase = createServerSupabaseClient();
+
+  try {
+    const athleteId = await resolveViewerAthleteId(supabase, user.id);
+
+    // Derive phase: users.current_phase (source of truth once advanced) else
+    // grade-derived from graduation_year — identical to GET /api/athlete/phase.
+    const { data: userData, error: userError } = await supabase
+      .from("users")
+      .select("current_phase")
+      .eq("id", athleteId)
+      .maybeSingle();
+
+    if (userError) {
+      logger.error("Error fetching user phase", userError);
+      throw createError({
+        statusCode: 500,
+        statusMessage: "Failed to fetch user phase",
+      });
+    }
+
+    let phase = (userData?.current_phase ?? null) as Phase | null;
+
+    if (!phase) {
+      const { data: prefData, error: prefError } = await supabase
+        .from("user_preferences")
+        .select("data")
+        .eq("user_id", athleteId)
+        .eq("category", "player")
+        .maybeSingle();
+
+      if (prefError) {
+        logger.error("Error fetching player preferences", prefError);
+        throw createError({
+          statusCode: 500,
+          statusMessage: "Failed to fetch player preferences",
+        });
+      }
+
+      const playerData = prefData?.data as Record<string, unknown> | null;
+      const graduationYear =
+        typeof playerData?.graduation_year === "number"
+          ? playerData.graduation_year
+          : null;
+      phase = computePhaseFromGraduationYear(graduationYear);
+    }
+
+    const currentGrade = PHASE_GRADES[phase];
+
+    // Fetch the current grade's task catalog and the athlete's completion state,
+    // then merge into the shape getWhatMattersNow expects.
+    const [tasksResult, athleteTasksResult] = await Promise.all([
+      supabase
+        .from("task")
+        .select(
+          "id, category, grade_level, title, required, dependency_task_ids, why_it_matters",
+        )
+        .eq("grade_level", currentGrade),
+      supabase
+        .from("athlete_task")
+        .select("task_id, status")
+        .eq("athlete_id", athleteId),
+    ]);
+
+    if (tasksResult.error) {
+      logger.error("Error fetching tasks", tasksResult.error);
+      throw createError({
+        statusCode: 500,
+        statusMessage: "Failed to fetch tasks",
+      });
+    }
+    if (athleteTasksResult.error) {
+      logger.error("Error fetching athlete tasks", athleteTasksResult.error);
+      throw createError({
+        statusCode: 500,
+        statusMessage: "Failed to fetch athlete tasks",
+      });
+    }
+
+    const statusByTaskId = new Map(
+      (athleteTasksResult.data ?? []).map((at) => [at.task_id, at.status]),
+    );
+
+    const tasksWithStatus = (tasksResult.data ?? []).map((task) => {
+      const status = statusByTaskId.get(task.id);
+      return {
+        ...task,
+        athlete_task: status ? { status } : undefined,
+      } as unknown as TaskWithStatus;
+    });
+
+    return getWhatMattersNow({ phase, tasksWithStatus });
+  } catch (err) {
+    if (err instanceof Error && err.message === "Unauthorized") {
+      throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+    }
+    if (err instanceof Error && "statusCode" in err) {
+      throw err;
+    }
+    logger.error("Error in GET /api/athlete/what-matters-now", err);
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Failed to fetch what matters now",
+    });
+  }
+});

--- a/server/api/coaches/[id]/deletion-blockers.get.ts
+++ b/server/api/coaches/[id]/deletion-blockers.get.ts
@@ -37,6 +37,28 @@ export default defineEventHandler(async (event) => {
   const client = createServerSupabaseUserClient(token);
   const logger = useLogger(event, "coaches/deletion-blockers");
 
+  // Verify the coach exists and is visible to this user (RLS-scoped) before
+  // counting child rows. A null row means missing or not owned — return 404
+  // rather than leaking a canDelete verdict for a resource the caller can't see.
+  const { data: coach, error: existenceError } = await client
+    .from("coaches")
+    .select("id")
+    .eq("id", coachId)
+    .maybeSingle();
+  if (existenceError) {
+    logger.error("Failed to verify coach existence", existenceError);
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Failed to check deletion blockers",
+    });
+  }
+  if (!coach) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Coach not found",
+    });
+  }
+
   const blockers: BlockerInfo[] = [];
 
   // Check interactions

--- a/server/api/interactions/[id]/deletion-blockers.get.ts
+++ b/server/api/interactions/[id]/deletion-blockers.get.ts
@@ -1,5 +1,7 @@
-import { defineEventHandler, getRouterParam, createError } from "h3";
+import { defineEventHandler, getHeader, getCookie, createError } from "h3";
+import { createServerSupabaseUserClient } from "~/server/utils/supabase";
 import { requireAuth } from "~/server/utils/auth";
+import { requireUuidParam } from "~/server/utils/validation";
 import { useLogger } from "~/server/utils/logger";
 
 interface BlockerInfo {
@@ -19,18 +21,45 @@ interface BlockerInfo {
  */
 export default defineEventHandler(async (event) => {
   const logger = useLogger(event, "interactions/deletion-blockers");
-  const interactionId = getRouterParam(event, "id");
   logger.info("Checking deletion blockers");
-
-  if (!interactionId) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: "Interaction ID is required",
-    });
-  }
 
   // Require auth before revealing schema info
   await requireAuth(event);
+  const interactionId = requireUuidParam(event, "id");
+
+  const authHeader = getHeader(event, "authorization");
+  const token: string | null = authHeader?.startsWith("Bearer ")
+    ? authHeader.slice(7)
+    : getCookie(event, "sb-access-token") || null;
+  if (!token) {
+    throw createError({
+      statusCode: 401,
+      statusMessage: "Unauthorized - no authentication token",
+    });
+  }
+  const client = createServerSupabaseUserClient(token);
+
+  // Verify the interaction exists and is visible to this user (RLS-scoped).
+  // A null row means it is missing or not owned — return 404 rather than a
+  // misleading canDelete:true for a resource the caller cannot see.
+  const { data: interaction, error: existenceError } = await client
+    .from("interactions")
+    .select("id")
+    .eq("id", interactionId)
+    .maybeSingle();
+  if (existenceError) {
+    logger.error("Failed to verify interaction existence", existenceError);
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Failed to check deletion blockers",
+    });
+  }
+  if (!interaction) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "Interaction not found",
+    });
+  }
 
   const blockers: BlockerInfo[] = [];
 

--- a/server/api/schools/[id]/deletion-blockers.get.ts
+++ b/server/api/schools/[id]/deletion-blockers.get.ts
@@ -1,12 +1,7 @@
-import {
-  defineEventHandler,
-  getRouterParam,
-  createError,
-  getHeader,
-  getCookie,
-} from "h3";
+import { defineEventHandler, createError, getHeader, getCookie } from "h3";
 import { createServerSupabaseUserClient } from "~/server/utils/supabase";
 import { requireAuth } from "~/server/utils/auth";
+import { requireUuidParam } from "~/server/utils/validation";
 import { useLogger } from "~/server/utils/logger";
 
 interface BlockerInfo {
@@ -25,17 +20,10 @@ interface BlockerInfo {
  * - message: User-friendly message explaining what's blocking deletion
  */
 export default defineEventHandler(async (event) => {
-  const schoolId = getRouterParam(event, "id");
-
-  if (!schoolId) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: "School ID is required",
-    });
-  }
-
   const logger = useLogger(event, "schools/deletion-blockers");
   await requireAuth(event);
+  const schoolId = requireUuidParam(event, "id");
+
   const authHeader = getHeader(event, "authorization");
   const token: string | null = authHeader?.startsWith("Bearer ")
     ? authHeader.slice(7)
@@ -47,6 +35,28 @@ export default defineEventHandler(async (event) => {
     });
   }
   const client = createServerSupabaseUserClient(token);
+
+  // Verify the school exists and is visible to this user (RLS-scoped) before
+  // counting child rows. A null row means missing or not owned — return 404
+  // rather than leaking a canDelete verdict for a resource the caller can't see.
+  const { data: school, error: existenceError } = await client
+    .from("schools")
+    .select("id")
+    .eq("id", schoolId)
+    .maybeSingle();
+  if (existenceError) {
+    logger.error("Failed to verify school existence", existenceError);
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Failed to check deletion blockers",
+    });
+  }
+  if (!school) {
+    throw createError({
+      statusCode: 404,
+      statusMessage: "School not found",
+    });
+  }
 
   const blockers: BlockerInfo[] = [];
 

--- a/server/utils/athleteAccess.ts
+++ b/server/utils/athleteAccess.ts
@@ -1,6 +1,9 @@
 import type { H3Event } from "h3";
 import { createError } from "h3";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "~/types/database";
 import { useSupabaseAdmin } from "~/server/utils/supabase";
+import { getUserRole } from "~/server/utils/auth";
 import { useLogger } from "~/server/utils/logger";
 
 /**
@@ -60,4 +63,43 @@ export async function resolveTargetAthleteId(
   }
 
   return requestedAthleteId;
+}
+
+/**
+ * Resolve which athlete a viewer's dashboard should render.
+ *
+ * A player views their own data. A parent (no explicit athleteId param) is
+ * auto-resolved to the linked player in their family unit, so parent and player
+ * see the SAME derived timeline. Falls back to the caller when the viewer is not
+ * a parent or has no linked player. This is the auto-resolution counterpart to
+ * `resolveTargetAthleteId`, which authorizes an explicitly requested athleteId.
+ */
+export async function resolveViewerAthleteId(
+  supabase: SupabaseClient<Database>,
+  userId: string,
+): Promise<string> {
+  const role = await getUserRole(userId, supabase);
+  if (role !== "parent") {
+    return userId;
+  }
+
+  const { data: familyMembership } = await supabase
+    .from("family_members")
+    .select("family_unit_id")
+    .eq("user_id", userId)
+    .eq("role", "parent")
+    .maybeSingle();
+
+  if (!familyMembership) {
+    return userId;
+  }
+
+  const { data: playerMember } = await supabase
+    .from("family_members")
+    .select("user_id")
+    .eq("family_unit_id", familyMembership.family_unit_id)
+    .eq("role", "player")
+    .maybeSingle();
+
+  return playerMember?.user_id ?? userId;
 }

--- a/tests/unit/server/api/coaches/deletion-blockers.get.spec.ts
+++ b/tests/unit/server/api/coaches/deletion-blockers.get.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mutable state — read at call time by mock factories
 const mockState = {
+  parentExists: true,
+  parentError: null as object | null,
   interactionCount: 0,
   interactionError: null as object | null,
   offerCount: 0,
@@ -11,15 +13,14 @@ const mockState = {
   authToken: "Bearer valid-token",
 };
 
+const COACH_ID = "22222222-2222-2222-2222-222222222222";
+
 vi.mock("~/server/utils/auth", () => ({
-  requireAuth: vi.fn(async () => ({
-    id: "user-id",
-    email: "user@example.com",
-  })),
+  requireAuth: vi.fn(async () => ({ id: "user-id", email: "user@example.com" })),
 }));
 
 vi.mock("~/server/utils/validation", () => ({
-  requireUuidParam: vi.fn(() => "test-coach-id"),
+  requireUuidParam: vi.fn(() => COACH_ID),
 }));
 
 vi.mock("~/server/utils/logger", () => ({
@@ -31,6 +32,21 @@ vi.mock("~/server/utils/logger", () => ({
   }),
 }));
 
+// Existence probe: from("coaches").select("id").eq("id", id).maybeSingle()
+function buildExistenceChain() {
+  return {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        maybeSingle: vi.fn().mockResolvedValue({
+          data: mockState.parentExists ? { id: COACH_ID } : null,
+          error: mockState.parentError,
+        }),
+      }),
+    }),
+  };
+}
+
+// Count query: from(child).select("*", {count,head}).eq(col, id)  (awaited)
 function buildSelectChain(
   getCount: () => number | null,
   getError: () => object | null,
@@ -49,24 +65,22 @@ function buildSelectChain(
 vi.mock("~/server/utils/supabase", () => ({
   createServerSupabaseUserClient: vi.fn(() => ({
     from: (table: string) => {
-      if (table === "interactions") {
+      if (table === "coaches") return buildExistenceChain();
+      if (table === "interactions")
         return buildSelectChain(
           () => mockState.interactionCount,
           () => mockState.interactionError,
         );
-      }
-      if (table === "offers") {
+      if (table === "offers")
         return buildSelectChain(
           () => mockState.offerCount,
           () => mockState.offerError,
         );
-      }
-      if (table === "social_media_posts") {
+      if (table === "social_media_posts")
         return buildSelectChain(
           () => mockState.postCount,
           () => mockState.postError,
         );
-      }
       return buildSelectChain(
         () => 0,
         () => null,
@@ -96,10 +110,19 @@ import { requireAuth } from "~/server/utils/auth";
 import { requireUuidParam } from "~/server/utils/validation";
 import { createServerSupabaseUserClient } from "~/server/utils/supabase";
 
-const mockEvent = { context: { params: { id: "test-coach-id" } } } as any;
+const mockEvent = { context: { params: { id: COACH_ID } } } as any;
+
+const getHandler = async () => {
+  const { default: handler } = await import(
+    "~/server/api/coaches/[id]/deletion-blockers.get"
+  );
+  return handler;
+};
 
 describe("GET /api/coaches/[id]/deletion-blockers", () => {
   beforeEach(async () => {
+    mockState.parentExists = true;
+    mockState.parentError = null;
     mockState.interactionCount = 0;
     mockState.interactionError = null;
     mockState.offerCount = 0;
@@ -112,18 +135,35 @@ describe("GET /api/coaches/[id]/deletion-blockers", () => {
       id: "user-id",
       email: "user@example.com",
     });
-    vi.mocked(requireUuidParam).mockReturnValue("test-coach-id");
+    vi.mocked(requireUuidParam).mockReturnValue(COACH_ID);
 
     const h3 = await import("h3");
     vi.mocked(h3.getHeader).mockReturnValue("Bearer valid-token");
     vi.mocked(h3.getCookie).mockReturnValue(undefined);
   });
 
-  const getHandler = async () => {
-    const { default: handler } =
-      await import("~/server/api/coaches/[id]/deletion-blockers.get");
-    return handler;
-  };
+  // ── Parent existence / ownership (regression: was 200 for any id) ──────────
+
+  describe("nonexistent or non-owned coach", () => {
+    it("throws 404 when the coach row is not visible to the caller", async () => {
+      mockState.parentExists = false;
+      const handler = await getHandler();
+
+      await expect(handler(mockEvent)).rejects.toMatchObject({
+        statusCode: 404,
+        message: "Coach not found",
+      });
+    });
+
+    it("throws 500 when the existence probe errors", async () => {
+      mockState.parentError = { message: "db down" };
+      const handler = await getHandler();
+
+      await expect(handler(mockEvent)).rejects.toMatchObject({
+        statusCode: 500,
+      });
+    });
+  });
 
   describe("no blockers", () => {
     it("returns canDelete:true and empty blockers when all counts are 0", async () => {
@@ -132,7 +172,7 @@ describe("GET /api/coaches/[id]/deletion-blockers", () => {
 
       expect(result.canDelete).toBe(true);
       expect(result.blockers).toEqual([]);
-      expect(result.coachId).toBe("test-coach-id");
+      expect(result.coachId).toBe(COACH_ID);
       expect(result.message).toBe("Coach can be deleted successfully.");
     });
   });
@@ -236,12 +276,11 @@ describe("GET /api/coaches/[id]/deletion-blockers", () => {
   });
 
   describe("DB errors are logged but do not throw", () => {
-    it("does not block deletion when interaction query returns an error (warns and skips)", async () => {
+    it("does not block deletion when interaction count query returns an error (warns and skips)", async () => {
       mockState.interactionError = { message: "DB connection failed" };
       const handler = await getHandler();
       const result = await handler(mockEvent);
 
-      // Error is logged via logger.warn, count stays 0 so no blocker added
       expect(result.canDelete).toBe(true);
       expect(result.blockers).toEqual([]);
     });

--- a/tests/unit/server/api/interactions/deletion-blockers.get.spec.ts
+++ b/tests/unit/server/api/interactions/deletion-blockers.get.spec.ts
@@ -1,7 +1,19 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+const mockState = {
+  parentExists: true,
+  parentError: null as object | null,
+  authToken: "Bearer valid-token",
+};
+
+const INTERACTION_ID = "33333333-3333-3333-3333-333333333333";
+
 vi.mock("~/server/utils/auth", () => ({
-  requireAuth: vi.fn(),
+  requireAuth: vi.fn(async () => ({ id: "user-id", email: "user@example.com" })),
+}));
+
+vi.mock("~/server/utils/validation", () => ({
+  requireUuidParam: vi.fn(() => INTERACTION_ID),
 }));
 
 vi.mock("~/server/utils/logger", () => ({
@@ -13,12 +25,22 @@ vi.mock("~/server/utils/logger", () => ({
   }),
 }));
 
+const mockMaybeSingle = vi.fn();
+const mockEq = vi.fn(() => ({ maybeSingle: mockMaybeSingle }));
+const mockSelect = vi.fn(() => ({ eq: mockEq }));
+const mockFrom = vi.fn(() => ({ select: mockSelect }));
+
+vi.mock("~/server/utils/supabase", () => ({
+  createServerSupabaseUserClient: vi.fn(() => ({ from: mockFrom })),
+}));
+
 vi.mock("h3", async (importOriginal) => {
   const actual = await importOriginal<typeof import("h3")>();
   return {
     ...actual,
     defineEventHandler: (fn: Function) => fn,
-    getRouterParam: vi.fn().mockReturnValue("test-interaction-id"),
+    getHeader: vi.fn(() => mockState.authToken),
+    getCookie: vi.fn(() => undefined),
     createError: (config: { statusCode: number; statusMessage: string }) => {
       const err = new Error(config.statusMessage) as Error & {
         statusCode: number;
@@ -30,83 +52,106 @@ vi.mock("h3", async (importOriginal) => {
 });
 
 import { requireAuth } from "~/server/utils/auth";
+import { requireUuidParam } from "~/server/utils/validation";
+import { createServerSupabaseUserClient } from "~/server/utils/supabase";
 
-const mockEvent = { context: { params: { id: "test-interaction-id" } } } as any;
+const mockEvent = { context: { params: { id: INTERACTION_ID } } } as any;
+
+const getHandler = async () => {
+  const { default: handler } = await import(
+    "~/server/api/interactions/[id]/deletion-blockers.get"
+  );
+  return handler;
+};
 
 describe("GET /api/interactions/[id]/deletion-blockers", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    mockState.parentExists = true;
+    mockState.parentError = null;
+    mockState.authToken = "Bearer valid-token";
     vi.clearAllMocks();
-    vi.resetModules();
+
+    vi.mocked(requireAuth).mockResolvedValue({
+      id: "user-id",
+      email: "user@example.com",
+    });
+    vi.mocked(requireUuidParam).mockReturnValue(INTERACTION_ID);
+    mockMaybeSingle.mockImplementation(async () => ({
+      data: mockState.parentExists ? { id: INTERACTION_ID } : null,
+      error: mockState.parentError,
+    }));
+
+    const h3 = await import("h3");
+    vi.mocked(h3.getHeader).mockReturnValue("Bearer valid-token");
+    vi.mocked(h3.getCookie).mockReturnValue(undefined);
+  });
+
+  // ── Parent existence / ownership (regression: was 200 for any id) ──────────
+
+  describe("nonexistent or non-owned interaction", () => {
+    it("throws 404 when the interaction row is not visible to the caller", async () => {
+      mockState.parentExists = false;
+      const handler = await getHandler();
+
+      await expect(handler(mockEvent)).rejects.toMatchObject({
+        statusCode: 404,
+        message: "Interaction not found",
+      });
+    });
+
+    it("throws 500 when the existence probe errors", async () => {
+      mockState.parentError = { message: "db down" };
+      const handler = await getHandler();
+
+      await expect(handler(mockEvent)).rejects.toMatchObject({
+        statusCode: 500,
+      });
+    });
+
+    it("verifies existence against the interactions table by id", async () => {
+      const handler = await getHandler();
+      await handler(mockEvent);
+
+      expect(mockFrom).toHaveBeenCalledWith("interactions");
+      expect(mockSelect).toHaveBeenCalledWith("id");
+      expect(mockEq).toHaveBeenCalledWith("id", INTERACTION_ID);
+    });
   });
 
   describe("happy path — no blockers", () => {
-    it("returns canDelete:true and empty blockers array when no FK references exist", async () => {
-      vi.mocked(requireAuth).mockResolvedValue({
-        id: "user-id",
-        email: "user@example.com",
-      });
-
-      const { getRouterParam } = await import("h3");
-      vi.mocked(getRouterParam).mockReturnValue("test-interaction-id");
-
-      const { default: handler } =
-        await import("~/server/api/interactions/[id]/deletion-blockers.get");
-
+    it("returns canDelete:true and empty blockers when the interaction exists", async () => {
+      const handler = await getHandler();
       const result = await handler(mockEvent);
 
       expect(result.canDelete).toBe(true);
       expect(result.blockers).toEqual([]);
-      expect(result.interactionId).toBe("test-interaction-id");
+      expect(result.interactionId).toBe(INTERACTION_ID);
       expect(result.message).toBe("Interaction can be deleted successfully.");
-    });
-  });
-
-  describe("missing ID", () => {
-    it("throws 400 when interaction ID is missing from router params", async () => {
-      const { getRouterParam } = await import("h3");
-      vi.mocked(getRouterParam).mockReturnValue(undefined);
-
-      const { default: handler } =
-        await import("~/server/api/interactions/[id]/deletion-blockers.get");
-
-      await expect(handler(mockEvent)).rejects.toMatchObject({
-        statusCode: 400,
-        message: "Interaction ID is required",
-      });
     });
   });
 
   describe("auth failure", () => {
     it("re-throws H3Error from requireAuth without wrapping", async () => {
-      const { getRouterParam } = await import("h3");
-      vi.mocked(getRouterParam).mockReturnValue("test-interaction-id");
-
       const h3Error = Object.assign(new Error("Unauthorized"), {
         statusCode: 401,
       });
       vi.mocked(requireAuth).mockRejectedValue(h3Error);
 
-      const { default: handler } =
-        await import("~/server/api/interactions/[id]/deletion-blockers.get");
-
+      const handler = await getHandler();
       await expect(handler(mockEvent)).rejects.toMatchObject({
         statusCode: 401,
         message: "Unauthorized",
       });
+      expect(createServerSupabaseUserClient).not.toHaveBeenCalled();
     });
 
     it("re-throws 403 Forbidden from requireAuth", async () => {
-      const { getRouterParam } = await import("h3");
-      vi.mocked(getRouterParam).mockReturnValue("test-interaction-id");
-
       const h3Error = Object.assign(new Error("Forbidden"), {
         statusCode: 403,
       });
       vi.mocked(requireAuth).mockRejectedValue(h3Error);
 
-      const { default: handler } =
-        await import("~/server/api/interactions/[id]/deletion-blockers.get");
-
+      const handler = await getHandler();
       await expect(handler(mockEvent)).rejects.toMatchObject({
         statusCode: 403,
         message: "Forbidden",
@@ -114,21 +159,23 @@ describe("GET /api/interactions/[id]/deletion-blockers", () => {
     });
   });
 
+  describe("missing token", () => {
+    it("throws 401 when no authorization token is present", async () => {
+      mockState.authToken = "";
+      const { getHeader } = await import("h3");
+      vi.mocked(getHeader).mockReturnValue("");
+
+      const handler = await getHandler();
+      await expect(handler(mockEvent)).rejects.toMatchObject({
+        statusCode: 401,
+      });
+    });
+  });
+
   describe("response shape", () => {
     it("always returns interactionId, canDelete, blockers, and message fields", async () => {
-      vi.mocked(requireAuth).mockResolvedValue({
-        id: "user-id",
-        email: "user@example.com",
-      });
-
-      const { getRouterParam } = await import("h3");
-      vi.mocked(getRouterParam).mockReturnValue("abc-123");
-
-      const { default: handler } =
-        await import("~/server/api/interactions/[id]/deletion-blockers.get");
-
-      const mockEventWithId = { context: { params: { id: "abc-123" } } } as any;
-      const result = await handler(mockEventWithId);
+      const handler = await getHandler();
+      const result = await handler(mockEvent);
 
       expect(result).toHaveProperty("interactionId");
       expect(result).toHaveProperty("canDelete");

--- a/tests/unit/server/api/schools/deletion-blockers.get.spec.ts
+++ b/tests/unit/server/api/schools/deletion-blockers.get.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Mutable state — read at call time by mock factories
 const mockState = {
+  parentExists: true,
+  parentError: null as object | null,
   coachCount: 0,
   coachError: null as object | null,
   interactionCount: 0,
@@ -19,14 +21,16 @@ const mockState = {
   suggestionCount: 0,
   suggestionError: null as object | null,
   authToken: "Bearer valid-token",
-  schoolId: "test-school-id",
 };
 
+const SCHOOL_ID = "11111111-1111-1111-1111-111111111111";
+
 vi.mock("~/server/utils/auth", () => ({
-  requireAuth: vi.fn(async () => ({
-    id: "user-id",
-    email: "user@example.com",
-  })),
+  requireAuth: vi.fn(async () => ({ id: "user-id", email: "user@example.com" })),
+}));
+
+vi.mock("~/server/utils/validation", () => ({
+  requireUuidParam: vi.fn(() => SCHOOL_ID),
 }));
 
 vi.mock("~/server/utils/logger", () => ({
@@ -38,6 +42,21 @@ vi.mock("~/server/utils/logger", () => ({
   }),
 }));
 
+// Existence probe: from(parent).select("id").eq("id", id).maybeSingle()
+function buildExistenceChain() {
+  return {
+    select: vi.fn().mockReturnValue({
+      eq: vi.fn().mockReturnValue({
+        maybeSingle: vi.fn().mockResolvedValue({
+          data: mockState.parentExists ? { id: SCHOOL_ID } : null,
+          error: mockState.parentError,
+        }),
+      }),
+    }),
+  };
+}
+
+// Count query: from(child).select("*", {count,head}).eq(col, id)  (awaited)
 function buildSelectChain(
   getCount: () => number | null,
   getError: () => object | null,
@@ -56,54 +75,47 @@ function buildSelectChain(
 vi.mock("~/server/utils/supabase", () => ({
   createServerSupabaseUserClient: vi.fn(() => ({
     from: (table: string) => {
-      if (table === "coaches") {
+      if (table === "schools") return buildExistenceChain();
+      if (table === "coaches")
         return buildSelectChain(
           () => mockState.coachCount,
           () => mockState.coachError,
         );
-      }
-      if (table === "interactions") {
+      if (table === "interactions")
         return buildSelectChain(
           () => mockState.interactionCount,
           () => mockState.interactionError,
         );
-      }
-      if (table === "offers") {
+      if (table === "offers")
         return buildSelectChain(
           () => mockState.offerCount,
           () => mockState.offerError,
         );
-      }
-      if (table === "school_status_history") {
+      if (table === "school_status_history")
         return buildSelectChain(
           () => mockState.historyCount,
           () => mockState.historyError,
         );
-      }
-      if (table === "social_media_posts") {
+      if (table === "social_media_posts")
         return buildSelectChain(
           () => mockState.postCount,
           () => mockState.postError,
         );
-      }
-      if (table === "documents") {
+      if (table === "documents")
         return buildSelectChain(
           () => mockState.docCount,
           () => mockState.docError,
         );
-      }
-      if (table === "events") {
+      if (table === "events")
         return buildSelectChain(
           () => mockState.eventCount,
           () => mockState.eventError,
         );
-      }
-      if (table === "suggestion") {
+      if (table === "suggestion")
         return buildSelectChain(
           () => mockState.suggestionCount,
           () => mockState.suggestionError,
         );
-      }
       return buildSelectChain(
         () => 0,
         () => null,
@@ -117,7 +129,6 @@ vi.mock("h3", async (importOriginal) => {
   return {
     ...actual,
     defineEventHandler: (fn: Function) => fn,
-    getRouterParam: vi.fn(() => mockState.schoolId),
     getHeader: vi.fn(() => mockState.authToken),
     getCookie: vi.fn(() => undefined),
     createError: (config: { statusCode: number; statusMessage: string }) => {
@@ -131,12 +142,22 @@ vi.mock("h3", async (importOriginal) => {
 });
 
 import { requireAuth } from "~/server/utils/auth";
+import { requireUuidParam } from "~/server/utils/validation";
 import { createServerSupabaseUserClient } from "~/server/utils/supabase";
 
-const mockEvent = { context: { params: { id: "test-school-id" } } } as any;
+const mockEvent = { context: { params: { id: SCHOOL_ID } } } as any;
+
+const getHandler = async () => {
+  const { default: handler } = await import(
+    "~/server/api/schools/[id]/deletion-blockers.get"
+  );
+  return handler;
+};
 
 describe("GET /api/schools/[id]/deletion-blockers", () => {
   beforeEach(async () => {
+    mockState.parentExists = true;
+    mockState.parentError = null;
     mockState.coachCount = 0;
     mockState.coachError = null;
     mockState.interactionCount = 0;
@@ -154,35 +175,54 @@ describe("GET /api/schools/[id]/deletion-blockers", () => {
     mockState.suggestionCount = 0;
     mockState.suggestionError = null;
     mockState.authToken = "Bearer valid-token";
-    mockState.schoolId = "test-school-id";
 
     vi.mocked(requireAuth).mockResolvedValue({
       id: "user-id",
       email: "user@example.com",
     });
+    vi.mocked(requireUuidParam).mockReturnValue(SCHOOL_ID);
 
     const h3 = await import("h3");
-    vi.mocked(h3.getRouterParam).mockReturnValue("test-school-id");
     vi.mocked(h3.getHeader).mockReturnValue("Bearer valid-token");
     vi.mocked(h3.getCookie).mockReturnValue(undefined);
   });
 
-  const getHandler = async () => {
-    const { default: handler } =
-      await import("~/server/api/schools/[id]/deletion-blockers.get");
-    return handler;
-  };
+  // ── Parent existence / ownership (regression: was 200 for any id) ──────────
 
-  describe("missing school ID", () => {
-    it("throws 400 when school ID is missing", async () => {
-      mockState.schoolId = "";
-      const { getRouterParam } = await import("h3");
-      vi.mocked(getRouterParam).mockReturnValue(undefined);
-
+  describe("nonexistent or non-owned school", () => {
+    it("throws 404 when the school row is not visible to the caller", async () => {
+      mockState.parentExists = false;
       const handler = await getHandler();
+
+      await expect(handler(mockEvent)).rejects.toMatchObject({
+        statusCode: 404,
+        message: "School not found",
+      });
+    });
+
+    it("throws 500 when the existence probe errors", async () => {
+      mockState.parentError = { message: "db down" };
+      const handler = await getHandler();
+
+      await expect(handler(mockEvent)).rejects.toMatchObject({
+        statusCode: 500,
+      });
+    });
+  });
+
+  describe("invalid id", () => {
+    it("propagates the 400 thrown by requireUuidParam", async () => {
+      vi.mocked(requireUuidParam).mockImplementation(() => {
+        const err = new Error("Invalid id: must be a valid UUID") as Error & {
+          statusCode: number;
+        };
+        err.statusCode = 400;
+        throw err;
+      });
+      const handler = await getHandler();
+
       await expect(handler(mockEvent)).rejects.toMatchObject({
         statusCode: 400,
-        message: "School ID is required",
       });
     });
   });
@@ -194,7 +234,7 @@ describe("GET /api/schools/[id]/deletion-blockers", () => {
 
       expect(result.canDelete).toBe(true);
       expect(result.blockers).toEqual([]);
-      expect(result.schoolId).toBe("test-school-id");
+      expect(result.schoolId).toBe(SCHOOL_ID);
       expect(result.message).toBe("School can be deleted successfully.");
     });
   });
@@ -389,7 +429,7 @@ describe("GET /api/schools/[id]/deletion-blockers", () => {
   });
 
   describe("DB errors are logged but do not throw", () => {
-    it("does not add a blocker when a query returns an error (warns and skips)", async () => {
+    it("does not add a blocker when a count query returns an error (warns and skips)", async () => {
       mockState.coachError = { message: "timeout" };
       mockState.interactionError = { message: "timeout" };
       const handler = await getHandler();

--- a/tests/unit/server/api/what-matters-now.spec.ts
+++ b/tests/unit/server/api/what-matters-now.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("~/server/utils/auth", () => ({
+  requireAuth: vi.fn(),
+  getUserRole: vi.fn(),
+}));
+vi.mock("~/server/utils/supabase", () => ({
+  createServerSupabaseClient: vi.fn(),
+  useSupabaseAdmin: vi.fn(),
+}));
+vi.mock("h3", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    createError: vi.fn((opts: { statusCode: number; statusMessage: string }) => {
+      const err = new Error(opts.statusMessage) as Error & { statusCode: number };
+      err.statusCode = opts.statusCode;
+      return err;
+    }),
+    defineEventHandler: vi.fn((handler: (event: unknown) => unknown) => handler),
+  };
+});
+
+/**
+ * A minimal chainable Supabase stub. Each `.from(...)` chain resolves via
+ * `.maybeSingle()` to the next queued result, in call order.
+ */
+function makeSupabaseStub(results: Array<{ data: unknown; error: unknown }>) {
+  let i = 0;
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    maybeSingle: () => Promise.resolve(results[i++] ?? { data: null, error: null }),
+  };
+  return { from: () => chain };
+}
+
+describe("resolveViewerAthleteId", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns the caller unchanged for a player", async () => {
+    const { getUserRole } = await import("~/server/utils/auth");
+    vi.mocked(getUserRole).mockResolvedValue("player" as never);
+
+    const { resolveViewerAthleteId } = await import("~/server/utils/athleteAccess");
+    const supabase = makeSupabaseStub([]);
+
+    const result = await resolveViewerAthleteId(supabase as never, "player-1");
+    expect(result).toBe("player-1");
+  });
+
+  it("resolves a parent to the linked player in their family unit", async () => {
+    const { getUserRole } = await import("~/server/utils/auth");
+    vi.mocked(getUserRole).mockResolvedValue("parent" as never);
+
+    const { resolveViewerAthleteId } = await import("~/server/utils/athleteAccess");
+    const supabase = makeSupabaseStub([
+      { data: { family_unit_id: "unit-1" }, error: null },
+      { data: { user_id: "player-9" }, error: null },
+    ]);
+
+    const result = await resolveViewerAthleteId(supabase as never, "parent-1");
+    expect(result).toBe("player-9");
+  });
+
+  it("falls back to the parent when no player is linked", async () => {
+    const { getUserRole } = await import("~/server/utils/auth");
+    vi.mocked(getUserRole).mockResolvedValue("parent" as never);
+
+    const { resolveViewerAthleteId } = await import("~/server/utils/athleteAccess");
+    const supabase = makeSupabaseStub([
+      { data: { family_unit_id: "unit-1" }, error: null },
+      { data: null, error: null },
+    ]);
+
+    const result = await resolveViewerAthleteId(supabase as never, "parent-1");
+    expect(result).toBe("parent-1");
+  });
+});
+
+describe("GET /api/athlete/what-matters-now", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("rejects unauthenticated requests with 401", async () => {
+    const { requireAuth } = await import("~/server/utils/auth");
+    const { createServerSupabaseClient } = await import("~/server/utils/supabase");
+    vi.mocked(requireAuth).mockRejectedValue(
+      Object.assign(new Error("Unauthorized"), { statusCode: 401 }),
+    );
+
+    const { default: handler } = await import(
+      "~/server/api/athlete/what-matters-now.get"
+    );
+    const mockEvent = {
+      context: {},
+      node: { req: { headers: {} }, res: {} },
+    } as never;
+
+    await expect(handler(mockEvent)).rejects.toMatchObject({ statusCode: 401 });
+    expect(createServerSupabaseClient).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/server/utils/athleteAccess.spec.ts
+++ b/tests/unit/server/utils/athleteAccess.spec.ts
@@ -10,14 +10,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { H3Event } from "h3";
 
-vi.mock("~/server/utils/logger", () => ({
-  useLogger: () => ({
+vi.mock("~/server/utils/logger", () => {
+  const stub = () => ({
     info: vi.fn(),
     error: vi.fn(),
     warn: vi.fn(),
     debug: vi.fn(),
-  }),
-}));
+  });
+  return { useLogger: stub, createLogger: stub };
+});
 
 const mockSupabaseAdmin = {
   from: vi.fn(),


### PR DESCRIPTION
## Why

iOS parent login shows **"Junior Year | 20/100 | No pending priorities"** while the athlete's web login shows the real top task (e.g. "Take official SAT or ACT"). Root cause: iOS points at production (`myrecruitingcompass.com` = `main`), and `main` ships `/api/athlete/phase` + `/api/athlete/status` but **not** `/api/athlete/what-matters-now` — that endpoint exists only on `develop`. The 404 makes the iOS timeline card fall back to "No pending priorities".

Promoting `develop → main` deploys the missing endpoint (`1082c920`) plus the related status/phase parity fixes (July-1 grade-roll pivot `a9c923b6`, status error propagation `7e413c7d`, missing-user 500 fix `e0f31430`), unblocking the iOS timeline card with no iOS change required.

## Scope

31 commits. Notable:
- `feat(athlete): shared what-matters-now endpoint` — the fix
- phase/status parity + grade-roll fixes
- profile tab reorg, positions vocabulary, family-shared profile, dependabot bumps

## ⚠️ DB migrations in this diff — review before deploy

- `20260821000000_family_shared_player_prefs_rls.sql`
- `20260821000000_video_links_platform_other.sql`
- `20260821000100_reconcile_parent_player_owned_prefs.sql`
- `20260821000200_family_shared_profile_photo.sql`

The family-shared migrations were reportedly already applied to prod on 2026-08-09; confirm Supabase migration state so the deploy is a no-op / non-conflicting before merging.

## Test plan

- [ ] CI green on the PR
- [ ] Confirm prod migration state vs. the 4 files above
- [ ] After deploy: `GET /api/athlete/what-matters-now` returns 200 on prod
- [ ] iOS parent login timeline card shows the top-priority task (not "No pending priorities")

https://claude.ai/code/session_01DfKUc46SNbxeivGzfasoSd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated “What Matters Now” endpoint to provide athletes with current, phase-specific tasks and statuses.
  * Parents with a linked athlete now receive that athlete’s relevant information automatically.

* **Bug Fixes**
  * Improved deletion-blocker checks for coaches, interactions, and schools.
  * Inaccessible or nonexistent records now return clear 404 responses.
  * Added authentication, UUID validation, and database-error handling.
  * Prevented blocker counts when record verification fails.

* **Tests**
  * Expanded coverage for authentication, validation, access restrictions, missing records, and database errors.

* **Documentation**
  * Added guidance for URL handling and iOS timeline synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->