### PR TITLE
fix(db): cascade family_invitations.invited_by on user delete

### DIFF
--- a/supabase/migrations/20260828000000_family_invitations_invited_by_cascade.sql
+++ b/supabase/migrations/20260828000000_family_invitations_invited_by_cascade.sql
@@ -1,0 +1,20 @@
+-- family_invitations.invited_by → public.users had ON DELETE NO ACTION, so
+-- deleting a user who ever sent an invite FK-fails ("Database error deleting
+-- user"). The app's process-account-deletions cron works around this by
+-- deleting family_invitations manually, but the raw Supabase admin
+-- deleteUser() path (used by E2E cleanup / global-teardown) chokes on it.
+--
+-- invited_by is NOT NULL, so ON DELETE SET NULL is not an option. CASCADE is
+-- the correct semantics: an invitation authored by a now-deleted user is void.
+-- This matches family_invitations.family_unit_id, which already cascades on
+-- family_units delete. Deleting the invitation record does NOT remove any
+-- already-accepted membership (family_members is a separate row).
+
+ALTER TABLE public.family_invitations
+  DROP CONSTRAINT IF EXISTS family_invitations_invited_by_fkey;
+
+ALTER TABLE public.family_invitations
+  ADD CONSTRAINT family_invitations_invited_by_fkey
+  FOREIGN KEY (invited_by)
+  REFERENCES public.users (id)
+  ON DELETE CASCADE;


### PR DESCRIPTION
## Problem

`family_invitations.invited_by → public.users` was `ON DELETE NO ACTION`, so deleting any user who ever sent an invite FK-failed with "Database error deleting user". Surfaced while purging E2E debris: `test.player2029` wouldn't delete. The `process-account-deletions` cron worked around it by deleting invitations manually, but the raw Supabase admin `deleteUser()` path (E2E cleanup / global-teardown, PR #409) chokes.

## Change

Drop the FK, re-add it `ON DELETE CASCADE`. `invited_by` is `NOT NULL` so `SET NULL` isn't possible; CASCADE is the right semantics — an invitation authored by a deleted user is void, and `family_unit_id` already cascades identically. Deleting the invitation row does **not** remove any accepted membership (`family_members` is a separate row).

## Applied live

Applied to the shared DB via Supabase MCP (`db push` drifts locally). Verified: `confdeltype` flipped `a` (NO ACTION) → `c` (CASCADE). Repo migration file included so fresh environments get it.

## Test plan

- [x] Constraint verified live post-apply (`c`)
- [x] Unblocks raw `deleteUser()` for invite-senders (was the exact `test.player2029` blocker)

https://claude.ai/code/session_018xvbaQXAsF2cFfEKbMxoWk