### PR TITLE
feat(ui): FormSegmentedControl + Direction select migration

### DIFF
--- a/components/DesignSystem/Form/FormSegmentedControl.vue
+++ b/components/DesignSystem/Form/FormSegmentedControl.vue
@@ -1,0 +1,92 @@
+<script setup lang="ts">
+import { computed, useId } from "vue";
+
+interface SegmentOption {
+  value: string;
+  label: string;
+}
+
+interface Props {
+  modelValue: string;
+  label: string;
+  options: SegmentOption[];
+  name?: string;
+  required?: boolean;
+  disabled?: boolean;
+  error?: string;
+  size?: "sm" | "md";
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  name: undefined,
+  required: false,
+  disabled: false,
+  error: "",
+  size: "md",
+});
+
+const emit = defineEmits<{
+  "update:modelValue": [value: string];
+  blur: [];
+}>();
+
+const fieldId = useId();
+const groupName = computed(() => props.name ?? `${fieldId}-group`);
+const errorId = computed(() => (props.error ? `${fieldId}-error` : undefined));
+
+const segmentPadding = computed(() =>
+  props.size === "sm" ? "px-2 py-1.5 text-xs" : "px-4 py-2.5 text-sm",
+);
+
+const select = (value: string) => {
+  if (props.disabled) return;
+  emit("update:modelValue", value);
+};
+</script>
+
+<template>
+  <fieldset
+    :aria-describedby="errorId"
+    :aria-invalid="!!error || undefined"
+    class="min-w-0 border-0 p-0"
+  >
+    <legend class="block text-sm font-medium text-slate-700 mb-2">
+      {{ label }}
+      <span v-if="required" class="text-red-500" aria-hidden="true">*</span>
+      <span v-if="required" class="sr-only">(required)</span>
+    </legend>
+
+    <div
+      class="flex w-full gap-1 rounded-xl border-2 bg-white p-1"
+      :class="error ? 'border-red-500' : 'border-slate-300'"
+    >
+      <label
+        v-for="option in options"
+        :key="option.value"
+        class="flex-1 cursor-pointer rounded-lg text-center font-medium whitespace-nowrap transition-colors select-none focus-within:ring-2 focus-within:ring-blue-500"
+        :class="[
+          segmentPadding,
+          modelValue === option.value
+            ? 'bg-blue-600 text-white shadow-xs'
+            : 'text-slate-700 hover:bg-slate-50',
+          disabled ? 'cursor-not-allowed opacity-50' : '',
+        ]"
+      >
+        <input
+          type="radio"
+          class="sr-only"
+          :name="groupName"
+          :value="option.value"
+          :checked="modelValue === option.value"
+          :required="required"
+          :disabled="disabled"
+          @change="select(option.value)"
+          @blur="emit('blur')"
+        />
+        {{ option.label }}
+      </label>
+    </div>
+
+    <DesignSystemFieldError v-if="error" :id="errorId" :error="error" />
+  </fieldset>
+</template>

--- a/components/Events/EventQuickLogModal.vue
+++ b/components/Events/EventQuickLogModal.vue
@@ -38,18 +38,14 @@
           </div>
 
           <!-- Direction -->
-          <div>
-            <label class="block text-sm font-medium text-slate-700 mb-2">
-              Who initiated?
-            </label>
-            <select
-              v-model="data.direction"
-              class="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
-            >
-              <option value="inbound">Coach contacted us</option>
-              <option value="outbound">We contacted coach</option>
-            </select>
-          </div>
+          <DesignSystemFormSegmentedControl
+            v-model="data.direction"
+            label="Who initiated?"
+            :options="[
+              { value: 'inbound', label: 'Coach contacted us' },
+              { value: 'outbound', label: 'We contacted coach' },
+            ]"
+          />
 
           <!-- Notes -->
           <div>

--- a/components/Interaction/InteractionFilters.vue
+++ b/components/Interaction/InteractionFilters.vue
@@ -100,28 +100,19 @@
       </div>
 
       <!-- Direction -->
-      <div>
-        <label
-          for="filter-direction"
-          class="block text-sm font-medium text-slate-700 mb-1"
-          >Direction</label
-        >
-        <select
-          id="filter-direction"
-          :value="filterValues.get('direction') || ''"
-          @change="
-            emits('update:filter', {
-              field: 'direction',
-              value: ($event.target as HTMLSelectElement).value || null,
-            })
-          "
-          class="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm focus:outline-2 focus:outline-blue-600 focus:outline-offset-1 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-        >
-          <option value="">-- All --</option>
-          <option value="outbound">Outbound</option>
-          <option value="inbound">Inbound</option>
-        </select>
-      </div>
+      <DesignSystemFormSegmentedControl
+        label="Direction"
+        size="sm"
+        :model-value="filterValues.get('direction') || ''"
+        :options="[
+          { value: '', label: 'All' },
+          { value: 'outbound', label: 'Outbound' },
+          { value: 'inbound', label: 'Inbound' },
+        ]"
+        @update:model-value="
+          emits('update:filter', { field: 'direction', value: $event || null })
+        "
+      />
 
       <!-- Sentiment -->
       <div>

--- a/components/Interactions/InteractionAddForm.vue
+++ b/components/Interactions/InteractionAddForm.vue
@@ -35,25 +35,16 @@
       </div>
 
       <!-- Direction -->
-      <div>
-        <label
-          for="direction"
-          class="block text-sm font-medium text-slate-700 mb-2"
-        >
-          Direction <span class="text-red-600">*</span>
-        </label>
-        <select
-          id="direction"
-          v-model="newInteraction.direction"
-          required
-          class="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-          :disabled="loading"
-        >
-          <option value="">Select Direction</option>
-          <option value="outbound">Outbound (We initiated)</option>
-          <option value="inbound">Inbound (They contacted us)</option>
-        </select>
-      </div>
+      <DesignSystemFormSegmentedControl
+        v-model="newInteraction.direction"
+        label="Direction"
+        required
+        :disabled="loading"
+        :options="[
+          { value: 'outbound', label: 'Outbound (We initiated)' },
+          { value: 'inbound', label: 'Inbound (They contacted us)' },
+        ]"
+      />
 
       <!-- Coach (optional) -->
       <div v-if="coaches.length > 0">

--- a/components/Interactions/InteractionFiltersBar.vue
+++ b/components/Interactions/InteractionFiltersBar.vue
@@ -32,29 +32,17 @@
       </div>
 
       <!-- Direction Filter -->
-      <div>
-        <label
-          for="direction-filter"
-          class="block text-sm font-medium text-slate-700 mb-2"
-        >
-          Direction
-        </label>
-        <select
-          id="direction-filter"
-          :value="selectedDirection"
-          @change="
-            $emit(
-              'update:selectedDirection',
-              ($event.target as HTMLSelectElement).value,
-            )
-          "
-          class="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-        >
-          <option value="">Both</option>
-          <option value="outbound">Sent by Us</option>
-          <option value="inbound">Received</option>
-        </select>
-      </div>
+      <DesignSystemFormSegmentedControl
+        label="Direction"
+        size="sm"
+        :model-value="selectedDirection"
+        :options="[
+          { value: '', label: 'Both' },
+          { value: 'outbound', label: 'Sent by Us' },
+          { value: 'inbound', label: 'Received' },
+        ]"
+        @update:model-value="$emit('update:selectedDirection', $event)"
+      />
 
       <!-- Date Range Filter -->
       <div>

--- a/components/Search/AdvancedFilters.vue
+++ b/components/Search/AdvancedFilters.vue
@@ -176,22 +176,17 @@
       </div>
 
       <!-- Direction -->
-      <div>
-        <label class="block text-sm font-medium text-gray-700 mb-1"
-          >Direction</label
-        >
-        <select
-          :value="filters.interactions.direction"
-          @change="
-            updateFilter('interactions', 'direction', getSelectValue($event))
-          "
-          class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
-        >
-          <option value="">All Directions</option>
-          <option value="inbound">Inbound</option>
-          <option value="outbound">Outbound</option>
-        </select>
-      </div>
+      <DesignSystemFormSegmentedControl
+        label="Direction"
+        size="sm"
+        :model-value="filters.interactions.direction"
+        :options="[
+          { value: '', label: 'All Directions' },
+          { value: 'inbound', label: 'Inbound' },
+          { value: 'outbound', label: 'Outbound' },
+        ]"
+        @update:model-value="updateFilter('interactions', 'direction', $event)"
+      />
 
       <!-- Date Range -->
       <div class="grid grid-cols-2 gap-3">

--- a/pages/coaches/[id]/communications.vue
+++ b/pages/coaches/[id]/communications.vue
@@ -49,19 +49,16 @@
           </div>
 
           <!-- Direction Filter -->
-          <div>
-            <label class="block text-sm font-medium text-gray-700 mb-2"
-              >Direction</label
-            >
-            <select
-              v-model="selectedDirection"
-              class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
-            >
-              <option value="">Both</option>
-              <option value="outbound">Sent by Us</option>
-              <option value="inbound">Received from Coach</option>
-            </select>
-          </div>
+          <DesignSystemFormSegmentedControl
+            v-model="selectedDirection"
+            label="Direction"
+            size="sm"
+            :options="[
+              { value: '', label: 'Both' },
+              { value: 'outbound', label: 'Sent by Us' },
+              { value: 'inbound', label: 'Received from Coach' },
+            ]"
+          />
 
           <!-- Date Range -->
           <div>

--- a/planning/segmented-control-direction-migration.md
+++ b/planning/segmented-control-direction-migration.md
@@ -1,0 +1,34 @@
+# Plan: FormSegmentedControl + Direction migration
+
+**Branch:** `feat/segmented-control` (off develop) · worktree `wt-segmented-control` · port 3010
+**Origin:** dropdown-usage audit — image "When a dropdown shouldn't exist" bucket 1 (2-4 options → radio/segmented).
+
+## Goal
+Build one reusable segmented control, migrate all 6 interaction-Direction `<select>`s to it. Later 2-4 option selects (coach-role ×5, sort-dir) reuse it in a follow-up.
+
+## Component — `components/DesignSystem/Form/FormSegmentedControl.vue`
+Styled native radios (fieldset + legend, visually-hidden `<input type=radio>` + styled label segments). Free keyboard/arrow nav + SR semantics.
+
+Props mirror `FormSelect`: `modelValue: string`, `label`, `options: {value,label}[]`, `name?`, `required?`, `disabled?`, `error?`, `size?: 'sm'|'md'`.
+Emits: `update:modelValue`, `blur`.
+Styling: design tokens only (audit:tokens gate). Active `bg-brand-blue-600 text-white`; inactive `text-slate-700 hover:bg-slate-50`; focus-visible ring. Neutral filter segment = an option with `value:""` (no special config).
+
+## Migration — 6 sites (same string values, no store/API change)
+| Site | Shape | size |
+|---|---|---|
+| Interactions/InteractionFiltersBar.vue:42 | filter 3-way | sm |
+| Interaction/InteractionFilters.vue:109 | filter 3-way | sm |
+| Search/AdvancedFilters.vue:183 | filter 3-way | sm |
+| coaches/[id]/communications.vue:56 | filter 3-way | sm |
+| Interactions/InteractionAddForm.vue:45 | form 2-way, required | md |
+| Events/EventQuickLogModal.vue:45 | form 2-way | md |
+
+Excluded: `offers/index.vue:327` sortDirection (separate bucket).
+
+## TDD
+1. RED: `tests/unit/components/FormSegmentedControl.spec.ts` (render, emit on click, keyboard, disabled, active class, neutral option) + `tests/unit/a11y/FormSegmentedControl.a11y.spec.ts`.
+2. GREEN: build component.
+3. Migrate 6 sites; fix any `getByRole('combobox')` → `radio` in existing tests.
+
+## Gates
+`npm run type-check`, `npm run lint`, `npm run audit:tokens`, `npm run test`. Browser (port 3010): interactions filter bar + quick-log modal.

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -3,6 +3,7 @@ import { nextTick, ref } from "vue";
 import { createPinia, setActivePinia } from "pinia";
 import { config } from "@vue/test-utils";
 import * as axeMatchers from "vitest-axe/matchers";
+import DesignSystemFormSegmentedControl from "~/components/DesignSystem/Form/FormSegmentedControl.vue";
 expect.extend(axeMatchers);
 
 // Set up environment for Pinia
@@ -253,6 +254,19 @@ config.global.stubs = {
     template:
       '<span :class="name" :data-icon="name" aria-hidden="true"><slot /></span>',
   },
+  DesignSystemFieldError: {
+    name: "DesignSystemFieldError",
+    props: ["error", "id"],
+    template: '<div :id="id" role="alert">{{ error }}</div>',
+  },
+};
+
+// Register real DesignSystem primitives that unit tests render directly.
+// Vitest has no Nuxt auto-import, so consumers of these components would
+// otherwise render an unresolved custom element.
+config.global.components = {
+  ...(config.global.components ?? {}),
+  DesignSystemFormSegmentedControl,
 };
 
 // Initialize Pinia for tests

--- a/tests/unit/a11y/FormSegmentedControl.a11y.spec.ts
+++ b/tests/unit/a11y/FormSegmentedControl.a11y.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import { axe } from "vitest-axe";
+import FormSegmentedControl from "~/components/DesignSystem/Form/FormSegmentedControl.vue";
+
+const AXE_OPTIONS = { rules: { "color-contrast": { enabled: false } } };
+
+const fieldErrorStub = {
+  template: '<div :id="id" role="alert">{{ error }}</div>',
+  props: ["error", "id"],
+};
+
+const OPTIONS = [
+  { value: "", label: "Both" },
+  { value: "outbound", label: "Sent" },
+  { value: "inbound", label: "Received" },
+];
+
+const mountControl = (props: Record<string, unknown> = {}) =>
+  mount(FormSegmentedControl, {
+    props: { modelValue: "", label: "Direction", options: OPTIONS, ...props },
+    attachTo: document.body,
+    global: { stubs: { DesignSystemFieldError: fieldErrorStub } },
+  });
+
+describe("FormSegmentedControl accessibility", () => {
+  it("has no violations in default state", async () => {
+    const wrapper = mountControl();
+    expect(await axe(wrapper.element, AXE_OPTIONS)).toHaveNoViolations();
+    wrapper.unmount();
+  });
+
+  it("has no violations when required", async () => {
+    const wrapper = mountControl({ required: true });
+    expect(await axe(wrapper.element, AXE_OPTIONS)).toHaveNoViolations();
+    wrapper.unmount();
+  });
+
+  it("has no violations when showing an error", async () => {
+    const wrapper = mountControl({ error: "Pick a direction" });
+    expect(await axe(wrapper.element, AXE_OPTIONS)).toHaveNoViolations();
+    wrapper.unmount();
+  });
+});

--- a/tests/unit/components/FormSegmentedControl.spec.ts
+++ b/tests/unit/components/FormSegmentedControl.spec.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import FormSegmentedControl from "~/components/DesignSystem/Form/FormSegmentedControl.vue";
+
+const fieldErrorStub = {
+  template: '<div :id="id" role="alert">{{ error }}</div>',
+  props: ["error", "id"],
+};
+
+const OPTIONS = [
+  { value: "", label: "Both" },
+  { value: "outbound", label: "Sent" },
+  { value: "inbound", label: "Received" },
+];
+
+const mountControl = (props: Record<string, unknown> = {}) =>
+  mount(FormSegmentedControl, {
+    props: { modelValue: "", label: "Direction", options: OPTIONS, ...props },
+    global: { stubs: { DesignSystemFieldError: fieldErrorStub } },
+  });
+
+describe("FormSegmentedControl", () => {
+  it("renders one radio per option", () => {
+    const wrapper = mountControl();
+    const radios = wrapper.findAll('input[type="radio"]');
+    expect(radios).toHaveLength(OPTIONS.length);
+  });
+
+  it("renders each option label", () => {
+    const wrapper = mountControl();
+    OPTIONS.forEach((o) => expect(wrapper.text()).toContain(o.label));
+  });
+
+  it("renders the group label as a legend", () => {
+    const wrapper = mountControl();
+    expect(wrapper.find("legend").text()).toContain("Direction");
+  });
+
+  it("marks the segment matching modelValue as checked", () => {
+    const wrapper = mountControl({ modelValue: "outbound" });
+    const checked = wrapper.find('input[type="radio"]:checked')
+      .element as HTMLInputElement;
+    expect(checked.value).toBe("outbound");
+  });
+
+  it("emits update:modelValue with the option value when a segment is chosen", async () => {
+    const wrapper = mountControl();
+    const inbound = wrapper
+      .findAll('input[type="radio"]')
+      .find((r) => (r.element as HTMLInputElement).value === "inbound")!;
+    await inbound.setValue();
+    expect(wrapper.emitted("update:modelValue")?.[0]).toEqual(["inbound"]);
+  });
+
+  it("supports a neutral empty-value segment", async () => {
+    const wrapper = mountControl({ modelValue: "outbound" });
+    const both = wrapper
+      .findAll('input[type="radio"]')
+      .find((r) => (r.element as HTMLInputElement).value === "")!;
+    await both.setValue();
+    expect(wrapper.emitted("update:modelValue")?.[0]).toEqual([""]);
+  });
+
+  it("disables every radio when disabled", () => {
+    const wrapper = mountControl({ disabled: true });
+    wrapper
+      .findAll('input[type="radio"]')
+      .forEach((r) =>
+        expect((r.element as HTMLInputElement).disabled).toBe(true),
+      );
+  });
+
+  it("groups radios under a shared name", () => {
+    const wrapper = mountControl();
+    const names = wrapper
+      .findAll('input[type="radio"]')
+      .map((r) => (r.element as HTMLInputElement).name);
+    expect(new Set(names).size).toBe(1);
+    expect(names[0]).toBeTruthy();
+  });
+
+  it("marks the group required when required", () => {
+    const wrapper = mountControl({
+      required: true,
+      options: [
+        { value: "outbound", label: "Sent" },
+        { value: "inbound", label: "Received" },
+      ],
+      modelValue: "outbound",
+    });
+    const anyRequired = wrapper
+      .findAll('input[type="radio"]')
+      .some((r) => (r.element as HTMLInputElement).required);
+    expect(anyRequired).toBe(true);
+  });
+
+  it("renders an error message when error is set", () => {
+    const wrapper = mountControl({ error: "Pick a direction" });
+    expect(wrapper.find('[role="alert"]').text()).toContain(
+      "Pick a direction",
+    );
+  });
+});

--- a/tests/unit/components/Interaction/InteractionFilters.spec.ts
+++ b/tests/unit/components/Interaction/InteractionFilters.spec.ts
@@ -29,7 +29,7 @@ describe("InteractionFilters", () => {
       expect(
         wrapper.find('input[placeholder="Subject, content..."]').exists(),
       ).toBe(true);
-      expect(wrapper.findAll("select")).toHaveLength(4); // Type, Direction, Sentiment, Time Period
+      expect(wrapper.findAll("select")).toHaveLength(3); // Type, Sentiment, Time Period (Direction is a segmented control)
       expect(wrapper.text()).toContain("Search");
       expect(wrapper.text()).toContain("Type");
       expect(wrapper.text()).toContain("Direction");
@@ -40,7 +40,7 @@ describe("InteractionFilters", () => {
     it("renders logged by filter when parent", () => {
       const wrapper = createWrapper({ isParent: true });
 
-      expect(wrapper.findAll("select")).toHaveLength(5); // Type, Logged By, Direction, Sentiment, Time Period
+      expect(wrapper.findAll("select")).toHaveLength(4); // Type, Logged By, Sentiment, Time Period (Direction is a segmented control)
       expect(wrapper.text()).toContain("Logged By");
     });
 
@@ -86,16 +86,20 @@ describe("InteractionFilters", () => {
 
     it("renders all direction options", () => {
       const wrapper = createWrapper();
-      const directionSelect = wrapper.findAll("select")[1];
+      const values = wrapper
+        .findAll('input[type="radio"]')
+        .map((r) => r.attributes("value"));
 
-      expect(directionSelect.html()).toContain("-- All --");
-      expect(directionSelect.html()).toContain("Outbound");
-      expect(directionSelect.html()).toContain("Inbound");
+      expect(values).toContain("");
+      expect(values).toContain("outbound");
+      expect(values).toContain("inbound");
+      expect(wrapper.text()).toContain("Outbound");
+      expect(wrapper.text()).toContain("Inbound");
     });
 
     it("renders all sentiment options", () => {
       const wrapper = createWrapper();
-      const sentimentSelect = wrapper.findAll("select")[2];
+      const sentimentSelect = wrapper.find("#filter-sentiment");
 
       expect(sentimentSelect.html()).toContain("-- All --");
       expect(sentimentSelect.html()).toContain("Very Positive");
@@ -106,7 +110,7 @@ describe("InteractionFilters", () => {
 
     it("renders all time period options", () => {
       const wrapper = createWrapper();
-      const timePeriodSelect = wrapper.findAll("select")[3];
+      const timePeriodSelect = wrapper.find("#filter-time-period");
 
       expect(timePeriodSelect.html()).toContain("-- All Time --");
       expect(timePeriodSelect.html()).toContain("Last 7 days");
@@ -212,17 +216,16 @@ describe("InteractionFilters", () => {
       const filterValues = new Map([["direction", "inbound"]]);
       const wrapper = createWrapper({ filterValues });
 
-      const directionSelect = wrapper.findAll("select")[1];
-      expect((directionSelect.element as HTMLSelectElement).value).toBe(
-        "inbound",
-      );
+      const checked = wrapper.find('input[type="radio"]:checked')
+        .element as HTMLInputElement;
+      expect(checked.value).toBe("inbound");
     });
 
     it("displays current sentiment value", () => {
       const filterValues = new Map([["sentiment", "positive"]]);
       const wrapper = createWrapper({ filterValues });
 
-      const sentimentSelect = wrapper.findAll("select")[2];
+      const sentimentSelect = wrapper.find("#filter-sentiment");
       expect((sentimentSelect.element as HTMLSelectElement).value).toBe(
         "positive",
       );
@@ -232,7 +235,7 @@ describe("InteractionFilters", () => {
       const filterValues = new Map([["timePeriod", "30"]]);
       const wrapper = createWrapper({ filterValues });
 
-      const timePeriodSelect = wrapper.findAll("select")[3];
+      const timePeriodSelect = wrapper.find("#filter-time-period");
       expect((timePeriodSelect.element as HTMLSelectElement).value).toBe("30");
     });
 
@@ -254,7 +257,7 @@ describe("InteractionFilters", () => {
         ],
       });
 
-      const loggedBySelect = wrapper.findAll("select")[1];
+      const loggedBySelect = wrapper.find("#filter-logged-by");
       expect((loggedBySelect.element as HTMLSelectElement).value).toBe(
         "athlete-1",
       );
@@ -302,9 +305,11 @@ describe("InteractionFilters", () => {
 
     it("emits update:filter when direction changes", async () => {
       const wrapper = createWrapper();
-      const directionSelect = wrapper.findAll("select")[1];
+      const outbound = wrapper
+        .findAll('input[type="radio"]')
+        .find((r) => r.attributes("value") === "outbound")!;
 
-      await directionSelect.setValue("outbound");
+      await outbound.setValue();
 
       expect(wrapper.emitted("update:filter")).toBeTruthy();
       expect(wrapper.emitted("update:filter")![0]).toEqual([
@@ -314,7 +319,7 @@ describe("InteractionFilters", () => {
 
     it("emits update:filter when sentiment changes", async () => {
       const wrapper = createWrapper();
-      const sentimentSelect = wrapper.findAll("select")[2];
+      const sentimentSelect = wrapper.find("#filter-sentiment");
 
       await sentimentSelect.setValue("positive");
 
@@ -326,7 +331,7 @@ describe("InteractionFilters", () => {
 
     it("emits update:filter when time period changes", async () => {
       const wrapper = createWrapper();
-      const timePeriodSelect = wrapper.findAll("select")[3];
+      const timePeriodSelect = wrapper.find("#filter-time-period");
 
       await timePeriodSelect.setValue("30");
 
@@ -352,7 +357,7 @@ describe("InteractionFilters", () => {
         ],
       });
 
-      const loggedBySelect = wrapper.findAll("select")[1];
+      const loggedBySelect = wrapper.find("#filter-logged-by");
       await loggedBySelect.setValue("athlete-1");
 
       expect(wrapper.emitted("update:filter")).toBeTruthy();
@@ -373,8 +378,10 @@ describe("InteractionFilters", () => {
       expect(wrapper.html()).toContain('id="filter-type"');
       expect(wrapper.html()).toContain('for="filter-logged-by"');
       expect(wrapper.html()).toContain('id="filter-logged-by"');
-      expect(wrapper.html()).toContain('for="filter-direction"');
-      expect(wrapper.html()).toContain('id="filter-direction"');
+      // Direction is a segmented control: labelled by its <legend>, not a for= label.
+      expect(
+        wrapper.findAll("legend").some((l) => l.text().includes("Direction")),
+      ).toBe(true);
       expect(wrapper.html()).toContain('for="filter-sentiment"');
       expect(wrapper.html()).toContain('id="filter-sentiment"');
       expect(wrapper.html()).toContain('for="filter-time-period"');

--- a/tests/unit/components/Interactions/InteractionAddForm.spec.ts
+++ b/tests/unit/components/Interactions/InteractionAddForm.spec.ts
@@ -36,7 +36,13 @@ describe("InteractionAddForm Component", () => {
       });
 
       expect(wrapper.find('select[id="type"]').exists()).toBe(true);
-      expect(wrapper.find('select[id="direction"]').exists()).toBe(true);
+      // Direction is a segmented control (radios), not a <select>.
+      expect(
+        wrapper.findAll('input[type="radio"]').some((r) => {
+          const v = r.attributes("value");
+          return v === "outbound" || v === "inbound";
+        }),
+      ).toBe(true);
       expect(wrapper.find('textarea[id="content"]').exists()).toBe(true);
       expect(wrapper.find('input[id="occurred_at"]').exists()).toBe(true);
     });
@@ -114,8 +120,13 @@ describe("InteractionAddForm Component", () => {
         props: { coaches: mockCoaches, loading: false },
       });
 
-      const directionSelect = wrapper.find('select[id="direction"]');
-      expect(directionSelect.attributes("required")).toBeDefined();
+      const directionRadios = wrapper
+        .findAll('input[type="radio"]')
+        .filter((r) => ["outbound", "inbound"].includes(r.attributes("value")!));
+      expect(directionRadios.length).toBeGreaterThan(0);
+      expect(
+        directionRadios.every((r) => r.attributes("required") != null),
+      ).toBe(true);
     });
 
     it("should require content field", async () => {
@@ -197,7 +208,10 @@ describe("InteractionAddForm Component", () => {
 
       // Fill form
       await wrapper.find('select[id="type"]').setValue("email");
-      await wrapper.find('select[id="direction"]').setValue("outbound");
+      await wrapper
+        .findAll('input[type="radio"]')
+        .find((r) => r.attributes("value") === "outbound")!
+        .setValue();
       await wrapper.find('textarea[id="content"]').setValue("Test content");
       await wrapper
         .find('input[id="occurred_at"]')

--- a/tests/unit/components/Interactions/InteractionFiltersBar.spec.ts
+++ b/tests/unit/components/Interactions/InteractionFiltersBar.spec.ts
@@ -1,6 +1,19 @@
 import { describe, it, expect } from "vitest";
-import { mount } from "@vue/test-utils";
+import { mount, type VueWrapper } from "@vue/test-utils";
 import InteractionFiltersBar from "~/components/Interactions/InteractionFiltersBar.vue";
+
+// Direction is a segmented control (radios), not a <select>.
+const directionRadios = (wrapper: VueWrapper) =>
+  wrapper
+    .findAll('input[type="radio"]')
+    .filter((r) => ["", "outbound", "inbound"].includes(r.attributes("value")!));
+
+const checkedDirection = (wrapper: VueWrapper) =>
+  (
+    directionRadios(wrapper).find(
+      (r) => (r.element as HTMLInputElement).checked,
+    )?.element as HTMLInputElement | undefined
+  )?.value ?? "";
 
 describe("InteractionFiltersBar Component", () => {
   describe("Rendering", () => {
@@ -15,7 +28,7 @@ describe("InteractionFiltersBar Component", () => {
       });
 
       expect(wrapper.find("#type-filter").exists()).toBe(true);
-      expect(wrapper.find("#direction-filter").exists()).toBe(true);
+      expect(directionRadios(wrapper).length).toBe(3);
       expect(wrapper.find("#date-filter").exists()).toBe(true);
       expect(wrapper.find("#sentiment-filter").exists()).toBe(true);
     });
@@ -122,13 +135,10 @@ describe("InteractionFiltersBar Component", () => {
         },
       });
 
-      const directionFilter = wrapper.find("#direction-filter");
-      const options = directionFilter.findAll("option");
-
-      expect(options.length).toBe(3); // Both + Outbound + Inbound
-      expect(directionFilter.text()).toContain("Both");
-      expect(directionFilter.text()).toContain("Sent by Us");
-      expect(directionFilter.text()).toContain("Received");
+      expect(directionRadios(wrapper).length).toBe(3); // Both + Outbound + Inbound
+      expect(wrapper.text()).toContain("Both");
+      expect(wrapper.text()).toContain("Sent by Us");
+      expect(wrapper.text()).toContain("Received");
     });
 
     it("should emit update:selectedDirection when direction changes", async () => {
@@ -141,8 +151,10 @@ describe("InteractionFiltersBar Component", () => {
         },
       });
 
-      const directionFilter = wrapper.find("#direction-filter");
-      await directionFilter.setValue("outbound");
+      const outbound = directionRadios(wrapper).find(
+        (r) => r.attributes("value") === "outbound",
+      )!;
+      await outbound.setValue();
 
       expect(wrapper.emitted("update:selectedDirection")).toBeTruthy();
       expect(wrapper.emitted("update:selectedDirection")?.[0]).toEqual([
@@ -160,10 +172,7 @@ describe("InteractionFiltersBar Component", () => {
         },
       });
 
-      const directionFilter = wrapper.find("#direction-filter");
-      expect((directionFilter.element as HTMLSelectElement).value).toBe(
-        "inbound",
-      );
+      expect(checkedDirection(wrapper)).toBe("inbound");
     });
   });
 
@@ -326,14 +335,11 @@ describe("InteractionFiltersBar Component", () => {
       });
 
       const typeFilter = wrapper.find("#type-filter");
-      const directionFilter = wrapper.find("#direction-filter");
       const dateFilter = wrapper.find("#date-filter");
       const sentimentFilter = wrapper.find("#sentiment-filter");
 
       expect((typeFilter.element as HTMLSelectElement).value).toBe("email");
-      expect((directionFilter.element as HTMLSelectElement).value).toBe(
-        "outbound",
-      );
+      expect(checkedDirection(wrapper)).toBe("outbound");
       expect((dateFilter.element as HTMLSelectElement).value).toBe("7");
       expect((sentimentFilter.element as HTMLSelectElement).value).toBe(
         "positive",
@@ -351,7 +357,9 @@ describe("InteractionFiltersBar Component", () => {
       });
 
       await wrapper.find("#type-filter").setValue("email");
-      await wrapper.find("#direction-filter").setValue("outbound");
+      await directionRadios(wrapper)
+        .find((r) => r.attributes("value") === "outbound")!
+        .setValue();
       await wrapper.find("#date-filter").setValue("30");
 
       expect(wrapper.emitted("update:selectedType")).toBeTruthy();
@@ -390,12 +398,11 @@ describe("InteractionFiltersBar Component", () => {
       });
 
       const typeFilter = wrapper.find("#type-filter");
-      const directionFilter = wrapper.find("#direction-filter");
       const dateFilter = wrapper.find("#date-filter");
       const sentimentFilter = wrapper.find("#sentiment-filter");
 
       expect((typeFilter.element as HTMLSelectElement).value).toBe("");
-      expect((directionFilter.element as HTMLSelectElement).value).toBe("");
+      expect(checkedDirection(wrapper)).toBe("");
       expect((dateFilter.element as HTMLSelectElement).value).toBe("");
       expect((sentimentFilter.element as HTMLSelectElement).value).toBe("");
     });
@@ -413,14 +420,17 @@ describe("InteractionFiltersBar Component", () => {
       });
 
       const typeLabel = wrapper.find('label[for="type-filter"]');
-      const directionLabel = wrapper.find('label[for="direction-filter"]');
       const dateLabel = wrapper.find('label[for="date-filter"]');
       const sentimentLabel = wrapper.find('label[for="sentiment-filter"]');
 
       expect(typeLabel.exists()).toBe(true);
-      expect(directionLabel.exists()).toBe(true);
       expect(dateLabel.exists()).toBe(true);
       expect(sentimentLabel.exists()).toBe(true);
+      // Direction is a segmented control: labelled by its <legend>, not a for= label.
+      const directionLegend = wrapper
+        .findAll("legend")
+        .find((l) => l.text().includes("Direction"));
+      expect(directionLegend).toBeTruthy();
     });
 
     it("should have proper ids on all select elements", () => {
@@ -434,7 +444,7 @@ describe("InteractionFiltersBar Component", () => {
       });
 
       expect(wrapper.find("#type-filter").exists()).toBe(true);
-      expect(wrapper.find("#direction-filter").exists()).toBe(true);
+      expect(directionRadios(wrapper).length).toBe(3);
       expect(wrapper.find("#date-filter").exists()).toBe(true);
       expect(wrapper.find("#sentiment-filter").exists()).toBe(true);
     });


### PR DESCRIPTION
## What

Replaces six interaction **Direction** dropdowns with a reusable segmented control. Addresses the *"few options → use radios"* dropdown anti-pattern: a 2–4 option single-select shouldn't be a `<select>`.

### Component
`components/DesignSystem/Form/FormSegmentedControl.vue` — styled **native radios** in a `fieldset`/`legend` (free keyboard nav + screen-reader semantics, near-zero JS).
- Props mirror `FormSelect`: `modelValue`, `label`, `options`, `required`, `disabled`, `error`, plus `size: sm|md`
- Emits `update:modelValue`, `blur`
- Neutral filter segment is just an option with `value: ""`

### Migrated (same string values — no store/API change)
| Site | Shape |
|---|---|
| `Interactions/InteractionFiltersBar` | filter 3-way (sm) |
| `Interaction/InteractionFilters` | filter 3-way (sm) |
| `Search/AdvancedFilters` | filter 3-way (sm) |
| `coaches/[id]/communications` | filter 3-way (sm) |
| `Interactions/InteractionAddForm` | form 2-way, required (md) |
| `Events/EventQuickLogModal` | form 2-way (md) |

Excluded: `offers/index.vue` sortDirection (different bucket, later).

## Tests
- New unit (10) + a11y (3) specs for the component
- Registered the component globally in `tests/setup.ts` (vitest has no Nuxt auto-import)
- Migrated 3 affected specs from `<select>`/combobox assertions to radio markup

## Verification
- `type-check`, `lint`, `audit:tokens` — clean
- Full unit suite: **7987 passed / 0 failed**
- Browser-verified live on `/interactions` (demo account): selecting a segment filters correctly, active-filter chip appears, **zero console errors**

## Follow-ups (primitive now exists to reuse)
- coach-role selects (5 copies) → radio group
- sort-direction 2-opt → toggle
- bucket-4 entity pickers (school/coach) → typeahead

https://claude.ai/code/session_01NdorsLtFCeyp6npEmv19rW