### PR TITLE
Promote develop → main: CI test-selector fix

### DIFF
--- a/tests/e2e/fixtures/schools.fixture.ts
+++ b/tests/e2e/fixtures/schools.fixture.ts
@@ -257,10 +257,10 @@ export const notesFixtures = {
  */
 export const notesSelectors = {
   sharedNotesSection: 'h2.text-lg.font-semibold:has-text("Notes")',
-  editButton: 'button[aria-label="Edit notes"]',
-  cancelButton: 'button[aria-label="Cancel editing notes"]',
-  saveButton: 'button:has-text("Save Notes")',
-  notesTextarea: "#notes-textarea",
+  editButton: 'button[aria-label="Edit Notes"]',
+  cancelButton: 'button[aria-label="Cancel editing Notes"]',
+  saveButton: 'button:has-text("Save")',
+  notesTextarea: '[id^="notes-textarea"]',
   notesDisplay: ".text-slate-700.text-sm.whitespace-pre-wrap",
 };
 

--- a/tests/unit/components/School/SchoolNotesCard.spec.ts
+++ b/tests/unit/components/School/SchoolNotesCard.spec.ts
@@ -20,7 +20,7 @@ const makeProps = (overrides: Record<string, unknown> = {}) => ({
 const editBtn = (wrapper: ReturnType<typeof mount>) =>
   wrapper.findAll("button").find((b) => b.text().match(/Edit|Cancel/));
 const saveBtn = (wrapper: ReturnType<typeof mount>) =>
-  wrapper.findAll("button").find((b) => b.text().includes("Save Notes"));
+  wrapper.findAll("button").find((b) => /Save|Saving/.test(b.text()));
 
 describe("SchoolNotesCard", () => {
   describe("Notes section", () => {


### PR DESCRIPTION
Promotion. Single commit: aligns SchoolNotesCard unit spec + E2E notes fixture with the renamed "Save" button (commit c0d07201 drift that was failing the develop Test & Verify job).

Test-only change, no prod code. Restores full main↔develop sync.

Develop run green: unit, quality, Deploy to Staging, Staging Smoke E2E, Lighthouse all pass (after repointing the stale VERCEL_PROJECT_ID_STAGING secret to the consolidated Vercel project).

https://claude.ai/code/session_01QdYBUxbQpa1GhQCaFsHebi