### PR TITLE
chore(perf): gate Lighthouse CI with budgets + quiet Sentry logs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,7 +209,11 @@ jobs:
           LHCI_CI_PASSWORD: ${{ secrets.LHCI_CI_PASSWORD }}
           LHCI_PROFILE_SLUG: ${{ secrets.LHCI_PROFILE_SLUG }}
 
+      - name: Run Lighthouse CI assert
+        run: npx lhci assert --config=lighthouserc.cjs
+
       - name: Run Lighthouse CI upload
+        if: always()
         run: npx lhci upload --config=lighthouserc.cjs
 
       - name: Post Slack report

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -6,7 +6,7 @@ const PROFILE_SLUG = process.env.LHCI_PROFILE_SLUG;
 module.exports = {
   ci: {
     collect: {
-      numberOfRuns: 1,
+      numberOfRuns: 3,
       puppeteerScript: "./scripts/lhci-auth.cjs",
       url: [
         `${BASE_URL}/login`,
@@ -18,6 +18,17 @@ module.exports = {
       settings: {
         // Required for Chrome in CI / Docker environments
         chromeFlags: "--no-sandbox --disable-dev-shm-usage",
+      },
+    },
+    // Budgets are warn-only: an SPA (ssr:false) yields noisy lab scores, so a
+    // regression surfaces in the LHCI report + Slack post without ever failing
+    // the build. Tighten to "error" once baselines prove stable per page.
+    assert: {
+      assertions: {
+        "categories:performance": ["warn", { minScore: 0.6 }],
+        "categories:accessibility": ["warn", { minScore: 0.9 }],
+        "categories:best-practices": ["warn", { minScore: 0.9 }],
+        "categories:seo": ["warn", { minScore: 0.9 }],
       },
     },
     upload: {

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -10,7 +10,7 @@ Sentry.init({
 
   integrations: [
     Sentry.replayIntegration(),
-    Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
+    Sentry.consoleLoggingIntegration({ levels: ["warn", "error"] }),
   ],
 
   enableLogs: true,
@@ -33,9 +33,4 @@ Sentry.init({
     // fetch it and Sentry captures the linked FetchError. Not possible in prod.
     /builds\/meta\/dev\.json/,
   ],
-});
-
-// TODO: REMOVE — Sentry logs verification test
-Sentry.logger.info("Sentry client logs verification", {
-  log_source: "sentry_test",
 });


### PR DESCRIPTION
## Summary

Performance monitoring was already fully wired (Vercel Speed Insights + Analytics, Sentry tracing, Lighthouse CI) — issue #16's actual gaps were that Lighthouse **collected but never asserted** and Sentry shipped noise. This closes those.

## Changes

- **Lighthouse CI now gates.** Added warn-only category budgets (`performance` 0.6; `accessibility`/`best-practices`/`seo` 0.9) + an `lhci assert` step in `test.yml`. Was collecting + uploading but never evaluating, so regressions surfaced in reports yet never flagged.
- **`numberOfRuns` 1 → 3** — LHCI takes the median; kills single-sample jitter.
- **warn-only, deliberately** — `ssr:false` SPA gives noisy lab scores. Report + Slack surface regressions without red-flagging the build. Tighten to `error` per page once baselines stabilize.
- **Sentry cleanup** — removed the leftover `TODO: REMOVE` verification info-log firing on every prod page load; narrowed `consoleLoggingIntegration` to `["warn","error"]` so routine `console.log` stops forwarding (volume/cost).

## Test plan

- [x] `lighthouserc.cjs` parses (node require)
- [x] `test.yml` valid YAML
- [ ] Next `develop` push runs Lighthouse job → confirm `lhci assert` step reports budgets, job stays green (warn-only)

Closes #16

https://claude.ai/code/session_01QdYBUxbQpa1GhQCaFsHebi