### PR TITLE
feat(schools): formalize status pipeline + interaction-based Contacted stat

### DIFF
--- a/components/Dashboard/SchoolInterestChart.vue
+++ b/components/Dashboard/SchoolInterestChart.vue
@@ -125,7 +125,7 @@ const chartData = computed(() => {
   const statusCounts: Record<string, number> = {
     researching: 0,
     contacted: 0,
-    interested: 0,
+    visiting: 0,
     offer_received: 0,
     committed: 0,
   };
@@ -140,14 +140,14 @@ const chartData = computed(() => {
   const labels = [
     "Researching",
     "Contacted",
-    "Interested",
+    "Visiting",
     "Offer Received",
     "Committed",
   ];
   const data = [
     statusCounts.researching,
     statusCounts.contacted,
-    statusCounts.interested,
+    statusCounts.visiting,
     statusCounts.offer_received,
     statusCounts.committed,
   ];
@@ -155,7 +155,7 @@ const chartData = computed(() => {
   const colors = [
     "researching",
     "contacted",
-    "interested",
+    "visiting",
     "offer_received",
     "committed",
   ];
@@ -207,9 +207,9 @@ const initializeChart = () => {
     contacted:
       getComputedStyle(root).getPropertyValue("--brand-blue-500").trim() ||
       "#3b82f6", // audit-ignore — Chart.js config requires raw hex
-    interested:
-      getComputedStyle(root).getPropertyValue("--brand-emerald-500").trim() ||
-      "#10b981", // audit-ignore — Chart.js config requires raw hex
+    visiting:
+      getComputedStyle(root).getPropertyValue("--brand-violet-500").trim() ||
+      "#8b5cf6", // audit-ignore — Chart.js config requires raw hex
     offer_received:
       getComputedStyle(root).getPropertyValue("--brand-orange-500").trim() ||
       "#f97316", // audit-ignore — Chart.js config requires raw hex

--- a/components/Dashboard/SchoolStatusOverview.vue
+++ b/components/Dashboard/SchoolStatusOverview.vue
@@ -14,7 +14,9 @@
         class="text-center p-4 rounded-lg border border-slate-200"
       >
         <p class="text-2xl mb-1">{{ getStatusEmoji(status.status) }}</p>
-        <p class="text-xs capitalize text-slate-600">{{ status.status }}</p>
+        <p class="text-xs text-slate-600">
+          {{ getSchoolStatusLabel(status.status) }}
+        </p>
         <p class="text-2xl font-bold mt-1 text-slate-900">{{ status.count }}</p>
       </div>
     </div>
@@ -28,7 +30,7 @@
       >
         <h3 class="font-semibold mb-3 flex items-center gap-2 text-slate-900">
           <span>{{ getStatusEmoji(status.status) }}</span>
-          <span class="capitalize">{{ status.status }}</span>
+          <span>{{ getSchoolStatusLabel(status.status) }}</span>
           <span class="text-xs font-normal text-slate-600"
             >({{ status.schools.length }})</span
           >
@@ -65,6 +67,10 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import type { School } from "~/types/models";
+import {
+  SCHOOL_STATUS_OPTIONS,
+  getSchoolStatusLabel,
+} from "~/utils/schoolStatusOptions";
 
 interface Props {
   schools: School[];
@@ -72,44 +78,30 @@ interface Props {
 
 const props = defineProps<Props>();
 
-const statusCounts = computed(() => {
-  const statuses = [
-    "researching",
-    "contacted",
-    "interested",
-    "offer_received",
-    "declined",
-    "committed",
-  ];
-  return statuses.map((status) => ({
+const CANONICAL_STATUSES = SCHOOL_STATUS_OPTIONS.map((option) => option.value);
+
+const statusCounts = computed(() =>
+  CANONICAL_STATUSES.map((status) => ({
     status,
     count: props.schools.filter((s) => s.status === status).length,
-  }));
-});
+  })),
+);
 
-const schoolsByStatus = computed(() => {
-  const statuses = [
-    "researching",
-    "contacted",
-    "interested",
-    "offer_received",
-    "declined",
-    "committed",
-  ];
-  return statuses.map((status) => ({
+const schoolsByStatus = computed(() =>
+  CANONICAL_STATUSES.map((status) => ({
     status,
     schools: props.schools.filter((s) => s.status === status),
-  }));
-});
+  })),
+);
 
 const getStatusEmoji = (status: string): string => {
   const emojis: Record<string, string> = {
     researching: "🔍",
     contacted: "📞",
-    interested: "✨",
+    visiting: "🏫",
     offer_received: "🎉",
-    declined: "❌",
     committed: "✅",
+    not_pursuing: "🚫",
   };
   return emojis[status] || "📌";
 };

--- a/components/School/SchoolForm.vue
+++ b/components/School/SchoolForm.vue
@@ -215,6 +215,7 @@ import { z } from "zod";
 import type { CollegeDataResult } from "~/composables/useCollegeData";
 import type { CollegeSearchResult } from "~/types/api";
 import FormErrorSummary from "~/components/Validation/FormErrorSummary.vue";
+import { SCHOOL_STATUS_OPTIONS } from "~/utils/schoolStatusOptions";
 
 // Division options
 const divisionOptions = computed(() => [
@@ -224,15 +225,13 @@ const divisionOptions = computed(() => [
   { value: "D3", label: "Division 3 (D3)" },
 ]);
 
-// Status options
-const statusOptions = computed(() => [
-  { value: "researching", label: "Researching" },
-  { value: "contacted", label: "Contacted" },
-  { value: "interested", label: "Interested" },
-  { value: "offer_received", label: "Offer Received" },
-  { value: "declined", label: "Declined" },
-  { value: "committed", label: "Committed" },
-]);
+// Status options — derived from the canonical funnel (single source of truth).
+const statusOptions = computed(() =>
+  SCHOOL_STATUS_OPTIONS.map((option) => ({
+    value: option.value,
+    label: option.label,
+  })),
+);
 
 const props = defineProps<{
   loading: boolean;

--- a/components/School/SchoolListCard.vue
+++ b/components/School/SchoolListCard.vue
@@ -51,10 +51,10 @@
           {{ school.division }}
         </span>
         <span
-          :class="getStatusBadgeClass(school.status)"
+          :class="getSchoolStatusBadgeClass(school.status)"
           class="px-2 py-0.5 text-xs font-medium rounded-full"
         >
-          {{ formatSchoolStatus(school.status) }}
+          {{ getSchoolStatusLabel(school.status) }}
         </span>
         <span
           v-if="overall"
@@ -108,11 +108,11 @@ import { computed } from "vue";
 import type { School } from "~/types";
 import SchoolLogo from "~/components/School/SchoolLogo.vue";
 import { getCarnegieSize } from "~/utils/schoolSize";
+import { getSizeBadgeClass } from "~/utils/schoolBadges";
 import {
-  getStatusBadgeClass,
-  getSizeBadgeClass,
-  formatSchoolStatus,
-} from "~/utils/schoolBadges";
+  getSchoolStatusBadgeClass,
+  getSchoolStatusLabel,
+} from "~/utils/schoolStatusOptions";
 import type { OverallPersonalFit } from "~/utils/fitScoreCalculation";
 
 const props = defineProps<{

--- a/components/School/SchoolRecruitingStatusSection.vue
+++ b/components/School/SchoolRecruitingStatusSection.vue
@@ -10,41 +10,17 @@
       />
     </div>
 
-    <label for="recruiting-status-select" class="sr-only">
-      Change recruiting status
-    </label>
-    <div class="relative">
-      <select
-        id="recruiting-status-select"
-        data-testid="recruiting-status-select"
-        :value="status"
-        :disabled="statusUpdating"
-        :aria-busy="statusUpdating"
-        class="w-full appearance-none px-3 py-2.5 pr-9 text-sm rounded-lg border border-slate-300 bg-slate-50 text-slate-900 cursor-pointer focus:ring-2 focus:ring-blue-600 focus:border-blue-600 disabled:opacity-50 disabled:cursor-not-allowed"
-        @change="handleChange"
-      >
-        <option
-          v-for="option in SCHOOL_STATUS_OPTIONS"
-          :key="option.value"
-          :value="option.value"
-        >
-          {{ option.label }}
-        </option>
-      </select>
-      <UIcon
-        name="i-heroicons-chevron-up-down"
-        class="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400"
-        aria-hidden="true"
-      />
-    </div>
+    <SchoolStatusStepper
+      :status="(status as SchoolStatusValue)"
+      :updating="statusUpdating"
+      @select="emit('update:status', $event)"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import {
-  SCHOOL_STATUS_OPTIONS,
-  type SchoolStatusValue,
-} from "~/utils/schoolStatusOptions";
+import SchoolStatusStepper from "~/components/School/SchoolStatusStepper.vue";
+import type { SchoolStatusValue } from "~/utils/schoolStatusOptions";
 
 defineProps<{
   status: string;
@@ -54,9 +30,4 @@ defineProps<{
 const emit = defineEmits<{
   "update:status": [status: SchoolStatusValue];
 }>();
-
-const handleChange = (event: Event) => {
-  const target = event.target as HTMLSelectElement;
-  emit("update:status", target.value as SchoolStatusValue);
-};
 </script>

--- a/components/School/SchoolStatusStepper.vue
+++ b/components/School/SchoolStatusStepper.vue
@@ -1,0 +1,146 @@
+<template>
+  <div :class="isNotPursuing ? 'opacity-60' : ''">
+    <!-- Progress track -->
+    <ol class="flex items-start" :aria-disabled="updating ? 'true' : 'false'">
+      <li
+        v-for="(node, index) in nodes"
+        :key="node.value"
+        class="flex items-start"
+        :class="index === 0 ? '' : 'flex-1'"
+      >
+        <!-- Connector into this node -->
+        <span
+          v-if="index > 0"
+          class="mt-4 h-0.5 flex-1 rounded-full"
+          :class="node.connectorDone ? 'bg-blue-600' : 'bg-slate-200'"
+          aria-hidden="true"
+        />
+
+        <div class="flex flex-col items-center gap-1.5" :class="index > 0 ? 'px-1' : 'pr-1'">
+          <button
+            type="button"
+            :disabled="updating || isNotPursuing"
+            :aria-label="node.ariaLabel"
+            :aria-current="node.state === 'current' ? 'step' : undefined"
+            class="flex h-8 w-8 items-center justify-center rounded-full border-2 text-xs font-semibold transition focus:outline-none focus:ring-2 focus:ring-blue-600 focus:ring-offset-1 disabled:cursor-not-allowed"
+            :class="nodeCircleClass(node.state)"
+            @click="emit('select', node.value)"
+          >
+            <UIcon
+              v-if="node.state === 'completed'"
+              name="i-heroicons-check"
+              class="h-4 w-4"
+              aria-hidden="true"
+            />
+            <span v-else>{{ index + 1 }}</span>
+          </button>
+          <span
+            class="text-center text-xs leading-tight"
+            :class="node.state === 'current' ? 'font-semibold text-slate-900' : 'text-slate-500'"
+          >
+            {{ node.label }}
+          </span>
+        </div>
+      </li>
+    </ol>
+
+    <!-- Off-ramp: not pursuing banner -->
+    <div
+      v-if="isNotPursuing"
+      class="mt-4 flex items-center justify-between gap-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2.5"
+    >
+      <span class="text-sm font-medium text-red-700">Not pursuing</span>
+      <button
+        type="button"
+        data-testid="reactivate-status"
+        :disabled="updating"
+        class="rounded-md bg-white px-3 py-1.5 text-xs font-semibold text-red-700 shadow-xs ring-1 ring-red-200 transition hover:bg-red-100 focus:outline-none focus:ring-2 focus:ring-red-500 disabled:opacity-50"
+        @click="emit('select', 'researching')"
+      >
+        Reactivate
+      </button>
+    </div>
+
+    <!-- Off-ramp: mark not pursuing -->
+    <div v-else class="mt-4 flex justify-center">
+      <button
+        type="button"
+        data-testid="mark-not-pursuing"
+        :disabled="updating"
+        class="text-xs font-medium text-slate-400 underline-offset-2 transition hover:text-red-600 hover:underline focus:outline-none focus:text-red-600 disabled:opacity-50 disabled:cursor-not-allowed"
+        @click="emit('select', 'not_pursuing')"
+      >
+        Mark not pursuing
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import {
+  SCHOOL_STATUS_OPTIONS,
+  getSchoolStatusLabel,
+  type SchoolStatusValue,
+} from "~/utils/schoolStatusOptions";
+
+const props = withDefaults(
+  defineProps<{
+    status: SchoolStatusValue;
+    updating?: boolean;
+  }>(),
+  { updating: false },
+);
+
+const emit = defineEmits<{
+  select: [value: SchoolStatusValue];
+}>();
+
+type NodeState = "completed" | "current" | "upcoming";
+
+/** The 5 monotonic progress stages — `not_pursuing` is a terminal off-ramp, not a node. */
+const PROGRESS_STAGES = SCHOOL_STATUS_OPTIONS.filter(
+  (option) => option.value !== "not_pursuing",
+);
+
+const isNotPursuing = computed(() => props.status === "not_pursuing");
+
+/** Index of the active stage in the progress track; -1 when off-ramped. */
+const currentIndex = computed(() =>
+  PROGRESS_STAGES.findIndex((stage) => stage.value === props.status),
+);
+
+const nodeLabel = (value: SchoolStatusValue): string =>
+  value === "offer_received" ? "Offer" : getSchoolStatusLabel(value);
+
+const nodes = computed(() =>
+  PROGRESS_STAGES.map((stage, index) => {
+    const state: NodeState =
+      index < currentIndex.value
+        ? "completed"
+        : index === currentIndex.value
+          ? "current"
+          : "upcoming";
+    const label = nodeLabel(stage.value);
+    const stateWord =
+      state === "current" ? "current stage" : `${state}`;
+    return {
+      value: stage.value,
+      label,
+      state,
+      connectorDone: index <= currentIndex.value,
+      ariaLabel: `Set status to ${getSchoolStatusLabel(stage.value)} (${stateWord})`,
+    };
+  }),
+);
+
+const nodeCircleClass = (state: NodeState): string => {
+  if (state === "completed") {
+    return "border-blue-600 bg-blue-600 text-white";
+  }
+  if (state === "current") {
+    return "border-blue-600 bg-white text-blue-700 ring-2 ring-blue-200";
+  }
+  return "border-slate-300 bg-white text-slate-400";
+};
+</script>

--- a/components/Schools/FilterPanel.vue
+++ b/components/Schools/FilterPanel.vue
@@ -101,11 +101,13 @@
           @change="$emit('update:filter', 'status', $event || null)"
         >
           <option value="">All</option>
-          <option value="researching">Researching</option>
-          <option value="contacted">Contacted</option>
-          <option value="interested">Interested</option>
-          <option value="offer_received">Offer</option>
-          <option value="committed">Committed</option>
+          <option
+            v-for="option in statusOptions"
+            :key="option.value"
+            :value="option.value"
+          >
+            {{ option.label }}
+          </option>
         </SchoolFilterSelect>
 
         <!-- State -->
@@ -193,6 +195,13 @@
 
 <script setup lang="ts">
 import type { HomeLocation } from "~/types/models";
+import { SCHOOL_STATUS_OPTIONS } from "~/utils/schoolStatusOptions";
+
+// Status filter choices derived from the canonical funnel (single source of truth).
+const statusOptions = SCHOOL_STATUS_OPTIONS.map((option) => ({
+  value: option.value,
+  label: option.label,
+}));
 
 interface SchoolFilterValues {
   name?: string;

--- a/composables/useRecruitingPacket.ts
+++ b/composables/useRecruitingPacket.ts
@@ -156,18 +156,12 @@ export const useRecruitingPacket = () => {
         interactionCount: school.id ? countInteractionsForSchool(school.id) : 0,
       };
 
-      // Tier by status and other signals
-      if (
-        school.status === "official_visit_scheduled" ||
-        school.status === "recruited" ||
-        school.status === "offer_received" ||
-        school.status === "committed"
-      ) {
+      // Tier by status and other signals. The legacy camp_invite / recruited /
+      // official_visit_invited / official_visit_scheduled stages collapsed into
+      // the canonical `visiting` funnel stage (tier_b).
+      if (school.status === "offer_received" || school.status === "committed") {
         grouped.tier_a.push(packetData);
-      } else if (
-        school.status === "official_visit_invited" ||
-        school.status === "camp_invite"
-      ) {
+      } else if (school.status === "visiting") {
         grouped.tier_b.push(packetData);
       } else {
         grouped.tier_c.push(packetData);

--- a/composables/useSchoolStats.ts
+++ b/composables/useSchoolStats.ts
@@ -45,6 +45,17 @@ export function useSchoolStats(
     return ids;
   });
 
+  // School IDs with at least one logged interaction of any type. "Contacted" is
+  // an activity signal (a real interaction exists), not the `contacted` status
+  // stage — a school can be past `contacted` in the funnel yet still counts.
+  const contactedSchoolIds = computed<Set<string>>(() => {
+    const ids = new Set<string>();
+    for (const i of interactions.value) {
+      if (i.school_id) ids.add(i.school_id);
+    }
+    return ids;
+  });
+
   const stats = computed(() => [
     {
       label: "Total Schools",
@@ -70,7 +81,8 @@ export function useSchoolStats(
     },
     {
       label: "Contacted",
-      value: schools.value.filter((s) => s.status === "contacted").length,
+      value: schools.value.filter((s) => contactedSchoolIds.value.has(s.id))
+        .length,
       icon: "i-heroicons-chat-bubble-left-right",
       color: "purple" as const,
       testId: "stat-contacted",

--- a/composables/useSchools.ts
+++ b/composables/useSchools.ts
@@ -21,13 +21,16 @@ const logger = createClientLogger("useSchools");
  * - Queries filter by family_unit_id instead of user_id
  * - Student-created schools are scoped to their family
  *
- * School status levels:
+ * School status — a monotonic recruiting funnel (single source of truth in
+ * utils/schoolStatusOptions.ts):
  * - researching: Initial exploration phase
  * - contacted: First contact made with coaches
- * - interested: School expressed interest
+ * - visiting: Visiting the program (camps, unofficial/official visits)
  * - offer_received: Scholarship offer received
- * - declined: Offer declined or program not pursuing
  * - committed: Committed to attend
+ * - not_pursuing: Terminal off-ramp (no longer pursuing this program)
+ * Affinity ("interested") is NOT a status — it is the favorite flag
+ * (is_favorite), not this enum.
  *
  * Features:
  * - Track school details (location, conference, division)

--- a/pages/schools/[id]/coaches.vue
+++ b/pages/schools/[id]/coaches.vue
@@ -294,7 +294,7 @@ const school = computed((): School | undefined => {
     favicon_url: null,
     twitter_handle: null,
     instagram_handle: null,
-    status: "interested",
+    status: "researching",
     notes: null,
     pros: [],
     cons: [],

--- a/planning/2026-08-21-school-status-pipeline-spec.md
+++ b/planning/2026-08-21-school-status-pipeline-spec.md
@@ -1,0 +1,206 @@
+# School Status Pipeline — Formalization Spec
+
+**Date:** 2026-08-21
+**Author:** Chris + Claude
+**Status:** APPROVED — decisions locked 2026-08-21, implementation in progress
+**Repos:** `recruiting-compass-web`, `recruiting-compass-ios` (single shared Supabase DB)
+
+---
+
+## Problem
+
+The `school_status` field currently conflates two independent axes and has no
+defined order:
+
+- **Progress** — where a school sits in the recruiting funnel (a monotonic
+  milestone chain).
+- **Affinity** — how much the athlete likes the school (a feeling).
+
+Symptoms observed:
+
+- **11 enum values**, only **6 exposed** in the web `SchoolForm`, and iOS/web
+  **disagree on ordering** (iOS enum: `researching → interested → contacted`;
+  web `useSchools` doc: `researching → contacted → interested`).
+- iOS enum has `unknown` and lacks `declined`; web DB has `declined` and lacks
+  `unknown`. Divergent value sets.
+- `interested` is an affinity, not a milestone — but it lives on the progress
+  axis, duplicating the existing `isFavorite` star.
+- No documented order → the "Contacted" stat (schools where `status ==
+  'contacted'`) is a single-stage snapshot that confuses users (a school with 3
+  logged interactions read `interested`, so "0 contacted"). Interim patch
+  (migrations `20260828000001`/`20260828000002`) auto-advances
+  researching/interested → contacted on interaction. This spec is the durable fix.
+
+---
+
+## Goals
+
+1. One **canonical, ordered, monotonic** progress pipeline, shared byte-for-byte
+   across iOS and web (single source-of-truth constant).
+2. Move **affinity off the status axis** — fold `interested` into the favorite flag.
+3. **Auto-advance** rules so the pipeline tracks reality (interaction → contacted,
+   visit → visiting, offer → offer_received) instead of relying on manual bumps.
+4. A **visible pipeline UI** (stepper/progress) so the athlete sees current stage
+   and what's next.
+5. Keep both platforms at **parity** — same stages, order, names, auto-advance,
+   and stat definitions.
+
+## Non-goals
+
+- Redesigning interactions, offers, or events themselves.
+- Changing the favorite feature beyond absorbing `interested`.
+
+---
+
+## Proposed canonical pipeline
+
+Monotonic progress stages (a school only moves forward; off-ramp is terminal).
+**5 stages + off-ramp** (`recruited` dropped per Q3 — recruiting activity is
+covered by interactions + the `visiting` stage):
+
+| # | Stage | Meaning | Auto-advance trigger |
+|---|-------|---------|----------------------|
+| 1 | `researching` | Added; evaluating fit | default on create |
+| 2 | `contacted` | First outreach sent/received | log an interaction |
+| 3 | `visiting` | Visit invited / scheduled / completed (incl. camp invite) | manual (future: visit event) |
+| 4 | `offer_received` | Offer on the table | manual (future: offer logged) |
+| 5 | `committed` | Committed | manual |
+| — | `not_pursuing` | Off-ramp / dead (terminal) | manual |
+
+**Affinity (separate axis):** `isFavorite` boolean — already exists. Absorbs the
+old `interested` meaning ("I like this school").
+
+### Value migration map (existing rows → new set)
+
+| Existing value | New status | Notes |
+|----------------|-----------|-------|
+| `researching` | `researching` | unchanged |
+| `interested` | `contacted` if ≥1 interaction, else `researching` (+ set `is_favorite = true` either way) | Q1: affinity → favorite; interaction → contacted |
+| `contacted` | `contacted` | unchanged |
+| `camp_invite` | `visiting` | collapse (Q3) |
+| `recruited` | `visiting` | collapse (Q3) |
+| `official_visit_invited` | `visiting` | collapse |
+| `official_visit_scheduled` | `visiting` | collapse |
+| `offer_received` | `offer_received` | unchanged |
+| `committed` | `committed` | unchanged |
+| `declined` | `not_pursuing` | collapse (web-only value) |
+| `not_pursuing` | `not_pursuing` | unchanged |
+| `unknown` | `researching` | collapse (iOS-only value) |
+
+**Q1 resolved:** old `interested` rows → `is_favorite = true`; status →
+`contacted` if the school has ≥1 interaction, else `researching`. (The interim
+patch already advanced interested-with-interactions → contacted, so those are
+`contacted`; this migration sets the favorite flag and downgrades the rest.)
+
+---
+
+## Ordering: single source of truth
+
+Define one ordered list; both platforms derive from it.
+
+- **iOS** — replace the ad-hoc `SchoolStatus` case order with an explicit
+  `orderedStages: [SchoolStatus]` (progress stages only) + `isTerminal`. Add a
+  `rank(_:) -> Int` for monotonic comparisons.
+- **web** — a `SCHOOL_STATUS_ORDER: SchoolStatus[]` constant (e.g.
+  `constants/schoolStatus.ts`) replacing the stale `useSchools` doc comment and
+  the partial `SchoolForm` options.
+- Both lists MUST be identical. Add a parity test on each side asserting the
+  ordered value list matches the agreed spec.
+
+Monotonic enforcement: auto-advance only ever moves a school to a **higher-rank**
+stage; never downgrades. Manual edits may move anywhere (user override), but the
+form should present stages in canonical order.
+
+---
+
+## Auto-advance rules (phase in)
+
+| Event | Advance to (if current rank lower) |
+|-------|-----------------------------------|
+| Interaction logged | `contacted` |
+| Camp-invite / inbound interaction | `recruited` (future) |
+| Visit event (invited/scheduled/past) | `visiting` (future) |
+| Offer logged | `offer_received` (future) |
+
+Implement at the **DB layer** (triggers) so both platforms share behavior with
+no app code — the interaction→contacted trigger already exists
+(`advance_school_status_on_interaction`). Extend the same pattern for
+offer/visit in later phases. Each trigger must:
+- Compare current stage rank; only advance forward.
+- Write a `school_status_history` row (`changed_by` = the actor uuid;
+  `previous_status`/`new_status`).
+- Be `SECURITY DEFINER` with `search_path = public, pg_temp`.
+
+---
+
+## Stats impact
+
+- **"Contacted" stat (Q2 resolved)** — count of schools with **≥1 interaction**
+  (activity-derived), NOT `status == 'contacted'` and NOT cumulative rank. This
+  decouples the stat from the status field entirely and matches the dashboard's
+  interaction semantics. Apply identically iOS (`SchoolsListViewModel.analytics`)
+  + web (`useSchoolStats`). Any interaction type counts as a contact (consistent
+  with the dashboard interaction count).
+- **"Visited" stat** — already interaction/event-derived on iOS
+  (`visitedSchoolIds`); reconcile with new `visiting` stage.
+
+---
+
+## UI
+
+- **Stepper / progress indicator** on the school detail (both platforms) showing
+  the ordered stages, current stage highlighted, terminal off-ramp shown
+  distinctly. Platform-idiomatic chrome, identical stages/labels/order.
+- **Status picker** lists stages in canonical order (drop the partial 6-value
+  web form list; expose the full progress set + off-ramp).
+- **Favorite star** unchanged; messaging/onboarding copy clarifies favorite =
+  "I like it", status = "where it is in the process".
+
+---
+
+## Migration plan (phased)
+
+1. **Constants + parity tests** — land `SCHOOL_STATUS_ORDER` (web) and ordered
+   `SchoolStatus` (iOS) with matching values + tests. No data change.
+2. **DB enum reconciliation + data migration** — add any missing values
+   (`visiting`), migrate existing rows per the map above, set `is_favorite` for
+   old `interested`. History rows for each status change. Apply to prod via
+   Supabase migration.
+3. **Stat definition** — switch "Contacted" (and any stage stat) to the agreed
+   cumulative definition on both platforms; update tests.
+4. **Auto-advance triggers** — keep interaction→contacted; add visit/offer
+   triggers.
+5. **UI** — status picker (canonical order) + stepper on both platforms.
+6. **Cleanup** — remove stale `useSchools` doc order, iOS `unknown`, web
+   `declined` once data migrated.
+
+Each phase: build gate per platform (`npx tsc --noEmit` web,
+`xcodebuild build` iOS), parity diff, commit + push **both repos same turn**.
+
+---
+
+## Open questions
+
+**Resolved 2026-08-21:**
+- Q1 — `interested` → favorite flag; `contacted` if ≥1 interaction else `researching`.
+- Q2 — "Contacted" stat = schools with ≥1 interaction (activity-derived).
+- Q3 — drop `recruited`; collapse camp_invite/recruited/official_visit_* → `visiting`.
+
+**Still open (non-blocking, defaults chosen):**
+4. Should `not_pursuing` be reversible (re-open), and does re-opening reset stage?
+   *(Default: reversible via manual status change; no auto-reset.)*
+5. Do we surface auto-advance to the user (toast: "Ashland moved to Contacted")?
+   *(Default: no toast for now; revisit after stepper ships.)*
+6. `visiting` — one stage (chosen). Stepper shows a single Visiting node.
+
+---
+
+## Already shipped (interim)
+
+- Migration `20260828000001_advance_school_status_on_interaction` — trigger +
+  backfill: researching/NULL → contacted on interaction.
+- Migration `20260828000002_advance_from_interested` — widened to include
+  `interested`; backfilled. (owen@andrikanich.com: Ashland `interested`→`contacted`,
+  now shows 1 contacted.)
+- Both applied to prod (`Recruiting Tracker 2025`, `xpxzhqghxecsjhvklsqg`).
+- iOS required **no** code change — stat already reads `status == 'contacted'`.

--- a/planning/2026-08-21-school-status-pipeline-spec.md
+++ b/planning/2026-08-21-school-status-pipeline-spec.md
@@ -195,6 +195,33 @@ Each phase: build gate per platform (`npx tsc --noEmit` web,
 
 ---
 
+## Pipeline stepper UI (spec)
+
+A visual progress indicator on the school detail screen, both platforms.
+
+- **Form:** horizontal stepper over the 5 progress stages (researching →
+  contacted → visiting → offer_received → committed) as ordered nodes joined by
+  connectors. Compact labels: Researching / Contacted / Visiting / Offer /
+  Committed.
+- **State per node:** completed (`rank < current`) = filled + checkmark;
+  current (`== current`) = accent, emphasized; upcoming (`rank > current`) =
+  muted/hollow. Connectors before the current node read as "done".
+- **Interactive:** tapping a node sets the school's status to that stage (same
+  path as the old dropdown). Manual moves allowed in either direction (matches
+  web `updateStatus`); auto-advance still only ever moves forward.
+- **Off-ramp:** `not_pursuing` is NOT a 6th node. When active, the stepper
+  renders dimmed and a "Not pursuing" banner shows with a **Reactivate** action
+  (returns to `researching`). When not active, a secondary **Mark not pursuing**
+  button sits below the stepper.
+- **Placement:** replaces the status dropdown as the primary control in the
+  "Recruiting Status" section (iOS `SchoolRecruitingStatusAndTierSection`; web
+  detail header/section). The dropdown is retired.
+- **Accessibility:** each node is a button labelled "Set status to X" plus its
+  state (current/completed/upcoming); the section keeps its "Recruiting Status"
+  header.
+- **Loading:** while a status update is in flight, the stepper is disabled and
+  shows a spinner in the header (existing `isUpdatingStatus` flag).
+
 ## Already shipped (interim)
 
 - Migration `20260828000001_advance_school_status_on_interaction` — trigger +

--- a/supabase/migrations/20260828000001_advance_school_status_on_interaction.sql
+++ b/supabase/migrations/20260828000001_advance_school_status_on_interaction.sql
@@ -1,0 +1,85 @@
+-- Auto-advance a school from the initial 'researching' stage to 'contacted'
+-- the first time an interaction is logged against it.
+--
+-- Why: the Schools "Contacted" stat (iOS SchoolsListViewModel + web
+-- useSchoolStats) counts schools whose status == 'contacted'. Logging an
+-- interaction never touched school.status, so a school you'd clearly reached
+-- out to still showed as 'researching' and never counted as contacted.
+--
+-- Rule: advance ONLY from 'researching' (or NULL). Any later stage
+-- (interested/committed/offer_received/etc.) is left untouched — 'interested'
+-- and beyond sit *after* 'contacted' in the funnel, so moving them would be a
+-- backward step. This keeps the pipeline monotonic and avoids double-counting.
+--
+-- Runs at the DB layer so iOS and web get identical behavior with no app code.
+
+create or replace function public.advance_school_status_on_interaction()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  current_status public.school_status;
+begin
+  select status into current_status
+  from public.schools
+  where id = new.school_id;
+
+  -- Only the initial stage (researching / NULL) auto-advances.
+  if current_status is not null
+     and current_status <> 'researching'::public.school_status then
+    return new;
+  end if;
+
+  update public.schools
+  set status = 'contacted'::public.school_status,
+      status_changed_at = now(),
+      updated_by = new.logged_by,
+      updated_at = now()
+  where id = new.school_id;
+
+  insert into public.school_status_history
+    (school_id, previous_status, new_status, changed_by, changed_at, notes)
+  values
+    (new.school_id, current_status::text, 'contacted', new.logged_by, now(),
+     'Auto-advanced: interaction logged');
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_advance_school_status_on_interaction on public.interactions;
+
+create trigger trg_advance_school_status_on_interaction
+after insert on public.interactions
+for each row
+execute function public.advance_school_status_on_interaction();
+
+-- One-time backfill: schools that already have interactions but are still at
+-- the initial stage. Uses the earliest interaction's logger as changed_by.
+with to_advance as (
+  select s.id as school_id,
+         s.status::text as previous_status,
+         (array_agg(i.logged_by order by i.created_at asc))[1] as first_logged_by
+  from public.schools s
+  join public.interactions i on i.school_id = s.id
+  where s.status is null
+     or s.status = 'researching'::public.school_status
+  group by s.id, s.status
+),
+updated as (
+  update public.schools s
+  set status = 'contacted'::public.school_status,
+      status_changed_at = now(),
+      updated_by = ta.first_logged_by,
+      updated_at = now()
+  from to_advance ta
+  where s.id = ta.school_id
+  returning s.id
+)
+insert into public.school_status_history
+  (school_id, previous_status, new_status, changed_by, changed_at, notes)
+select ta.school_id, ta.previous_status, 'contacted', ta.first_logged_by, now(),
+       'Auto-advanced (backfill): existing interaction'
+from to_advance ta;

--- a/supabase/migrations/20260828000002_advance_from_interested.sql
+++ b/supabase/migrations/20260828000002_advance_from_interested.sql
@@ -1,0 +1,81 @@
+-- Patch: also auto-advance schools at the 'interested' stage to 'contacted'
+-- when an interaction is logged (previously only 'researching'/NULL advanced).
+--
+-- Rationale: pending the full pipeline formalization (see
+-- planning/2026-08-21-school-status-pipeline-spec.md), 'interested' is an
+-- affinity signal that currently lives on the progress axis and sits *before*
+-- 'contacted' in the iOS ordering. A school you've logged interactions against
+-- should read as contacted regardless of whether it was tagged 'interested'.
+--
+-- Superseded design note: the long-term fix moves 'interested' off the status
+-- axis onto the favorite flag. This patch is the interim behavior.
+
+create or replace function public.advance_school_status_on_interaction()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  current_status public.school_status;
+begin
+  select status into current_status
+  from public.schools
+  where id = new.school_id;
+
+  -- Pre-contact stages that auto-advance: NULL, researching, interested.
+  if current_status is not null
+     and current_status not in (
+       'researching'::public.school_status,
+       'interested'::public.school_status
+     ) then
+    return new;
+  end if;
+
+  update public.schools
+  set status = 'contacted'::public.school_status,
+      status_changed_at = now(),
+      updated_by = new.logged_by,
+      updated_at = now()
+  where id = new.school_id;
+
+  insert into public.school_status_history
+    (school_id, previous_status, new_status, changed_by, changed_at, notes)
+  values
+    (new.school_id, current_status::text, 'contacted', new.logged_by, now(),
+     'Auto-advanced: interaction logged');
+
+  return new;
+end;
+$$;
+
+-- Backfill schools now covered by the widened rule (interested + any
+-- researching missed earlier) that already have interactions.
+with to_advance as (
+  select s.id as school_id,
+         s.status::text as previous_status,
+         (array_agg(i.logged_by order by i.created_at asc))[1] as first_logged_by
+  from public.schools s
+  join public.interactions i on i.school_id = s.id
+  where s.status is null
+     or s.status in (
+       'researching'::public.school_status,
+       'interested'::public.school_status
+     )
+  group by s.id, s.status
+),
+updated as (
+  update public.schools s
+  set status = 'contacted'::public.school_status,
+      status_changed_at = now(),
+      updated_by = ta.first_logged_by,
+      updated_at = now()
+  from to_advance ta
+  where s.id = ta.school_id
+  returning s.id
+)
+insert into public.school_status_history
+  (school_id, previous_status, new_status, changed_by, changed_at, notes)
+select ta.school_id, ta.previous_status, 'contacted', ta.first_logged_by, now(),
+       'Auto-advanced (backfill): existing interaction'
+from to_advance ta;

--- a/supabase/migrations/20260828000003_add_visiting_status.sql
+++ b/supabase/migrations/20260828000003_add_visiting_status.sql
@@ -1,0 +1,4 @@
+-- Pipeline formalization phase 1a: add the new 'visiting' stage value.
+-- Must be a standalone migration — a new enum value cannot be USED in the same
+-- transaction that adds it. Data reconciliation follows in 20260828000004.
+alter type public.school_status add value if not exists 'visiting';

--- a/supabase/migrations/20260828000004_reconcile_school_status_pipeline.sql
+++ b/supabase/migrations/20260828000004_reconcile_school_status_pipeline.sql
@@ -1,0 +1,40 @@
+-- Pipeline formalization phase 1b: reconcile existing rows to the canonical
+-- 5-stage funnel (researching -> contacted -> visiting -> offer_received ->
+-- committed) + off-ramp not_pursuing. See
+-- planning/2026-08-21-school-status-pipeline-spec.md.
+--
+-- No school_status_history rows are written here: this is a one-time bulk data
+-- reconciliation, not a user-driven status change, and there is no natural
+-- actor (changed_by is NOT NULL FK to auth.users). Trigger-driven and manual
+-- changes continue to write history normally.
+
+-- 'interested' is an affinity, not a progress stage -> move to the favorite flag.
+-- Interested rows WITH interactions already became 'contacted' via
+-- 20260828000002; the conditional keeps this idempotent. Remaining interested
+-- rows (no interactions) drop back to 'researching'.
+update public.schools s
+set is_favorite = true,
+    status = case
+      when exists (select 1 from public.interactions i where i.school_id = s.id)
+        then 'contacted'::public.school_status
+      else 'researching'::public.school_status
+    end,
+    updated_at = now()
+where s.status = 'interested'::public.school_status;
+
+-- Collapse recruiting/visit granularity into the single 'visiting' stage.
+update public.schools
+set status = 'visiting'::public.school_status,
+    updated_at = now()
+where status in (
+  'recruited'::public.school_status,
+  'camp_invite'::public.school_status,
+  'official_visit_invited'::public.school_status,
+  'official_visit_scheduled'::public.school_status
+);
+
+-- Collapse the web-only 'declined' off-ramp into 'not_pursuing'.
+update public.schools
+set status = 'not_pursuing'::public.school_status,
+    updated_at = now()
+where status = 'declined'::public.school_status;

--- a/tests/unit/components/Dashboard/SchoolInterestChart.spec.ts
+++ b/tests/unit/components/Dashboard/SchoolInterestChart.spec.ts
@@ -75,8 +75,8 @@ describe("SchoolInterestChart", () => {
   describe("status counting", () => {
     it("counts schools by their pipeline status", () => {
       const schools = [
-        createMockSchool({ status: "interested" }),
-        createMockSchool({ status: "interested" }),
+        createMockSchool({ status: "visiting" }),
+        createMockSchool({ status: "visiting" }),
         createContactedSchool(),
         createOfferSchool(),
         createCommittedSchool(),
@@ -89,13 +89,13 @@ describe("SchoolInterestChart", () => {
 
       expect(statusData[0]).toBe(0); // researching
       expect(statusData[1]).toBe(1); // contacted
-      expect(statusData[2]).toBe(2); // interested
+      expect(statusData[2]).toBe(2); // visiting
       expect(statusData[3]).toBe(1); // offer_received
       expect(statusData[4]).toBe(1); // committed
     });
 
     it("maps statuses to human-readable labels", () => {
-      const schools = [createMockSchool({ status: "interested" })];
+      const schools = [createMockSchool({ status: "visiting" })];
       wrapper = mountChart(schools);
 
       const chartConfig = chartConstructorCalls[0][1] as any;
@@ -104,14 +104,14 @@ describe("SchoolInterestChart", () => {
       expect(labels).toEqual([
         "Researching",
         "Contacted",
-        "Interested",
+        "Visiting",
         "Offer Received",
         "Committed",
       ]);
     });
 
     it("assigns distinct colors per status", () => {
-      const schools = [createMockSchool({ status: "interested" })];
+      const schools = [createMockSchool({ status: "visiting" })];
       wrapper = mountChart(schools);
 
       const chartConfig = chartConstructorCalls[0][1] as any;
@@ -142,7 +142,7 @@ describe("SchoolInterestChart", () => {
 
   describe("chart lifecycle", () => {
     it("creates a Chart.js bar chart on mount with data", () => {
-      const schools = [createMockSchool({ status: "interested" })];
+      const schools = [createMockSchool({ status: "visiting" })];
       wrapper = mountChart(schools);
 
       expect(chartConstructorCalls).toHaveLength(1);
@@ -153,14 +153,14 @@ describe("SchoolInterestChart", () => {
     });
 
     it("destroys previous chart before creating new one on data change", async () => {
-      const schools = [createMockSchool({ status: "interested" })];
+      const schools = [createMockSchool({ status: "visiting" })];
       wrapper = mountChart(schools);
 
       expect(chartConstructorCalls).toHaveLength(1);
 
       await wrapper.setProps({
         schools: [
-          createMockSchool({ status: "interested" }),
+          createMockSchool({ status: "visiting" }),
           createContactedSchool(),
         ],
       });
@@ -169,14 +169,14 @@ describe("SchoolInterestChart", () => {
     });
 
     it("reinitializes chart when schools data changes", async () => {
-      const schools = [createMockSchool({ status: "interested" })];
+      const schools = [createMockSchool({ status: "visiting" })];
       wrapper = mountChart(schools);
 
       expect(chartConstructorCalls).toHaveLength(1);
 
       await wrapper.setProps({
         schools: [
-          createMockSchool({ status: "interested" }),
+          createMockSchool({ status: "visiting" }),
           createContactedSchool(),
           createOfferSchool(),
         ],

--- a/tests/unit/components/School/SchoolForm.spec.ts
+++ b/tests/unit/components/School/SchoolForm.spec.ts
@@ -496,10 +496,10 @@ describe("SchoolForm", () => {
       expect(values).toEqual([
         "researching",
         "contacted",
-        "interested",
+        "visiting",
         "offer_received",
-        "declined",
         "committed",
+        "not_pursuing",
       ]);
     });
   });

--- a/tests/unit/components/School/SchoolRecruitingStatusSection.spec.ts
+++ b/tests/unit/components/School/SchoolRecruitingStatusSection.spec.ts
@@ -15,33 +15,24 @@ describe("SchoolRecruitingStatusSection", () => {
     expect(mountSection().text()).toContain("Recruiting Status");
   });
 
-  it("renders all 6 canonical options in the dropdown", () => {
-    const options = mountSection().find("select").findAll("option");
-    expect(options).toHaveLength(6);
-    expect(options[0].text()).toBe("Researching");
-    expect(options.at(-1)?.text()).toBe("Not Pursuing");
-  });
-
-  it("selects the current status", () => {
-    const select = mountSection({ status: "committed" }).find("select");
-    expect((select.element as HTMLSelectElement).value).toBe("committed");
-  });
-
-  it("emits update:status with the chosen value", async () => {
+  it("renders the 5-node progress stepper (not a dropdown)", () => {
     const wrapper = mountSection();
-    await wrapper.find("select").setValue("offer_received");
-    expect(wrapper.emitted("update:status")?.[0]).toEqual(["offer_received"]);
+    expect(wrapper.find("select").exists()).toBe(false);
+    expect(wrapper.findAll("ol button")).toHaveLength(5);
   });
 
-  it("disables the select while updating", () => {
-    const select = mountSection({ statusUpdating: true }).find("select");
-    expect((select.element as HTMLSelectElement).disabled).toBe(true);
+  it("re-emits update:status when a stepper node is chosen", async () => {
+    const wrapper = mountSection();
+    await wrapper.findAll("ol button")[1].trigger("click");
+    expect(wrapper.emitted("update:status")?.[0]).toEqual(["contacted"]);
   });
 
-  it("does not render a separate status badge (header pill owns that)", () => {
-    const wrapper = mountSection({ status: "committed" });
-    // only occurrence of the label is the selected <option>, no badge pill
-    const badge = wrapper.find("span.rounded-full");
-    expect(badge.exists()).toBe(false);
+  it("shows a spinner and disables nodes while updating", () => {
+    const wrapper = mountSection({ statusUpdating: true });
+    expect(wrapper.find("[role='status']").exists()).toBe(true);
+    const buttons = wrapper.findAll("ol button");
+    expect(buttons.every((b) => b.attributes("disabled") !== undefined)).toBe(
+      true,
+    );
   });
 });

--- a/tests/unit/components/School/SchoolRecruitingStatusSection.spec.ts
+++ b/tests/unit/components/School/SchoolRecruitingStatusSection.spec.ts
@@ -6,7 +6,7 @@ const mountSection = (
   props: Partial<{ status: string; statusUpdating: boolean }> = {},
 ) =>
   mount(SchoolRecruitingStatusSection, {
-    props: { status: "interested", statusUpdating: false, ...props },
+    props: { status: "researching", statusUpdating: false, ...props },
     global: { stubs: { UIcon: true } },
   });
 
@@ -15,9 +15,9 @@ describe("SchoolRecruitingStatusSection", () => {
     expect(mountSection().text()).toContain("Recruiting Status");
   });
 
-  it("renders all 10 parity options in the dropdown", () => {
+  it("renders all 6 canonical options in the dropdown", () => {
     const options = mountSection().find("select").findAll("option");
-    expect(options).toHaveLength(10);
+    expect(options).toHaveLength(6);
     expect(options[0].text()).toBe("Researching");
     expect(options.at(-1)?.text()).toBe("Not Pursuing");
   });

--- a/tests/unit/components/School/SchoolStatusStepper.spec.ts
+++ b/tests/unit/components/School/SchoolStatusStepper.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import SchoolStatusStepper from "~/components/School/SchoolStatusStepper.vue";
+import type { SchoolStatusValue } from "~/utils/schoolStatusOptions";
+
+const mountStepper = (
+  props: Partial<{ status: SchoolStatusValue; updating: boolean }> = {},
+) =>
+  mount(SchoolStatusStepper, {
+    props: { status: "researching", ...props },
+    global: { stubs: { UIcon: true } },
+  });
+
+const stepButtons = (wrapper: ReturnType<typeof mountStepper>) =>
+  wrapper.findAll("ol button");
+
+describe("SchoolStatusStepper", () => {
+  it("renders exactly the 5 progress nodes (no not_pursuing node)", () => {
+    const buttons = stepButtons(mountStepper());
+    expect(buttons).toHaveLength(5);
+    const labels = wrapperLabels(mountStepper());
+    expect(labels).toEqual([
+      "Researching",
+      "Contacted",
+      "Visiting",
+      "Offer",
+      "Committed",
+    ]);
+  });
+
+  it("marks completed and current nodes for a mid-funnel status", () => {
+    const buttons = stepButtons(mountStepper({ status: "visiting" }));
+    // researching(0), contacted(1) completed; visiting(2) current; rest upcoming
+    expect(buttons[0].attributes("aria-label")).toContain("(completed)");
+    expect(buttons[1].attributes("aria-label")).toContain("(completed)");
+    expect(buttons[2].attributes("aria-label")).toContain("(current stage)");
+    expect(buttons[2].attributes("aria-current")).toBe("step");
+    expect(buttons[3].attributes("aria-label")).toContain("(upcoming)");
+    expect(buttons[4].attributes("aria-label")).toContain("(upcoming)");
+  });
+
+  it("emits select with the stage value on node click", async () => {
+    const wrapper = mountStepper({ status: "researching" });
+    await stepButtons(wrapper)[3].trigger("click");
+    expect(wrapper.emitted("select")?.[0]).toEqual(["offer_received"]);
+  });
+
+  it("shows Reactivate when not_pursuing and emits select('researching')", async () => {
+    const wrapper = mountStepper({ status: "not_pursuing" });
+    expect(wrapper.find("[data-testid='mark-not-pursuing']").exists()).toBe(
+      false,
+    );
+    const reactivate = wrapper.find("[data-testid='reactivate-status']");
+    expect(reactivate.exists()).toBe(true);
+    expect(wrapper.text()).toContain("Not pursuing");
+    await reactivate.trigger("click");
+    expect(wrapper.emitted("select")?.[0]).toEqual(["researching"]);
+  });
+
+  it("emits select('not_pursuing') from the Mark-not-pursuing button", async () => {
+    const wrapper = mountStepper({ status: "contacted" });
+    const mark = wrapper.find("[data-testid='mark-not-pursuing']");
+    expect(mark.exists()).toBe(true);
+    await mark.trigger("click");
+    expect(wrapper.emitted("select")?.[0]).toEqual(["not_pursuing"]);
+  });
+
+  it("disables all node buttons while updating", () => {
+    const buttons = stepButtons(mountStepper({ updating: true }));
+    expect(buttons.every((b) => b.attributes("disabled") !== undefined)).toBe(
+      true,
+    );
+  });
+});
+
+const wrapperLabels = (wrapper: ReturnType<typeof mountStepper>): string[] =>
+  wrapper.findAll("ol li span.text-center").map((s) => s.text());

--- a/tests/unit/composables/useRecruitingPacket.spec.ts
+++ b/tests/unit/composables/useRecruitingPacket.spec.ts
@@ -93,7 +93,7 @@ const mockSchoolData: School[] = [
     location: "Houston, TX",
     division: "D1",
     conference: "Conference USA",
-    status: "camp_invite",
+    status: "visiting",
     is_favorite: false,
     user_id: "test-user-id",
     website: null,
@@ -374,7 +374,7 @@ describe("useRecruitingPacket", () => {
         generatedData.value?.schools.tier_a.some((s) => s.id === "school-1"),
       ).toBe(true);
 
-      // Rice should be in tier_b (camp_invite)
+      // Rice should be in tier_b (visiting)
       expect(
         generatedData.value?.schools.tier_b.some((s) => s.id === "school-2"),
       ).toBe(true);

--- a/tests/unit/composables/useSchoolStats.spec.ts
+++ b/tests/unit/composables/useSchoolStats.spec.ts
@@ -142,22 +142,27 @@ describe("useSchoolStats", () => {
     });
   });
 
-  it("counts contacted schools by status", () => {
+  it("counts contacted schools by logged interactions, not status", () => {
     const schools = ref<School[]>([
+      // Has an interaction → counts, regardless of funnel stage.
       {
         id: "1",
         name: "S1",
-        status: "contacted",
+        status: "committed",
         family_unit_id: "f1",
       } as School,
+      // Sits at `contacted` status but has NO interaction → does NOT count.
       {
         id: "2",
         name: "S2",
-        status: "interested",
+        status: "contacted",
         family_unit_id: "f1",
       } as School,
     ]);
-    const { stats } = useSchoolStats(schools, noInteractions(), noEvents());
+    const interactions = ref<Interaction[]>([
+      { id: "i1", school_id: "1", type: "email" } as Interaction,
+    ]);
+    const { stats } = useSchoolStats(schools, interactions, noEvents());
     expect(stats.value[3].label).toBe("Contacted");
     expect(stats.value[3].value).toBe(1);
   });

--- a/tests/unit/utils/schoolStatusOptions.spec.ts
+++ b/tests/unit/utils/schoolStatusOptions.spec.ts
@@ -6,37 +6,38 @@ import {
 } from "~/utils/schoolStatusOptions";
 
 describe("schoolStatusOptions", () => {
-  it("exposes the full 10-status parity set in funnel order", () => {
+  it("exposes the 6 canonical statuses in funnel order", () => {
     expect(SCHOOL_STATUS_OPTIONS.map((o) => o.value)).toEqual([
       "researching",
-      "interested",
       "contacted",
-      "camp_invite",
-      "recruited",
-      "official_visit_invited",
-      "official_visit_scheduled",
+      "visiting",
       "offer_received",
       "committed",
       "not_pursuing",
     ]);
   });
 
-  it("does not expose unknown or declined as selectable options", () => {
+  it("does not expose unknown, declined, or legacy values as selectable options", () => {
     const values = SCHOOL_STATUS_OPTIONS.map((o) => o.value);
     expect(values).not.toContain("unknown");
     expect(values).not.toContain("declined");
+    expect(values).not.toContain("interested");
+    expect(values).not.toContain("camp_invite");
+    expect(values).not.toContain("recruited");
+    expect(values).not.toContain("official_visit_invited");
+    expect(values).not.toContain("official_visit_scheduled");
   });
 
   it("labels match the iOS displayName vocabulary", () => {
-    expect(getSchoolStatusLabel("camp_invite")).toBe("Camp Invite");
-    expect(getSchoolStatusLabel("official_visit_invited")).toBe(
-      "Official Visit Invited",
-    );
+    expect(getSchoolStatusLabel("researching")).toBe("Researching");
+    expect(getSchoolStatusLabel("visiting")).toBe("Visiting");
+    expect(getSchoolStatusLabel("offer_received")).toBe("Offer Received");
     expect(getSchoolStatusLabel("not_pursuing")).toBe("Not Pursuing");
   });
 
-  it("falls back to Title-Cased snake_case for unmapped values", () => {
+  it("falls back to Title-Cased snake_case for unmapped/legacy values", () => {
     expect(getSchoolStatusLabel("declined")).toBe("Declined");
+    expect(getSchoolStatusLabel("camp_invite")).toBe("Camp Invite");
     expect(getSchoolStatusLabel("some_legacy_value")).toBe("Some Legacy Value");
   });
 

--- a/types/models.ts
+++ b/types/models.ts
@@ -78,12 +78,8 @@ export interface School {
   ncaa_id?: string | null;
   status:
     | "researching"
-    | "interested"
     | "contacted"
-    | "camp_invite"
-    | "recruited"
-    | "official_visit_invited"
-    | "official_visit_scheduled"
+    | "visiting"
     | "offer_received"
     | "committed"
     | "not_pursuing";

--- a/utils/schoolFilterConfigs.ts
+++ b/utils/schoolFilterConfigs.ts
@@ -10,6 +10,7 @@ import type { School } from "~/types";
 import type { HomeLocation } from "~/types/models";
 import type { FilterConfig, FilterValue } from "~/types/filters";
 import { extractStateFromLocation } from "~/utils/locationParser";
+import { SCHOOL_STATUS_OPTIONS } from "~/utils/schoolStatusOptions";
 
 export function createSchoolFilterConfigs(
   stateOptions: ComputedRef<{ value: string; label: string }[]>,
@@ -52,13 +53,10 @@ export function createSchoolFilterConfigs(
       type: "select",
       field: "status",
       label: "Status",
-      options: [
-        { value: "researching", label: "Researching" },
-        { value: "contacted", label: "Contacted" },
-        { value: "interested", label: "Interested" },
-        { value: "offer_received", label: "Offer Received" },
-        { value: "committed", label: "Committed" },
-      ],
+      options: SCHOOL_STATUS_OPTIONS.map((option) => ({
+        value: option.value,
+        label: option.label,
+      })),
     },
     { type: "boolean", field: "is_favorite", label: "Favorites Only" },
     {

--- a/utils/schoolStatusOptions.ts
+++ b/utils/schoolStatusOptions.ts
@@ -1,21 +1,29 @@
 /**
  * Canonical recruiting-status vocabulary — the single source of truth shared by
- * the detail header pill, the sidebar "Recruiting Status" dropdown, and the
- * status-history badges. Kept in lock-step with the iOS SchoolStatus enum
- * (values, labels, and 100/700 badge palette) for web ↔ iOS parity.
+ * the detail header pill, the sidebar "Recruiting Status" dropdown, the school
+ * form, the filter panel, and the status-history badges. Kept in lock-step with
+ * the iOS SchoolStatus enum (values, labels, and 100/700 badge palette) for
+ * web ↔ iOS parity.
  *
- * `unknown` and `declined` exist in the DB enum as fallbacks/legacy but are NOT
- * user-selectable here.
+ * The status field is a monotonic recruiting funnel:
+ *   researching → contacted → visiting → offer_received → committed
+ * plus the terminal off-ramp `not_pursuing`. `visiting` collapses the legacy
+ * camp_invite / recruited / official_visit_invited / official_visit_scheduled
+ * values into one stage; legacy `declined` maps to `not_pursuing`.
+ *
+ * Affinity ("interested") is NOT a status — it is expressed via the school's
+ * favorite flag (`is_favorite`), not this enum.
+ *
+ * See planning/2026-08-21-school-status-pipeline-spec.md.
+ *
+ * `unknown` and legacy values may still exist in the DB enum as fallbacks but
+ * are NOT user-selectable here.
  */
 
 export type SchoolStatusValue =
   | "researching"
-  | "interested"
   | "contacted"
-  | "camp_invite"
-  | "recruited"
-  | "official_visit_invited"
-  | "official_visit_scheduled"
+  | "visiting"
   | "offer_received"
   | "committed"
   | "not_pursuing";
@@ -26,16 +34,11 @@ export interface SchoolStatusOption {
   badgeClass: string;
 }
 
-/** Ordered as a recruiting funnel; drives the dropdown option order. */
+/** Ordered as a monotonic recruiting funnel; drives the dropdown option order. */
 export const SCHOOL_STATUS_OPTIONS: readonly SchoolStatusOption[] = [
   {
     value: "researching",
     label: "Researching",
-    badgeClass: "bg-slate-100 text-slate-700",
-  },
-  {
-    value: "interested",
-    label: "Interested",
     badgeClass: "bg-slate-100 text-slate-700",
   },
   {
@@ -44,23 +47,8 @@ export const SCHOOL_STATUS_OPTIONS: readonly SchoolStatusOption[] = [
     badgeClass: "bg-blue-100 text-blue-700",
   },
   {
-    value: "camp_invite",
-    label: "Camp Invite",
-    badgeClass: "bg-purple-100 text-purple-700",
-  },
-  {
-    value: "recruited",
-    label: "Recruited",
-    badgeClass: "bg-emerald-100 text-emerald-700",
-  },
-  {
-    value: "official_visit_invited",
-    label: "Official Visit Invited",
-    badgeClass: "bg-orange-100 text-orange-700",
-  },
-  {
-    value: "official_visit_scheduled",
-    label: "Official Visit Scheduled",
+    value: "visiting",
+    label: "Visiting",
     badgeClass: "bg-orange-100 text-orange-700",
   },
   {


### PR DESCRIPTION
## Why
Schools "Contacted" showed 0 while the dashboard showed 3 interactions. `status` conflated **progress** (funnel) with **affinity** (a feeling); the Contacted stat counted `status === 'contacted'`, so a school with logged interactions parked at `interested` never counted.

## What
- **Canonical funnel:** `researching → contacted → visiting → offer_received → committed`, off-ramp `not_pursuing`. `interested` → favorite flag; camp_invite/recruited/official_visit_* → `visiting`; legacy `declined` → `not_pursuing`.
- `SCHOOL_STATUS_OPTIONS` (single source of truth) reduced to the 6 canonical values; `SchoolForm`, `FilterPanel`, `SchoolListCard`, `schoolFilterConfigs`, and the dashboard `SchoolStatusOverview` / `SchoolInterestChart` all derive from it.
- **"Contacted" stat is now activity-derived** — schools with ≥1 interaction (`useSchoolStats`).
- Recruiting-packet tiers collapse onto the canonical stages.

## DB
Adds migrations `20260828000001..000004`: interaction→contacted trigger + backfill, add `visiting` enum value, one-time row reconciliation. **Already applied to prod** (`Recruiting Tracker 2025`).

## Cross-platform
Parity change — iOS PR ships the same day.

## Tests
`type-check` clean; 427 specs green + `SchoolInterestChart` 13/13; 6 specs updated to canonical vocabulary.

https://claude.ai/code/session_01JrwznWssjrRNVdwJc7KUqv