### PR TITLE
Promote develop → main: fix desktop 'More' dropdown navigation

### DIFF
--- a/components/Header/HeaderNavMore.vue
+++ b/components/Header/HeaderNavMore.vue
@@ -53,19 +53,23 @@
       </div>
     </Transition>
 
-    <!-- Backdrop -->
-    <Teleport to="body">
-      <Transition
-        enter-active-class="transition ease-out duration-100"
-        enter-from-class="opacity-0"
-        enter-to-class="opacity-100"
-        leave-active-class="transition ease-in duration-75"
-        leave-from-class="opacity-100"
-        leave-to-class="opacity-0"
-      >
-        <div v-if="isOpen" class="fixed inset-0 z-40" @click="isOpen = false" />
-      </Transition>
-    </Teleport>
+    <!-- Backdrop (dismiss on outside click). NOT teleported to body: the app
+         root (#__nuxt) has `isolation: isolate`, creating a stacking context.
+         Teleporting the backdrop to <body> put it OUTSIDE that context at z-40,
+         above the whole app — including this menu (trapped inside #__nuxt via
+         the sticky z-50 header) — so it swallowed every link click (dropdown
+         closed, navigation never fired). Kept in-context, menu z-50 > backdrop
+         z-40 as intended. -->
+    <Transition
+      enter-active-class="transition ease-out duration-100"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition ease-in duration-75"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div v-if="isOpen" class="fixed inset-0 z-40" @click="isOpen = false" />
+    </Transition>
   </div>
 </template>
 

--- a/tests/e2e/nav-more-dropdown.spec.ts
+++ b/tests/e2e/nav-more-dropdown.spec.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Regression: the desktop header "More" dropdown must navigate on click.
+ *
+ * Bug (all environments): the dropdown's dismiss backdrop was `Teleport`ed to
+ * <body>. The app root (#__nuxt) carries `isolation: isolate`, which creates a
+ * stacking context — so the body-level backdrop (z-40) painted ABOVE the whole
+ * app, including the menu itself (trapped inside #__nuxt behind the sticky
+ * z-50 header). Every link click landed on the backdrop: the dropdown closed
+ * (@click) but navigation never fired ("closes, no route"). The mobile menu,
+ * having no such backdrop, was unaffected — matching the reported symptom.
+ *
+ * Fix: keep the backdrop in the same stacking context as the menu (no Teleport),
+ * so menu z-50 > backdrop z-40 as intended and clicks reach the links.
+ *
+ * These assertions fail against the pre-fix component and pass after it.
+ */
+test.describe.configure({ mode: "serial" });
+
+test.describe("Header 'More' dropdown navigation (desktop)", () => {
+  const items: Array<{ testid: string; path: RegExp }> = [
+    { testid: "nav-more-events", path: /\/events(\/|$)/ },
+    { testid: "nav-more-performance", path: /\/performance(\/|$)/ },
+    { testid: "nav-more-documents", path: /\/documents(\/|$)/ },
+  ];
+
+  for (const { testid, path } of items) {
+    test(`clicking ${testid} routes to its page`, async ({ page }) => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+      await page.goto("/dashboard");
+
+      const moreButton = page.getByTestId("nav-more-button");
+      await moreButton.waitFor({ state: "visible" });
+      await moreButton.click();
+
+      const link = page.getByTestId(testid);
+      await link.waitFor({ state: "visible" });
+
+      // The regression: the teleported backdrop sat on top of the link, so the
+      // element at the link's center was the backdrop, not the anchor. Assert
+      // the link is the topmost element before clicking.
+      const linkIsOnTop = await link.evaluate((el) => {
+        const r = el.getBoundingClientRect();
+        const top = document.elementFromPoint(
+          r.x + r.width / 2,
+          r.y + r.height / 2,
+        );
+        return el === top || el.contains(top);
+      });
+      expect(
+        linkIsOnTop,
+        "More link must be the topmost element (not the backdrop)",
+      ).toBe(true);
+
+      await link.click();
+      await page.waitForURL(path, { timeout: 10000 });
+      expect(page.url()).toMatch(path);
+    });
+  }
+});


### PR DESCRIPTION
Promotes the #389 fix to production.

Desktop header **More** dropdown closed on link click but never navigated (all envs). Cause: the dismiss backdrop was Teleported to <body>; #__nuxt has `isolation: isolate`, trapping the sticky z-50 header/menu inside #__nuxt while the body-level backdrop (z-40) painted above it and swallowed clicks. Fix keeps the backdrop in the menu's stacking context. Verified live via Playwright + on QA. Includes tests/e2e/nav-more-dropdown.spec.ts regression.

Live prod bug affecting all desktop users.

https://claude.ai/code/session_01YAHFzhcNQLZp9ta6Egw2bS