### PR TITLE
feat(performance): baseball-convention metric formatting (iOS parity)

### DIFF
--- a/components/Dashboard/DashboardCharts.vue
+++ b/components/Dashboard/DashboardCharts.vue
@@ -135,7 +135,7 @@
               class="text-xl font-bold"
               :class="getMetricColor(metric.metric_type)"
             >
-              {{ metric.value }}
+              {{ formatMetricValue(metric.metric_type, metric.value) }}
               <span v-if="metric.unit" class="text-slate-500 text-sm ml-1">{{
                 metric.unit
               }}</span>
@@ -175,6 +175,7 @@
 
 <script setup lang="ts">
 import ParentGuidanceCard from "~/components/Dashboard/ParentGuidanceCard.vue";
+import { formatMetricValue } from "~/utils/metricFormat";
 import RecruitingCalendar from "~/components/Dashboard/RecruitingCalendar.vue";
 import InteractionTrendChart from "~/components/Dashboard/InteractionTrendChart.vue";
 import SchoolInterestChart from "~/components/Dashboard/SchoolInterestChart.vue";

--- a/components/Dashboard/PerformanceMetricsWidget.vue
+++ b/components/Dashboard/PerformanceMetricsWidget.vue
@@ -25,7 +25,7 @@
             class="text-xl font-bold"
             :class="getMetricColor(metric.metric_type)"
           >
-            {{ metric.value }}
+            {{ formatMetricValue(metric.metric_type, metric.value) }}
             <span v-if="metric.unit" class="text-slate-500 text-sm ml-1">{{
               metric.unit
             }}</span>
@@ -54,6 +54,7 @@
 </template>
 
 <script setup lang="ts">
+import { formatMetricValue } from "~/utils/metricFormat";
 interface Metric {
   id: string;
   metric_type: string;

--- a/components/Dashboard/PerformanceSummary.vue
+++ b/components/Dashboard/PerformanceSummary.vue
@@ -45,7 +45,7 @@
             </span>
           </div>
           <p class="text-sm font-semibold text-slate-900">
-            {{ metric.value }}
+            {{ formatMetricValue(metric.metric_type, metric.value) }}
             <span class="text-xs font-normal text-slate-600">{{
               metric.unit
             }}</span>
@@ -79,7 +79,7 @@
               </p>
             </div>
             <div class="text-right">
-              <p class="text-sm font-bold text-slate-900">{{ metric.value }}</p>
+              <p class="text-sm font-bold text-slate-900">{{ formatMetricValue(metric.metric_type, metric.value) }}</p>
               <p class="text-xs text-slate-600">{{ metric.unit }}</p>
             </div>
           </div>
@@ -101,6 +101,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+import { formatMetricValue } from "~/utils/metricFormat";
 import type { PerformanceMetric } from "~/types/models";
 
 interface Props {

--- a/components/Performance/PerformanceDashboard.vue
+++ b/components/Performance/PerformanceDashboard.vue
@@ -141,7 +141,7 @@
             </p>
           </div>
           <p class="text-lg font-semibold text-slate-900">
-            {{ metric.value }}
+            {{ formatMetricValue(metric.metric_type, metric.value) }}
             <span class="text-xs text-slate-600">{{
               getUnit(metric.metric_type)
             }}</span>
@@ -157,6 +157,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
+import { formatMetricValue } from "~/utils/metricFormat";
 import { usePerformanceAnalytics } from "~/composables/usePerformanceAnalytics";
 import type { Performance } from "~/types/models";
 import MetricSummaryRow from "./MetricSummaryRow.vue";
@@ -220,7 +221,7 @@ const getMetricStats = (type: string) => {
   if (typeMetrics.length === 0) return "—";
 
   const latest = typeMetrics[typeMetrics.length - 1]?.value || 0;
-  return latest.toFixed(1);
+  return formatMetricValue(type, latest);
 };
 
 const getMetricLabel = (type: string): string => {

--- a/pages/performance/index.vue
+++ b/pages/performance/index.vue
@@ -123,10 +123,10 @@
               </span>
             </div>
             <p class="text-sm text-gray-600 mb-3">
-              Last {{ trend.count }} records: {{ trend.min }} to {{ trend.max }}
+              Last {{ trend.count }} records: {{ formatMetricValue(trend.type, trend.min) }} to {{ formatMetricValue(trend.type, trend.max) }}
               {{ trend.unit }}
               <span v-if="trend.average" class="text-gray-700">
-                (avg: {{ trend.average }})</span
+                (avg: {{ formatMetricValue(trend.type, trend.average) }})</span
               >
             </p>
             <!-- Simple bar chart -->
@@ -136,7 +136,7 @@
                 :key="idx"
                 class="flex-1 bg-blue-500 rounded-t hover:bg-blue-600 transition"
                 :style="{ height: `${(value / trend.max) * 100}%` }"
-                :title="`${value}`"
+                :title="formatMetricValue(trend.type, value)"
               />
             </div>
           </div>
@@ -157,7 +157,7 @@
             {{ getMetricLabel(key) }}
           </p>
           <div class="flex items-baseline gap-2">
-            <p class="text-3xl font-bold text-blue-600">{{ metric.value }}</p>
+            <p class="text-3xl font-bold text-blue-600">{{ formatMetricValue(metric.metric_type, metric.value) }}</p>
             <p class="text-gray-500">{{ metric.unit }}</p>
           </div>
           <p class="text-xs text-gray-500 mt-2">
@@ -255,7 +255,7 @@
             <div>
               <p class="text-xs text-gray-600">Value</p>
               <p class="font-bold text-gray-900">
-                {{ metric.value }} {{ metric.unit }}
+                {{ formatMetricValue(metric.metric_type, metric.value) }} {{ metric.unit }}
               </p>
             </div>
             <div v-if="metric.verified">
@@ -457,6 +457,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted, reactive, computed, defineAsyncComponent } from "vue";
+import { formatMetricValue } from "~/utils/metricFormat";
 import { usePerformance } from "~/composables/usePerformance";
 import { useAppToast } from "~/composables/useAppToast";
 import { createClientLogger } from "~/utils/logger";
@@ -570,9 +571,7 @@ const metricTrends = computed(() => {
       const values = sorted.map((m) => m.value).slice(-10); // Last 10 records
       const min = Math.min(...values);
       const max = Math.max(...values);
-      const avg = (values.reduce((a, b) => a + b, 0) / values.length).toFixed(
-        2,
-      );
+      const avg = values.reduce((a, b) => a + b, 0) / values.length;
 
       // Determine trend (comparing first 3 to last 3)
       const first3 = values.slice(0, 3);

--- a/tests/unit/utils/metricFormat.spec.ts
+++ b/tests/unit/utils/metricFormat.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { formatMetricValue } from "~/utils/metricFormat";
+
+// Parity with iOS MetricTypeFormatTests — keep the two in lockstep.
+describe("formatMetricValue", () => {
+  it("batting_avg: 3 decimals, drops the leading zero", () => {
+    expect(formatMetricValue("batting_avg", 0.41)).toBe(".410");
+    expect(formatMetricValue("batting_avg", 0.4)).toBe(".400");
+    expect(formatMetricValue("batting_avg", 0)).toBe(".000");
+  });
+
+  it("batting_avg >= 1 keeps the leading digit", () => {
+    expect(formatMetricValue("batting_avg", 1.0)).toBe("1.000");
+    expect(formatMetricValue("batting_avg", 1.5)).toBe("1.500");
+  });
+
+  it("era: 2 decimals, keeps the leading digit", () => {
+    expect(formatMetricValue("era", 3.45)).toBe("3.45");
+    expect(formatMetricValue("era", 0)).toBe("0.00");
+    expect(formatMetricValue("era", 12)).toBe("12.00");
+  });
+
+  it("velocity / exit_velo: 1 decimal", () => {
+    expect(formatMetricValue("velocity", 82.3)).toBe("82.3");
+    expect(formatMetricValue("velocity", 82.3001)).toBe("82.3");
+    expect(formatMetricValue("exit_velo", 92.1)).toBe("92.1");
+    expect(formatMetricValue("velocity", 88)).toBe("88.0");
+  });
+
+  it("times: 2 decimals", () => {
+    expect(formatMetricValue("sixty_time", 7.23)).toBe("7.23");
+    expect(formatMetricValue("pop_time", 1.95)).toBe("1.95");
+  });
+
+  it("strikeouts: integer", () => {
+    expect(formatMetricValue("strikeouts", 12)).toBe("12");
+    expect(formatMetricValue("strikeouts", 12.0)).toBe("12");
+  });
+
+  it("other: 2 decimals, keeps leading zero", () => {
+    expect(formatMetricValue("other", 4.5)).toBe("4.50");
+    expect(formatMetricValue("other", 0.5)).toBe("0.50");
+  });
+
+  it("unknown / null type: plain integer-or-raw", () => {
+    expect(formatMetricValue(null, 88)).toBe("88");
+    expect(formatMetricValue(undefined, 88.3)).toBe("88.3");
+    expect(formatMetricValue("bogus", 42)).toBe("42");
+  });
+});

--- a/utils/metricFormat.ts
+++ b/utils/metricFormat.ts
@@ -1,0 +1,32 @@
+/**
+ * Baseball-convention display formatting for performance-metric values, keyed by metric type.
+ * Single source of truth on web; must stay byte-identical to iOS `MetricType.format(_:)`.
+ *
+ * Rules: batting average → 3 decimals dropping the leading zero (.410); ERA → 2 decimals
+ * keeping the leading digit (3.45); velocity / exit velo → 1 decimal (82.3); 60-yard & pop
+ * times → 2 decimals (7.23); strikeouts → integer; other → 2 decimals. Unknown/absent types
+ * fall back to a plain integer-or-raw string (mirrors the iOS template fallback).
+ *
+ * Number only — callers append the unit.
+ */
+const FRACTION_DIGITS: Record<string, number> = {
+  batting_avg: 3,
+  era: 2,
+  sixty_time: 2,
+  pop_time: 2,
+  other: 2,
+  velocity: 1,
+  exit_velo: 1,
+  strikeouts: 0,
+};
+
+export function formatMetricValue(
+  metricType: string | null | undefined,
+  value: number,
+): string {
+  const digits = metricType == null ? undefined : FRACTION_DIGITS[metricType];
+  if (digits === undefined) return String(value); // unknown type: plain integer-or-raw
+  const s = value.toFixed(digits);
+  if (metricType === "batting_avg" && s.startsWith("0.")) return s.slice(1);
+  return s;
+}

--- a/utils/templateResolver.ts
+++ b/utils/templateResolver.ts
@@ -18,6 +18,8 @@
  * a send-blocking gap.
  */
 
+import { formatMetricValue } from "./metricFormat";
+
 export type Row = Record<string, unknown>;
 
 export interface MetricRow {
@@ -114,7 +116,9 @@ const humanizeMetricLabel = (metricType?: string | null): string =>
 
 const metricDisplay = (m: MetricRow): string => {
   if (m.display_value && m.display_value.trim()) return m.display_value.trim();
-  if (m.value != null) return `${m.value}${m.unit ? ` ${m.unit}` : ""}`;
+  if (m.value != null) {
+    return `${formatMetricValue(m.metric_type, m.value)}${m.unit ? ` ${m.unit}` : ""}`;
+  }
   return "";
 };
 


### PR DESCRIPTION
Adds `utils/formatMetricValue` — a single type-keyed value formatter, byte-identical to iOS `MetricType.format`.

## Rules
| Type | Format | Example |
|---|---|---|
| batting_avg | 3 dec, drop leading 0 | `.410` |
| era | 2 dec, keep digit | `3.45` |
| velocity / exit_velo | 1 dec | `82.3` |
| sixty_time / pop_time | 2 dec | `7.23` |
| strikeouts | integer | `12` |
| other | 2 dec | `4.50` |

## Rerouted
templateResolver.metricDisplay fallback (display_value still wins), performance/index (tiles, history, trend min/max/avg + bar tooltips), PerformanceDashboard (summary + recent), PerformanceMetricsWidget, PerformanceSummary, DashboardCharts. Generic StatCard/ComparisonCard untouched (no metric_type). Trend avg kept numeric so the formatter controls precision.

## Tests
New `metricFormat.spec` (8, mirror iOS). Full unit suite green (8005), `tsc` clean.

Companion to iOS main `8f2cc816`. Fixes 0.41→.410 / 82.30→82.3 divergence from the dashboard handoff.

https://claude.ai/code/session_01KJunU5QTY567XxSt2o4CsA