### PR TITLE
feat(timeline): canonical task sort shared with iOS (parity)

### DIFF
--- a/components/Timeline/TaskList.vue
+++ b/components/Timeline/TaskList.vue
@@ -30,6 +30,7 @@ import type {
   TaskStatus,
 } from "~/types/timeline";
 import TaskItem from "~/components/Timeline/TaskItem.vue";
+import { compareTimelineTasks } from "~/utils/taskSort";
 
 interface Props {
   tasks: TaskWithStatus[];
@@ -69,15 +70,7 @@ const filteredAndSortedTasks = computed(() => {
     );
   }
 
-  // Sort by priority: required tasks first, then alphabetically
-  result = [...result].sort((a, b) => {
-    // Required tasks first
-    if (a.required && !b.required) return -1;
-    if (!a.required && b.required) return 1;
-
-    // Then alphabetically by title
-    return a.title.localeCompare(b.title);
-  });
+  result = [...result].sort(compareTimelineTasks);
 
   return result;
 });

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -129,7 +129,9 @@ export default [
       "playwright-report/**",
       "test-results/**",
       "vitest.config.ts",
-      "utils/positions.test.ts",
+      // tsconfig.json excludes `**/*.test.ts`, so type-aware linting cannot
+      // parse the co-located util tests.
+      "utils/**/*.test.ts",
     ],
   },
   js.configs.recommended,

--- a/utils/taskSort.test.ts
+++ b/utils/taskSort.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect } from "vitest";
+import type {
+  AthleteTask,
+  TaskCategory,
+  TaskStatus,
+  TaskWithStatus,
+} from "~/types/timeline";
+import { compareTimelineTasks } from "./taskSort";
+
+type TaskOverrides = Partial<TaskWithStatus> & {
+  id: string;
+  status?: TaskStatus;
+};
+
+function makeTask(overrides: TaskOverrides): TaskWithStatus {
+  const { status, ...taskOverrides } = overrides;
+
+  const athleteTask: AthleteTask | undefined = status
+    ? {
+        id: `at-${taskOverrides.id}`,
+        athlete_id: "athlete-1",
+        task_id: taskOverrides.id,
+        status,
+        completed_at: status === "completed" ? "2026-01-01T00:00:00Z" : null,
+        is_recovery_task: false,
+        created_at: null,
+        updated_at: null,
+      }
+    : undefined;
+
+  return {
+    id: taskOverrides.id,
+    category: "academic",
+    grade_level: 11,
+    title: taskOverrides.id,
+    description: null,
+    required: true,
+    dependency_task_ids: [],
+    why_it_matters: null,
+    failure_risk: null,
+    division_applicability: ["ALL"],
+    deadline_date: null,
+    created_at: null,
+    updated_at: null,
+    has_incomplete_prerequisites: false,
+    athlete_task: athleteTask,
+    ...taskOverrides,
+  };
+}
+
+function sortedIds(tasks: TaskWithStatus[]): string[] {
+  return [...tasks].sort(compareTimelineTasks).map((t) => t.id);
+}
+
+describe("compareTimelineTasks", () => {
+  it("sinks completed tasks below incomplete ones", () => {
+    const tasks = [
+      makeTask({ id: "done", status: "completed" }),
+      makeTask({ id: "in-progress", status: "in_progress" }),
+      makeTask({ id: "untouched" }),
+    ];
+
+    expect(sortedIds(tasks)).toEqual(["in-progress", "untouched", "done"]);
+  });
+
+  it("sinks locked tasks below actionable ones", () => {
+    const tasks = [
+      makeTask({ id: "locked", has_incomplete_prerequisites: true }),
+      makeTask({ id: "actionable" }),
+    ];
+
+    expect(sortedIds(tasks)).toEqual(["actionable", "locked"]);
+  });
+
+  it("ranks completion above lock state", () => {
+    const tasks = [
+      makeTask({ id: "completed-actionable", status: "completed" }),
+      makeTask({ id: "incomplete-locked", has_incomplete_prerequisites: true }),
+    ];
+
+    expect(sortedIds(tasks)).toEqual([
+      "incomplete-locked",
+      "completed-actionable",
+    ]);
+  });
+
+  it("orders required tasks before optional ones", () => {
+    const tasks = [
+      makeTask({ id: "optional", required: false }),
+      makeTask({ id: "required", required: true }),
+    ];
+
+    expect(sortedIds(tasks)).toEqual(["required", "optional"]);
+  });
+
+  it("orders by deadline ascending with missing deadlines last", () => {
+    const tasks = [
+      makeTask({ id: "none", deadline_date: null }),
+      makeTask({ id: "later", deadline_date: "2026-12-01" }),
+      makeTask({ id: "sooner", deadline_date: "2026-03-15" }),
+    ];
+
+    expect(sortedIds(tasks)).toEqual(["sooner", "later", "none"]);
+  });
+
+  it("orders by category weight, with unknown categories last", () => {
+    const tasks = [
+      makeTask({ id: "mindset", category: "mindset" }),
+      makeTask({ id: "exposure", category: "exposure" }),
+      makeTask({ id: "athletic", category: "athletic" }),
+      makeTask({ id: "recruiting", category: "recruiting" }),
+      makeTask({ id: "academic", category: "academic" }),
+      makeTask({
+        id: "unknown",
+        category: "wellness" as unknown as TaskCategory,
+      }),
+    ];
+
+    expect(sortedIds(tasks)).toEqual([
+      "academic",
+      "recruiting",
+      "athletic",
+      "exposure",
+      "mindset",
+      "unknown",
+    ]);
+  });
+
+  it("falls back to an alphabetical title tiebreak", () => {
+    const tasks = [
+      makeTask({ id: "c", title: "Camp invite" }),
+      makeTask({ id: "a", title: "ACT registration" }),
+      makeTask({ id: "b", title: "Book a visit" }),
+    ];
+
+    expect(sortedIds(tasks)).toEqual(["a", "b", "c"]);
+  });
+
+  it("applies every key in priority order for a mixed list", () => {
+    const tasks = [
+      makeTask({
+        id: "completed-urgent",
+        status: "completed",
+        deadline_date: "2026-01-01",
+      }),
+      makeTask({
+        id: "locked-required",
+        has_incomplete_prerequisites: true,
+        deadline_date: "2026-01-02",
+      }),
+      makeTask({
+        id: "optional-soon",
+        required: false,
+        deadline_date: "2026-02-01",
+      }),
+      makeTask({ id: "required-late", deadline_date: "2026-09-01" }),
+      makeTask({ id: "required-soon", deadline_date: "2026-02-01" }),
+      makeTask({
+        id: "required-soon-recruiting",
+        category: "recruiting",
+        deadline_date: "2026-02-01",
+      }),
+    ];
+
+    expect(sortedIds(tasks)).toEqual([
+      "required-soon",
+      "required-soon-recruiting",
+      "required-late",
+      "optional-soon",
+      "locked-required",
+      "completed-urgent",
+    ]);
+  });
+});

--- a/utils/taskSort.ts
+++ b/utils/taskSort.ts
@@ -1,0 +1,55 @@
+import type { TaskWithStatus } from "~/types/timeline";
+
+// Keys MUST match the `task.category` values actually stored in the DB
+// (academic / recruiting / athletic / exposure / mindset). An earlier map used
+// a fictional taxonomy (academic-standing, visibility-building, …) that matched
+// no rows, so every task fell to the caller's default — a total tie that made
+// the #1 "what matters now" task arbitrary (and different between web and iOS,
+// which issue independently-ordered queries).
+export const CATEGORY_PRIORITY = {
+  academic: 10,
+  recruiting: 9,
+  athletic: 8,
+  exposure: 7,
+  mindset: 5,
+} as const;
+
+// Sentinel that sorts after every real "YYYY-MM-DD" deadline string, so tasks
+// without a deadline land at the bottom of their tier instead of the top.
+const NO_DEADLINE = "￿";
+
+// Canonical timeline task ordering — MUST stay identical to the iOS
+// TimelineTaskSort comparator. Keys, in order:
+//   1. incomplete before completed
+//   2. actionable before locked (incomplete prerequisites)
+//   3. required before optional
+//   4. deadline ascending, null last
+//   5. category rank academic>recruiting>athletic>exposure>mindset, unknown last
+//   6. title A–Z (deterministic tiebreak)
+export function compareTimelineTasks(
+  a: TaskWithStatus,
+  b: TaskWithStatus,
+): number {
+  const aDone = a.athlete_task?.status === "completed" ? 1 : 0;
+  const bDone = b.athlete_task?.status === "completed" ? 1 : 0;
+  if (aDone !== bDone) return aDone - bDone;
+
+  const aLocked = a.has_incomplete_prerequisites ? 1 : 0;
+  const bLocked = b.has_incomplete_prerequisites ? 1 : 0;
+  if (aLocked !== bLocked) return aLocked - bLocked;
+
+  const aRequired = a.required ? 0 : 1;
+  const bRequired = b.required ? 0 : 1;
+  if (aRequired !== bRequired) return aRequired - bRequired;
+
+  const aDeadline = a.deadline_date ?? NO_DEADLINE;
+  const bDeadline = b.deadline_date ?? NO_DEADLINE;
+  if (aDeadline !== bDeadline) return aDeadline < bDeadline ? -1 : 1;
+
+  const priorities = CATEGORY_PRIORITY as Record<string, number>;
+  const aCategory = priorities[a.category] ?? 0;
+  const bCategory = priorities[b.category] ?? 0;
+  if (aCategory !== bCategory) return bCategory - aCategory;
+
+  return a.title.localeCompare(b.title);
+}

--- a/utils/whatMattersNow.ts
+++ b/utils/whatMattersNow.ts
@@ -1,4 +1,5 @@
 import type { Phase, TaskWithStatus } from "~/types/timeline";
+import { CATEGORY_PRIORITY } from "~/utils/taskSort";
 
 export interface WhatMattersItem {
   taskId: string;
@@ -8,20 +9,6 @@ export interface WhatMattersItem {
   priority: number;
   isRequired: boolean;
 }
-
-// Keys MUST match the `task.category` values actually stored in the DB
-// (academic / recruiting / athletic / exposure / mindset). An earlier map used
-// a fictional taxonomy (academic-standing, visibility-building, …) that matched
-// no rows, so every task fell to the `|| 5` default — a total tie that made the
-// #1 "what matters now" task arbitrary (and different between web and iOS,
-// which issue independently-ordered queries).
-const CATEGORY_PRIORITY: Record<string, number> = {
-  academic: 10,
-  recruiting: 9,
-  athletic: 8,
-  exposure: 7,
-  mindset: 5,
-};
 
 export function getWhatMattersNow(params: {
   phase: Phase;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -31,6 +31,8 @@ export default defineConfig({
       "tests/unit/**/*.spec.ts",
       "tests/integration/**/*.spec.ts",
       "tests/unit/**/*.test.mjs",
+      // Pure helpers under utils/ keep their tests co-located.
+      "utils/**/*.test.ts",
     ],
     exclude: ["node_modules/", "dist/", ".nuxt/", "tests/e2e/**"],
 


### PR DESCRIPTION
## Problem

A player on web and a parent on iOS saw the **same** recruiting-timeline tasks in a **different order** within each phase card. Cause is **platform, not role**.

- **Web** (`TaskList.vue`) sorted required-first, then title A–Z.
- **iOS** did not sort — rendered DB `id`-ascending order.

## Fix

Extract one canonical priority comparator, identical on web and iOS.

**Order:** incomplete → actionable (unlocked) → required → deadline ascending (null last) → category rank (academic›recruiting›athletic›exposure›mindset, unknown last) → title A–Z.

## Changes

- **`utils/taskSort.ts`** (new) — `compareTimelineTasks` + `CATEGORY_PRIORITY` as the single source of truth.
- **`components/Timeline/TaskList.vue`** — use the comparator (`filterCategory`/`filterStatus` filters unchanged).
- **`utils/whatMattersNow.ts`** — import the shared `CATEGORY_PRIORITY` (dedup); `|| 5` default preserved.
- **`utils/taskSort.test.ts`** (new) — 8 vitest cases, mirroring the iOS suite 1:1.
- **`eslint.config.js` / `vitest.config.ts`** — widened globs to run/lint the co-located `utils/**/*.test.ts` (mirrors existing `utils/positions.test.ts` precedent).

Kept byte-identical to the iOS `TimelineTaskSort` comparator (companion PR in recruiting-compass-ios).

## Test plan

- `npx vitest run utils/taskSort.test.ts` — 8/8 pass.
- `npx tsc --noEmit` — no new errors in changed files (pre-existing `.vue`-resolution noise only).
- Manual: same athlete/grad-year on both apps → each phase card lists tasks in identical order.

**Out of scope:** the "What Matters Now" top-5 sidebar keeps its own priority algorithm (unchanged).

https://claude.ai/code/session_01TJJyPdRL7k7NYQniWWUQqV