### PR TITLE
fix(rls): allow family members (parent or player) to create interactions

### DIFF
--- a/supabase/migrations/20260826000000_allow_family_members_create_interactions.sql
+++ b/supabase/migrations/20260826000000_allow_family_members_create_interactions.sql
@@ -1,0 +1,27 @@
+-- Allow any family member (parent or player) to log interactions.
+--
+-- The prior policy "Only players can create interactions" required the caller
+-- to hold the 'player' role, which blocked parents from logging interactions
+-- on behalf of their athlete even though the app exposes the "Add Interaction"
+-- flow to them. Parents manage the athlete's recruiting record, so membership
+-- in the family unit plus logged_by = auth.uid() is sufficient authorization;
+-- the role gate is dropped.
+
+-- Idempotent: this policy was already applied live to prod out-of-band, so drop
+-- the new name too. The migration then converges from any starting state (old
+-- policy present, new policy present, or neither) and `supabase db push` is safe
+-- to run against prod even though prod already has the new policy live.
+DROP POLICY IF EXISTS "Only players can create interactions" ON "public"."interactions";
+DROP POLICY IF EXISTS "Family members can create interactions" ON "public"."interactions";
+
+CREATE POLICY "Family members can create interactions"
+  ON "public"."interactions"
+  FOR INSERT
+  WITH CHECK (
+    ("family_unit_id" IN (
+      SELECT "family_members"."family_unit_id"
+      FROM "public"."family_members"
+      WHERE ("family_members"."user_id" = "auth"."uid"())
+    ))
+    AND ("logged_by" = "auth"."uid"())
+  );


### PR DESCRIPTION
## Summary

The interactions `INSERT` RLS policy `Only players can create interactions` required the caller to hold the `player` role, so **parents could not log interactions** on behalf of their athlete — even though both web and iOS expose the "Add Interaction" flow to them. The insert failed with a generic RLS rejection ("Failed to create interaction").

This migration drops the role gate. Family-unit membership plus `logged_by = auth.uid()` is sufficient authorization; both parents and players in the family can now log interactions.

## Context

- Root cause found while debugging a parent-account failure on iOS.
- The same policy change was **already applied live to prod** out-of-band via the Supabase MCP to unblock the user. This migration is the committed record of that change.

## Idempotency / deploy safety

Because prod already has the new policy live but its migration history lacks this version, `supabase db push` will run this file against prod. The migration drops **both** the old and new policy names before `CREATE`, so it converges from any starting state (old policy, new policy, or neither) and push is safe against prod and fresh/local DBs alike.

## Companion change

iOS commits (separate repo) align the interaction-type picker with the DB `interaction_type` enum and sort the school picker alphabetically.

## Test plan

- [ ] `supabase db push` (or CI migration run) succeeds against a DB that already has the policy live
- [ ] Parent account can create an interaction
- [ ] Player account can still create an interaction
- [ ] A user outside the family unit is still blocked

https://claude.ai/code/session_01TJJyPdRL7k7NYQniWWUQqV