### PR TITLE
fix(rls): allow linked parents to check off athlete tasks

### DIFF
--- a/supabase/migrations/20260826000001_allow_linked_parents_write_athlete_tasks.sql
+++ b/supabase/migrations/20260826000001_allow_linked_parents_write_athlete_tasks.sql
@@ -1,0 +1,34 @@
+-- Allow a linked parent to help check off recruiting-timeline tasks.
+--
+-- The athlete_task INSERT/UPDATE policies were self-only
+-- (athlete_id = auth.uid()), so a parent viewing their athlete's timeline could
+-- see tasks (SELECT is scoped to get_linked_user_ids) but could not complete
+-- them. Widen INSERT/UPDATE to the same linked scope the SELECT policy already
+-- uses: get_linked_user_ids() = self + accepted account_links (both directions).
+--
+-- Idempotent: this change was already applied live to prod out-of-band, so the
+-- new policy names are dropped first too. The migration converges from any
+-- starting state and `supabase db push` is safe against prod and local DBs.
+
+DROP POLICY IF EXISTS "Athletes can create own task records" ON "public"."athlete_task";
+DROP POLICY IF EXISTS "Linked users can create athlete task records" ON "public"."athlete_task";
+
+CREATE POLICY "Linked users can create athlete task records"
+  ON "public"."athlete_task"
+  FOR INSERT
+  WITH CHECK (
+    athlete_id IN (SELECT user_id FROM get_linked_user_ids())
+  );
+
+DROP POLICY IF EXISTS "Athletes can update own task status" ON "public"."athlete_task";
+DROP POLICY IF EXISTS "Linked users can update athlete task status" ON "public"."athlete_task";
+
+CREATE POLICY "Linked users can update athlete task status"
+  ON "public"."athlete_task"
+  FOR UPDATE
+  USING (
+    athlete_id IN (SELECT user_id FROM get_linked_user_ids())
+  )
+  WITH CHECK (
+    athlete_id IN (SELECT user_id FROM get_linked_user_ids())
+  );


### PR DESCRIPTION
## Summary

A parent viewing their athlete's **Recruiting Timeline** could see the tasks (SELECT is scoped to `get_linked_user_ids`) but the `athlete_task` INSERT/UPDATE policies were self-only (`athlete_id = auth.uid()`), so they couldn't check anything off — parents help manage their athlete's recruiting, so this blocked a core workflow.

This widens `athlete_task` INSERT/UPDATE to the same linked scope the SELECT policy already uses: `get_linked_user_ids()` = self + accepted `account_links` (both directions).

## Context

- Same class of gap as the interactions RLS fix (see companion PR #385).
- Already applied **live to prod** out-of-band via Supabase MCP to unblock the user; this migration is the committed record.

## Idempotency / deploy safety

Prod already has the new policies live but its migration history lacks this version, so `supabase db push` will run this file. It drops **both** the old and new policy names before each `CREATE`, so it converges from any starting state and push is safe against prod and fresh/local DBs.

## Companion change

iOS commit removes the disabled-checkbox gate for parents and writes `athlete_task` against the viewed athlete's id (not the signed-in parent's).

## Test plan

- [ ] `supabase db push` succeeds against a DB that already has the policies live
- [ ] Parent (accepted link) can complete an athlete's timeline task
- [ ] Player can still complete their own tasks
- [ ] A non-linked user is still blocked from writing another user's athlete_task

https://claude.ai/code/session_01TJJyPdRL7k7NYQniWWUQqV