### PR TITLE
test(e2e): auto-reap test-account debris via globalTeardown

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   workers: process.env.CI ? 2 : 4,
   reporter: "html",
   globalSetup: "./tests/e2e/global-setup.ts",
+  globalTeardown: "./tests/e2e/global-teardown.ts",
   timeout: 30000, // 30s per test — player auth state cached globally via storageState
 
   use: {

--- a/scripts/e2e-cleanup-users.ts
+++ b/scripts/e2e-cleanup-users.ts
@@ -1,13 +1,10 @@
 /**
- * Targeted cleanup of E2E test users accumulated in auth.users.
+ * Manual backlog purge of E2E test users accumulated in auth.users.
  *
- * Background:
- *   Many E2E specs create one-off auth users (signup tests, password-reset
- *   tests, parent/player provisioning, etc.) but never clean them up. The
- *   local DB now carries 1000+ stale users. supabase.auth.admin.listUsers()
- *   caps perPage at 1000, so our well-known test accounts can fall off the
- *   first page and existing helpers silently return undefined. The admin
- *   page also hangs while paginating through them all.
+ * Debris identification + deletion logic lives in the shared helper
+ * `tests/e2e/seed/helpers/debris.ts` (also used by the automatic
+ * global-teardown). This script is the manual, dry-run-by-default entry point
+ * for clearing an existing backlog.
  *
  * Usage:
  *   npx tsx scripts/e2e-cleanup-users.ts             # default: dry-run
@@ -17,71 +14,22 @@
  *
  * Safety:
  *   - Default mode is dry-run; --execute is required to delete.
- *   - PROTECT_EMAILS is an absolute deny-list and trumps any pattern match.
- *   - Pattern matches are conservative (require an epoch-ish timestamp in
- *     the local-part) to avoid catching real users with similar prefixes.
+ *   - reapDebris aborts if any protected (fixed TEST_ACCOUNTS) email matched.
+ *   - Also sweeps orphan family_units left behind by deleteUser.
  */
 import { config } from "dotenv";
 import { resolve } from "path";
 import { getSupabaseAdmin } from "../tests/e2e/seed/helpers/supabase-admin";
-import { TEST_ACCOUNTS } from "../tests/e2e/config/test-accounts";
+import {
+  isDebris,
+  listAllAuthUsers,
+  reapDebris,
+} from "../tests/e2e/seed/helpers/debris";
 
 config({ path: resolve(process.cwd(), ".env") });
 config({ path: resolve(process.cwd(), ".env.local") });
 
 const EXECUTE = process.argv.includes("--execute");
-
-// Hard deny-list: these accounts are NEVER deleted even if they match a
-// pattern below.
-const PROTECT_EMAILS = new Set<string>([
-  TEST_ACCOUNTS.player.email,
-  TEST_ACCOUNTS.parent.email,
-  TEST_ACCOUNTS.admin.email,
-  TEST_ACCOUNTS.iosParent.email,
-]);
-
-// Match emails created by E2E spec runs. Patterns require a 10+ digit run
-// id (epoch ms) in the local-part to avoid catching real users.
-const TEST_USER_PATTERNS = [
-  // Anything in the @example.com / @test-example.com sandboxes with an epoch
-  // timestamp is unambiguously test debris (no real users live there).
-  /^[a-z0-9._+-]+\d{10,}[a-z0-9._-]*@(test-)?example\.com$/i,
-  // Cross-domain explicit prefixes (in case any leaked to other domains).
-  /^test-[a-z-]+-\d{10,}@/i,
-  /^e2e-[a-z-]*-?\d{10,}@/i,
-  /^parent-e2e-\d{10,}@/i,
-  /^player-e2e-\d{10,}@/i,
-  /^test\.player\d+@andrikanich\.com$/i,
-];
-
-function isDebris(email: string | null | undefined): boolean {
-  if (!email) return false;
-  if (PROTECT_EMAILS.has(email)) return false;
-  return TEST_USER_PATTERNS.some((p) => p.test(email));
-}
-
-async function listAllAuthUsers(supabase: ReturnType<typeof getSupabaseAdmin>) {
-  const all: { id: string; email: string | null }[] = [];
-  let page = 1;
-  const MAX_PAGES = 50;
-  while (page <= MAX_PAGES) {
-    const { data, error } = await supabase.auth.admin.listUsers({
-      page,
-      perPage: 1000,
-    });
-    if (error) {
-      console.error(`listUsers page ${page} failed:`, error.message);
-      break;
-    }
-    const users = data?.users ?? [];
-    for (const u of users) {
-      all.push({ id: u.id, email: u.email ?? null });
-    }
-    if (users.length < 1000) break;
-    page++;
-  }
-  return all;
-}
 
 async function main() {
   const supabase = getSupabaseAdmin();
@@ -105,62 +53,17 @@ async function main() {
     console.log(`  …and ${debris.length - sample.length} more`);
   }
 
-  // Sanity check: refuse to proceed if any protected email matched.
-  const protectedMatches = debris.filter(
-    (u) => u.email && PROTECT_EMAILS.has(u.email),
-  );
-  if (protectedMatches.length > 0) {
-    console.error(
-      `❌ ABORT: matched ${protectedMatches.length} protected emails — pattern is too broad. ` +
-        `First: ${protectedMatches[0].email}`,
-    );
-    process.exit(1);
-  }
-
   if (!EXECUTE) {
     console.log("\n🔎 Dry run — pass --execute to actually delete");
     return;
   }
 
-  console.log("\n🧹 Deleting (with retry + pacing)…");
-  let deleted = 0;
-  let failed = 0;
-  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
-  for (let i = 0; i < debris.length; i++) {
-    const u = debris[i];
-    let lastErr: unknown = null;
-    for (let attempt = 0; attempt < 3; attempt++) {
-      const { error } = await supabase.auth.admin.deleteUser(u.id);
-      if (!error) {
-        deleted++;
-        lastErr = null;
-        break;
-      }
-      lastErr = error;
-      // Connect-timeout / 5xx: back off and retry.
-      await sleep(500 * (attempt + 1));
-    }
-    if (lastErr) {
-      failed++;
-      if (failed <= 5) {
-        const msg =
-          lastErr && typeof lastErr === "object" && "message" in lastErr
-            ? (lastErr as { message?: string }).message
-            : String(lastErr);
-        console.warn(`  ⚠️  ${u.email}: ${msg}`);
-      }
-    }
-    // Pace ~20 req/s to stay under Supabase admin limits.
-    await sleep(50);
-    if ((i + 1) % 50 === 0 || i === debris.length - 1) {
-      process.stdout.write(
-        `\r  ${i + 1}/${debris.length} (${deleted} ok, ${failed} fail)`,
-      );
-    }
-  }
-  process.stdout.write("\n");
-  console.log(`✅ Deleted ${deleted} users (${failed} failures)`);
+  console.log("\n🧹 Deleting debris users + orphan family_units…");
+  const r = await reapDebris(supabase, { execute: true });
+  console.log(
+    `✅ Deleted ${r.deletedUsers} users (${r.failedUsers} failures) ` +
+      `+ ${r.deletedUnits} orphan family_units`,
+  );
 }
 
 main().catch((err) => {

--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -1,0 +1,41 @@
+import type { FullConfig } from "@playwright/test";
+import { config } from "dotenv";
+import { resolve } from "path";
+import { getSupabaseAdmin } from "./seed/helpers/supabase-admin";
+import { reapDebris } from "./seed/helpers/debris";
+
+// Load Supabase credentials the same way global-setup does.
+config({ path: resolve(process.cwd(), ".env") });
+config({ path: resolve(process.cwd(), ".env.local") });
+
+/**
+ * Reap E2E debris after the run so the shared prod DB does not accumulate the
+ * one-off accounts specs create-without-teardown. Non-fatal by design: a
+ * cleanup failure must never fail an otherwise-green E2E run. Set
+ * E2E_SKIP_TEARDOWN=1 to disable (e.g. when debugging leaked data).
+ */
+async function globalTeardown(_config: FullConfig): Promise<void> {
+  if (process.env.E2E_SKIP_TEARDOWN === "1") {
+    console.log("🧹 E2E teardown skipped (E2E_SKIP_TEARDOWN=1)");
+    return;
+  }
+
+  console.log("🧹 E2E Global Teardown — reaping test debris...");
+  try {
+    const r = await reapDebris(getSupabaseAdmin(), { execute: true });
+    if (r.matched === 0) {
+      console.log("  ✅ No debris to reap");
+      return;
+    }
+    console.log(
+      `  ✅ Reaped ${r.deletedUsers}/${r.matched} debris users ` +
+        `(${r.failedUsers} failed) + ${r.deletedUnits} orphan family_units`,
+    );
+  } catch (error) {
+    // Never fail the run on cleanup — surface and move on.
+    const msg = error instanceof Error ? error.message : String(error);
+    console.warn(`  ⚠️  Teardown reap failed (non-fatal): ${msg}`);
+  }
+}
+
+export default globalTeardown;

--- a/tests/e2e/seed/helpers/debris.ts
+++ b/tests/e2e/seed/helpers/debris.ts
@@ -1,0 +1,232 @@
+/**
+ * Shared identification + reaping of E2E test debris.
+ *
+ * E2E runs against the live Supabase project (TEST_SUPABASE_URL is optional and
+ * falls back to the prod URL). Many specs mint one-off auth users with an epoch
+ * timestamp in the local-part and never delete them. Left unchecked they
+ * accumulate unbounded (hit 768 users / 744 family_units once), pollute the
+ * admin dashboard + growth analytics, and eventually push the well-known test
+ * accounts off listUsers()'s first 1000-row page.
+ *
+ * This module is the single source of truth for "what is debris" and "how to
+ * reap it", shared by:
+ *   - tests/e2e/global-teardown.ts  (runs automatically after every E2E run)
+ *   - scripts/e2e-cleanup-users.ts  (manual backlog purge, dry-run by default)
+ *
+ * Safety model:
+ *   - PROTECT_EMAILS is an absolute deny-list (the fixed TEST_ACCOUNTS).
+ *   - Patterns require a 10+ digit epoch in the local-part, so they cannot
+ *     match a real user who merely shares a prefix.
+ *   - reapDebris aborts before deleting if any protected email matched (proof
+ *     the pattern set has become too broad).
+ *   - deleteUser cascades public.users + family_members + child rows, but NOT
+ *     family_units — so we sweep member-less family_units as a second pass.
+ */
+import { TEST_ACCOUNTS } from "../../config/test-accounts";
+import type { getSupabaseAdmin } from "./supabase-admin";
+
+type Admin = ReturnType<typeof getSupabaseAdmin>;
+
+/** Fixed accounts that must NEVER be deleted, even if a pattern matches. */
+export const PROTECT_EMAILS = new Set<string>(
+  Object.values(TEST_ACCOUNTS).map((a) => a.email),
+);
+
+/**
+ * Emails created by E2E spec runs. Every pattern requires a 10+ digit run id
+ * (epoch ms) in the local-part to avoid catching real users.
+ */
+export const TEST_USER_PATTERNS: RegExp[] = [
+  // @example.com / @test-example.com sandboxes with an epoch timestamp — no
+  // real users live there, so this is unambiguously test debris.
+  /^[a-z0-9._+-]+\d{10,}[a-z0-9._-]*@(test-)?example\.com$/i,
+  // Cross-domain explicit prefixes (in case any leaked to other domains).
+  /^test-[a-z-]+-\d{10,}@/i,
+  /^e2e-[a-z-]*-?\d{10,}@/i,
+  /^parent-e2e-\d{10,}@/i,
+  /^player-e2e-\d{10,}@/i,
+  /^test\.player\d+@andrikanich\.com$/i,
+];
+
+export function isDebris(email: string | null | undefined): boolean {
+  if (!email) return false;
+  if (PROTECT_EMAILS.has(email)) return false;
+  return TEST_USER_PATTERNS.some((p) => p.test(email));
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Page through auth.users (listUsers caps perPage at 1000). */
+export async function listAllAuthUsers(
+  supabase: Admin,
+): Promise<{ id: string; email: string | null }[]> {
+  const all: { id: string; email: string | null }[] = [];
+  const MAX_PAGES = 50;
+  for (let page = 1; page <= MAX_PAGES; page++) {
+    const { data, error } = await supabase.auth.admin.listUsers({
+      page,
+      perPage: 1000,
+    });
+    if (error) {
+      console.error(`listUsers page ${page} failed:`, error.message);
+      break;
+    }
+    const users = data?.users ?? [];
+    for (const u of users) all.push({ id: u.id, email: u.email ?? null });
+    if (users.length < 1000) break;
+  }
+  return all;
+}
+
+/** Delete family_invitations sent by any of the given user ids (chunked). */
+async function deleteInvitationsBy(
+  supabase: Admin,
+  userIds: string[],
+): Promise<void> {
+  const CHUNK = 100;
+  for (let i = 0; i < userIds.length; i += CHUNK) {
+    const chunk = userIds.slice(i, i + CHUNK);
+    const { error } = await supabase
+      .from("family_invitations")
+      .delete()
+      .in("invited_by", chunk);
+    if (error) {
+      console.warn(`  ⚠️  delete family_invitations chunk: ${error.message}`);
+    }
+  }
+}
+
+/**
+ * Delete family_units that have no remaining members. deleteUser cascades
+ * family_members but leaves the parent family_unit as an orphan shell; this
+ * reaps those. A unit still holding child rows (schools/interactions/etc) will
+ * FK-block its own delete — that is logged and skipped, never fatal.
+ */
+async function deleteEmptyFamilyUnits(supabase: Admin): Promise<number> {
+  const { data: units, error: unitsErr } = await supabase
+    .from("family_units")
+    .select("id");
+  if (unitsErr || !units) {
+    if (unitsErr) console.warn(`  ⚠️  list family_units: ${unitsErr.message}`);
+    return 0;
+  }
+
+  const { data: members, error: membersErr } = await supabase
+    .from("family_members")
+    .select("family_unit_id");
+  if (membersErr) {
+    console.warn(`  ⚠️  list family_members: ${membersErr.message}`);
+    return 0;
+  }
+  const occupied = new Set(
+    (members ?? []).map((m: { family_unit_id: string }) => m.family_unit_id),
+  );
+  const emptyIds = units
+    .map((u: { id: string }) => u.id)
+    .filter((id: string) => !occupied.has(id));
+  if (emptyIds.length === 0) return 0;
+
+  let deleted = 0;
+  const CHUNK = 100;
+  for (let i = 0; i < emptyIds.length; i += CHUNK) {
+    const chunk = emptyIds.slice(i, i + CHUNK);
+    const { error } = await supabase
+      .from("family_units")
+      .delete()
+      .in("id", chunk);
+    if (error) {
+      console.warn(`  ⚠️  delete family_units chunk: ${error.message}`);
+      continue;
+    }
+    deleted += chunk.length;
+  }
+  return deleted;
+}
+
+export interface ReapResult {
+  totalUsers: number;
+  matched: number;
+  deletedUsers: number;
+  failedUsers: number;
+  deletedUnits: number;
+  dryRun: boolean;
+}
+
+/**
+ * Identify and (when execute=true) delete debris users + orphan family_units.
+ * Returns counts. Aborts by throwing if a protected email matched a pattern.
+ */
+export async function reapDebris(
+  supabase: Admin,
+  opts: { execute: boolean } = { execute: true },
+): Promise<ReapResult> {
+  const allUsers = await listAllAuthUsers(supabase);
+  const debris = allUsers.filter((u) => isDebris(u.email));
+
+  // Guardrail: a protected email should be impossible here (isDebris excludes
+  // them), so if one slipped through the pattern set is too broad — abort.
+  const protectedMatch = debris.find(
+    (u) => u.email && PROTECT_EMAILS.has(u.email),
+  );
+  if (protectedMatch) {
+    throw new Error(
+      `reapDebris ABORT: matched protected email ${protectedMatch.email} — ` +
+        `pattern set is too broad, refusing to delete`,
+    );
+  }
+
+  const base: ReapResult = {
+    totalUsers: allUsers.length,
+    matched: debris.length,
+    deletedUsers: 0,
+    failedUsers: 0,
+    deletedUnits: 0,
+    dryRun: !opts.execute,
+  };
+
+  if (!opts.execute || debris.length === 0) return base;
+
+  // family_invitations.invited_by references public.users with no ON DELETE
+  // cascade, so auth.admin.deleteUser() FK-fails for any user who sent an
+  // invite. Clear debris users' invitations first so their delete can proceed.
+  await deleteInvitationsBy(
+    supabase,
+    debris.map((u) => u.id),
+  );
+
+  let deletedUsers = 0;
+  let failedUsers = 0;
+  for (const u of debris) {
+    let lastErr: unknown = null;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const { error } = await supabase.auth.admin.deleteUser(u.id);
+      if (!error) {
+        deletedUsers++;
+        lastErr = null;
+        break;
+      }
+      lastErr = error;
+      await sleep(500 * (attempt + 1)); // back off on 5xx / connect-timeout
+    }
+    if (lastErr) {
+      failedUsers++;
+      if (failedUsers <= 5) {
+        const msg =
+          lastErr && typeof lastErr === "object" && "message" in lastErr
+            ? (lastErr as { message?: string }).message
+            : String(lastErr);
+        console.warn(`  ⚠️  ${u.email}: ${msg}`);
+      }
+    }
+    await sleep(50); // pace ~20 req/s under Supabase admin limits
+  }
+
+  const deletedUnits = await deleteEmptyFamilyUnits(supabase);
+
+  return {
+    ...base,
+    deletedUsers,
+    failedUsers,
+    deletedUnits,
+  };
+}


### PR DESCRIPTION
## Problem

E2E runs against the shared prod Supabase DB. Many specs create one-off auth users (epoch-suffixed emails) with no teardown, so they accumulated unbounded — **768 users / 744 family_units, ~99% test churn** — polluting the admin dashboard and growth analytics. `playwright.config.ts` had `globalSetup` but no `globalTeardown`; cleanup was manual-only.

## Change

- **`tests/e2e/seed/helpers/debris.ts`** (new) — single source of truth for debris ID + reaping: `isDebris`, epoch-gated `TEST_USER_PATTERNS`, `PROTECT_EMAILS` deny-list, `reapDebris`.
- **`reapDebris`** — deletes debris users, then sweeps orphan `family_units` (`auth.admin.deleteUser` cascades `family_members` but **not** `family_units`), and pre-deletes debris users' `family_invitations` (`invited_by` references `public.users` with no `ON DELETE` cascade — otherwise `deleteUser` FK-fails for any invite-sender).
- **`tests/e2e/global-teardown.ts`** (new) — wired via `playwright.config.ts`. Non-fatal by design (never fails a green run); `E2E_SKIP_TEARDOWN=1` disables.
- **`scripts/e2e-cleanup-users.ts`** — refactored onto the shared helper so manual purge + auto teardown never drift.

Backlog already purged out-of-band: **768→21 users, 744→15 family_units.**

## Known FK gotcha (surfaced, not fixed here)

`family_invitations.invited_by → public.users` has no `ON DELETE` cascade. The app's `process-account-deletions` cron handles family cascade manually so real deletes work; the raw admin path does not. Worked around in `reapDebris`. Candidate follow-up: migration adding cascade/SET NULL.

## Test plan

- [x] `npm run type-check` — 0 errors
- [x] `npm run lint` — 0 errors on changed files
- [x] Teardown direct-invoke runs clean, non-fatal ("No debris to reap")
- [x] `npx playwright test --list` parses config (498 tests)
- [ ] Full setup→teardown wiring verifies on next real `npm run test:e2e`

https://claude.ai/code/session_018xvbaQXAsF2cFfEKbMxoWk