### PR TITLE
feat(ui): segmented control for offers sort-direction + video platform

### DIFF
--- a/components/DesignSystem/Form/FormSegmentedControl.vue
+++ b/components/DesignSystem/Form/FormSegmentedControl.vue
@@ -15,6 +15,12 @@ interface Props {
   disabled?: boolean;
   error?: string;
   size?: "sm" | "md";
+  /** Fill the container width with equal segments (default). Set false to
+   *  size to content when placed inline beside other controls. */
+  block?: boolean;
+  /** Visually hide the legend while keeping it for screen readers. Use when
+   *  the group sits inline and its purpose is clear from context. */
+  hideLabel?: boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -23,6 +29,8 @@ const props = withDefaults(defineProps<Props>(), {
   disabled: false,
   error: "",
   size: "md",
+  block: true,
+  hideLabel: false,
 });
 
 const emit = defineEmits<{
@@ -50,21 +58,31 @@ const select = (value: string) => {
     :aria-invalid="!!error || undefined"
     class="min-w-0 border-0 p-0"
   >
-    <legend class="block text-sm font-medium text-slate-700 mb-2">
+    <legend
+      :class="
+        hideLabel
+          ? 'sr-only'
+          : 'block text-sm font-medium text-slate-700 mb-2'
+      "
+    >
       {{ label }}
       <span v-if="required" class="text-red-500" aria-hidden="true">*</span>
       <span v-if="required" class="sr-only">(required)</span>
     </legend>
 
     <div
-      class="flex w-full gap-1 rounded-xl border-2 bg-white p-1"
-      :class="error ? 'border-red-500' : 'border-slate-300'"
+      class="gap-1 rounded-xl border-2 bg-white p-1"
+      :class="[
+        block ? 'flex w-full' : 'inline-flex',
+        error ? 'border-red-500' : 'border-slate-300',
+      ]"
     >
       <label
         v-for="option in options"
         :key="option.value"
-        class="flex-1 cursor-pointer rounded-lg text-center font-medium whitespace-nowrap transition-colors select-none focus-within:ring-2 focus-within:ring-blue-500"
+        class="cursor-pointer rounded-lg text-center font-medium whitespace-nowrap transition-colors select-none focus-within:ring-2 focus-within:ring-blue-500"
         :class="[
+          block ? 'flex-1' : '',
           segmentPadding,
           modelValue === option.value
             ? 'bg-blue-600 text-white shadow-xs'

--- a/components/Settings/PlayerDetailsAthleticsTab.vue
+++ b/components/Settings/PlayerDetailsAthleticsTab.vue
@@ -323,23 +323,26 @@
           :key="link.id"
           class="flex items-center gap-3"
         >
-          <select
-            :value="link.platform"
+          <DesignSystemFormSegmentedControl
+            label="Video platform"
+            hide-label
+            :block="false"
+            size="sm"
+            :model-value="link.platform"
             :disabled="isParentRole"
-            @change="
-              (e) =>
+            :options="[
+              { value: 'hudl', label: 'Hudl' },
+              { value: 'youtube', label: 'YouTube' },
+              { value: 'vimeo', label: 'Vimeo' },
+              { value: 'other', label: 'Other' },
+            ]"
+            @update:model-value="
+              (v) =>
                 handleUpdate(link.id, {
-                  platform: (e.target as HTMLSelectElement).value as
-                    'hudl' | 'youtube' | 'vimeo' | 'other',
+                  platform: v as 'hudl' | 'youtube' | 'vimeo' | 'other',
                 })
             "
-            class="px-3 py-2.5 bg-slate-50 border border-slate-200 rounded-xl text-sm font-medium text-slate-700 focus:ring-2 focus:ring-blue-500 transition disabled:opacity-50"
-          >
-            <option value="hudl">Hudl</option>
-            <option value="youtube">YouTube</option>
-            <option value="vimeo">Vimeo</option>
-            <option value="other">Other</option>
-          </select>
+          />
           <input
             :value="link.url"
             :disabled="isParentRole"
@@ -383,15 +386,22 @@
           v-if="!isParentRole && videoLinks.links.value.length < 5"
           class="flex items-center gap-3"
         >
-          <select
-            v-model="newLinkPlatform"
-            class="px-3 py-2.5 bg-slate-50 border border-slate-200 rounded-xl text-sm font-medium text-slate-700 focus:ring-2 focus:ring-blue-500 transition"
-          >
-            <option value="hudl">Hudl</option>
-            <option value="youtube">YouTube</option>
-            <option value="vimeo">Vimeo</option>
-            <option value="other">Other</option>
-          </select>
+          <DesignSystemFormSegmentedControl
+            label="Video platform"
+            hide-label
+            :block="false"
+            size="sm"
+            :model-value="newLinkPlatform"
+            :options="[
+              { value: 'hudl', label: 'Hudl' },
+              { value: 'youtube', label: 'YouTube' },
+              { value: 'vimeo', label: 'Vimeo' },
+              { value: 'other', label: 'Other' },
+            ]"
+            @update:model-value="
+              (v) => (newLinkPlatform = v as 'hudl' | 'youtube' | 'vimeo' | 'other')
+            "
+          />
           <input
             v-model="newLinkUrl"
             type="url"

--- a/pages/offers/index.vue
+++ b/pages/offers/index.vue
@@ -319,18 +319,15 @@
               <option value="scholarship_amount">Amount</option>
             </select>
           </div>
-          <div>
-            <label class="block text-sm font-medium text-slate-700 mb-1"
-              >Direction</label
-            >
-            <select
-              v-model="filters.sortDirection"
-              class="w-full px-3 py-2 border border-slate-300 rounded-lg text-sm focus:ring-2 focus:ring-blue-500"
-            >
-              <option value="desc">Newest First</option>
-              <option value="asc">Oldest First</option>
-            </select>
-          </div>
+          <DesignSystemFormSegmentedControl
+            v-model="filters.sortDirection"
+            label="Direction"
+            size="sm"
+            :options="[
+              { value: 'desc', label: 'Newest First' },
+              { value: 'asc', label: 'Oldest First' },
+            ]"
+          />
         </div>
       </div>
 

--- a/tests/unit/components/FormSegmentedControl.spec.ts
+++ b/tests/unit/components/FormSegmentedControl.spec.ts
@@ -100,4 +100,27 @@ describe("FormSegmentedControl", () => {
       "Pick a direction",
     );
   });
+
+  it("fills width with equal segments by default (block)", () => {
+    const wrapper = mountControl();
+    const container = wrapper.find("fieldset > div");
+    expect(container.classes()).toContain("w-full");
+    expect(wrapper.find("label").classes()).toContain("flex-1");
+  });
+
+  it("sizes to content when block is false", () => {
+    const wrapper = mountControl({ block: false });
+    const container = wrapper.find("fieldset > div");
+    expect(container.classes()).toContain("inline-flex");
+    expect(container.classes()).not.toContain("w-full");
+    expect(wrapper.find("label").classes()).not.toContain("flex-1");
+  });
+
+  it("keeps the legend for screen readers but hides it visually when hideLabel", () => {
+    const wrapper = mountControl({ hideLabel: true });
+    const legend = wrapper.find("legend");
+    expect(legend.exists()).toBe(true);
+    expect(legend.text()).toContain("Direction");
+    expect(legend.classes()).toContain("sr-only");
+  });
 });


### PR DESCRIPTION
Follow-up to #406 (Direction migration). Extends `FormSegmentedControl` and migrates the two remaining short-label dropdowns that genuinely fit the segmented pattern.

## Component
- **`block`** (default `true`) — fill width with equal segments; set `false` to size to content when placed inline beside other controls
- **`hideLabel`** — keep the `<legend>` for screen readers but hide it visually

## Migrated
- `offers/index` **sort-direction** (Newest / Oldest First) — 2-seg filter, fills its column
- `PlayerDetailsAthleticsTab` **video platform** ×2 (Hudl / YouTube / Vimeo / Other) — inline `:block="false"` beside the URL input, matches the existing Bats/Throws pill language

## Deliberately NOT migrated (dropdown is the right control)
Closer read showed the flat "4 options → segmented" heuristic fails on context:
- **coach-role** (5 sites) — long labels ("Recruiting Coordinator") overflow a segmented row
- **height feet** — `number`-typed and paired with a 12-option inches select; segmenting only the feet half breaks the pair
- **campus size** — long labels ("Small (<5,000 students)") + one branch of a dynamic type-morph select

## Verification
- `type-check`, `lint`, `audit:tokens` — clean
- Full unit suite: **7990 passed / 0 failed** (+3 component specs: block fill/content, hideLabel)
- Browser-verified live on `/offers` and the athletics tab — renders correctly, **zero console errors**

https://claude.ai/code/session_01NdorsLtFCeyp6npEmv19rW