### PR TITLE
fix(e2e): correct COPPA under-13 assertion copy drift

### DIFF
--- a/tests/e2e/signup-flow.spec.ts
+++ b/tests/e2e/signup-flow.spec.ts
@@ -96,9 +96,11 @@ test.describe("Signup Page - Full Flow E2E Tests", () => {
 
       await page.click('[data-testid="signup-button"]');
 
-      // COPPA error message
+      // COPPA error message — signup.vue copy says "players under 13"
+      // (the /join page uses "users under 13"; keep this assertion matched to
+      // the page under test to avoid copy-drift false failures).
       await expect(
-        page.locator("text=not available for users under 13"),
+        page.locator("text=not available for players under 13"),
       ).toBeVisible({ timeout: 5000 });
     });
   });


### PR DESCRIPTION
## Root cause (systematic debugging)
Investigating the E2E failures on the cron-monitoring release, one turned out to be a **real deterministic failure**, not flake: the COPPA under-13 signup test failed on *every* run (both browsers) because of copy drift.

- Signup page blocks under-13 with **"...not available for players under 13..."** (`pages/signup.vue:210`)
- Test asserted **"...users under 13..."** (`signup-flow.spec.ts:101`)
- `/join` legitimately uses "users under 13" (`pages/join.vue:138`), but this test drives the **signup** page.

The age gate itself works — only the expected string was stale. Fixed the assertion to match the page under test.

## The rest of the failures = environmental flake (separate effort)
For the record, the other failures on that run are genuine flake, not addressed here:
- **coaches-crud-atomic** — already `test.describe.configure({ mode: "serial" })` + unique names; failed via `browserContext.close` + GPU `SharedImageManager` errors = browser crash under 2-worker CI load.
- **coaches-filtering / coaches-detail** — seed-dependent counts + debounce timing.
- **WebKit (~30 fails)** — explicitly non-blocking (`e2e.yml:78`), 33min run = timeout class.

These need a dedicated warm-server `--repeat-each` reproduction session to root-cause (condition-based waits / worker tuning / runner resources). Tracked as follow-up.

## Test plan
- [x] Assertion string now matches `pages/signup.vue:210` exactly (verified against source)
- [x] lint clean
- [ ] E2E run (needs Node22 + live DB + preview env)

https://claude.ai/code/session_01PBxaMsSYqUQR7Xc8A7vxkd