### PR TITLE
fix(nav): notification panel not clickable (same teleported-backdrop bug)

### DIFF
--- a/components/Header/NotificationCenter.vue
+++ b/components/Header/NotificationCenter.vue
@@ -118,19 +118,23 @@
       </div>
     </Transition>
 
-    <!-- Backdrop -->
-    <Teleport to="body">
-      <Transition
-        enter-active-class="transition ease-out duration-100"
-        enter-from-class="opacity-0"
-        enter-to-class="opacity-100"
-        leave-active-class="transition ease-in duration-75"
-        leave-from-class="opacity-100"
-        leave-to-class="opacity-0"
-      >
-        <div v-if="isOpen" class="fixed inset-0 z-40" @click="isOpen = false" />
-      </Transition>
-    </Teleport>
+    <!-- Backdrop (dismiss on outside click). NOT teleported to body: the app
+         root (#__nuxt) has `isolation: isolate`, creating a stacking context.
+         Teleporting the backdrop to <body> put it OUTSIDE that context at z-40,
+         above the whole app — including this panel (trapped inside #__nuxt via
+         the sticky z-50 header) — so it swallowed clicks on the notification
+         items and links (panel closed, action never fired). Kept in-context,
+         panel z-50 > backdrop z-40 as intended. -->
+    <Transition
+      enter-active-class="transition ease-out duration-100"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition ease-in duration-75"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div v-if="isOpen" class="fixed inset-0 z-40" @click="isOpen = false" />
+    </Transition>
   </div>
 </template>
 

--- a/tests/e2e/notification-center-nav.spec.ts
+++ b/tests/e2e/notification-center-nav.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Regression: the header notification panel must be clickable / navigate.
+ *
+ * Same bug class as the "More" dropdown (see nav-more-dropdown.spec.ts): the
+ * panel's dismiss backdrop was `Teleport`ed to <body>, and because #__nuxt has
+ * `isolation: isolate`, the body-level backdrop (z-40) painted above the panel
+ * (trapped inside #__nuxt behind the sticky z-50 header). Clicks on the panel's
+ * items/links hit the backdrop instead — the panel closed but nothing fired.
+ *
+ * Fix: keep the backdrop in the same stacking context as the panel (no
+ * Teleport). This asserts the panel's "View All" link is the topmost element
+ * and that clicking it navigates.
+ */
+test.describe.configure({ mode: "serial" });
+
+test.describe("Header notification panel (desktop)", () => {
+  test("panel content is clickable and 'View All' routes", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/dashboard");
+
+    const bell = page.getByRole("button", { name: /Notifications/ });
+    await bell.waitFor({ state: "visible" });
+    await bell.click();
+
+    const viewAll = page.getByRole("link", { name: /View All Notifications/i });
+    await viewAll.waitFor({ state: "visible" });
+
+    // The regression: the teleported backdrop sat on top of the panel, so the
+    // element at the link's center was the backdrop, not the anchor.
+    const linkIsOnTop = await viewAll.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      const top = document.elementFromPoint(
+        r.x + r.width / 2,
+        r.y + r.height / 2,
+      );
+      return el === top || el.contains(top);
+    });
+    expect(
+      linkIsOnTop,
+      "Notification panel link must be the topmost element (not the backdrop)",
+    ).toBe(true);
+
+    await viewAll.click();
+    await page.waitForURL(/\/notifications(\/|$)/, { timeout: 10000 });
+    expect(page.url()).toMatch(/\/notifications(\/|$)/);
+  });
+});


### PR DESCRIPTION
Follow-up to #389. Header notification panel had the identical teleported-backdrop stacking bug: dismiss backdrop Teleported to <body>, and #__nuxt has isolation:isolate, so the body-level backdrop (z-40) painted above the panel (trapped inside #__nuxt behind the sticky z-50 header), swallowing clicks on notification items and 'View All'. Fix: stop teleporting the backdrop (panel z-50 > backdrop z-40). Verified live via Playwright — 'View All' routes /dashboard -> /notifications. Adds tests/e2e/notification-center-nav.spec.ts. A sweep of all 20 other Teleport-to-body components confirmed the SAFE modal pattern; only the two header dropdowns had the split (both fixed). After merge, promote develop -> main. https://claude.ai/code/session_01YAHFzhcNQLZp9ta6Egw2bS