### PR TITLE
feat(schools): toast when logging an interaction advances a school to Contacted

### DIFF
--- a/pages/interactions/add.vue
+++ b/pages/interactions/add.vue
@@ -4,7 +4,8 @@ import { navigateTo } from "#app";
 import { useInteractions } from "~/composables/useInteractions";
 import { useUserStore } from "~/stores/user";
 import { useAppToast } from "~/composables/useAppToast";
-import type { Interaction } from "~/types/models";
+import { useSupabase } from "~/composables/useSupabase";
+import type { Interaction, School } from "~/types/models";
 import { createClientLogger } from "~/utils/logger";
 
 definePageMeta({
@@ -38,7 +39,29 @@ const handleSubmit = async (formData: any) => {
       attachments: [], // Will be populated by createInteraction if files are uploaded
     };
 
+    // A DB trigger auto-advances a pre-contact school to `contacted` when an
+    // interaction is logged. Look up the school's pre-contact state (no School
+    // object is in scope here) so we can confirm the advance afterward — matches
+    // the iOS manual-log flow.
+    let wasPreContact = false;
+    let advancedSchoolName = "";
+    if (formData.school_id) {
+      const supabase = useSupabase();
+      const { data: schoolRow } = await supabase
+        .from("schools")
+        .select("status, name")
+        .eq("id", formData.school_id)
+        .maybeSingle();
+      const school = schoolRow as Pick<School, "status" | "name"> | null;
+      wasPreContact = school?.status === "researching";
+      advancedSchoolName = school?.name ?? "";
+    }
+
     await createInteraction(interactionData);
+
+    if (wasPreContact) {
+      showToast(`${advancedSchoolName} moved to Contacted`, "success");
+    }
 
     await navigateTo("/interactions");
   } catch (err) {

--- a/pages/schools/[id]/interactions.vue
+++ b/pages/schools/[id]/interactions.vue
@@ -190,6 +190,7 @@ import { useInteractions } from "~/composables/useInteractions";
 import { useInteractionReminders } from "~/composables/useInteractionReminders";
 import { useCoaches } from "~/composables/useCoaches";
 import { useSchools } from "~/composables/useSchools";
+import { useAppToast } from "~/composables/useAppToast";
 import type { Interaction, School } from "~/types/models";
 import { useLiveRegion } from "~/composables/useLiveRegion";
 import { parseLocalDateOnly } from "~/utils/localDate";
@@ -211,6 +212,7 @@ const {
 const { createReminder } = useInteractionReminders();
 const { coaches, fetchCoaches } = useCoaches();
 const { getSchool } = useSchools();
+const { showToast } = useAppToast();
 
 const { announcement, announce, liveRegionAttrs } = useLiveRegion();
 const isDeleteDialogOpen = ref(false);
@@ -315,6 +317,12 @@ const handleAddInteraction = async (data: InteractionSubmitData) => {
     const occurredAtDate = new Date(data.occurred_at);
     const isoDatetime = occurredAtDate.toISOString();
 
+    // A DB trigger auto-advances a pre-contact school to `contacted` when an
+    // interaction is logged. Capture the pre-contact state before the create so
+    // we can confirm the advance to the user afterward (matches iOS manual-log).
+    const wasPreContact = schoolData.value?.status === "researching";
+    const advancedSchoolName = schoolName.value;
+
     const createdInteraction = await createInteraction(
       {
         school_id: id,
@@ -358,6 +366,10 @@ const handleAddInteraction = async (data: InteractionSubmitData) => {
 
     showAddForm.value = false;
     await fetchInteractions({ schoolId: id });
+
+    if (wasPreContact) {
+      showToast(`${advancedSchoolName} moved to Contacted`, "success");
+    }
   } catch (err) {
     logger.error("Failed to log interaction", err);
     const errorMsg =

--- a/tests/unit/pages/interactions-add.spec.ts
+++ b/tests/unit/pages/interactions-add.spec.ts
@@ -5,6 +5,16 @@ import { createPinia, setActivePinia } from "pinia";
 const createInteractionMock = vi.fn();
 const showToastMock = vi.fn();
 
+// Configurable result for the pre-contact school lookup performed before the
+// interaction is created. Defaults to a non-pre-contact school so the baseline
+// success path fires no auto-advance toast.
+let schoolLookupResult: { status: string; name: string } | null = {
+  status: "contacted",
+  name: "State University",
+};
+
+const maybeSingleMock = vi.fn(async () => ({ data: schoolLookupResult }));
+
 vi.mock("~/composables/useInteractions", () => ({
   useInteractions: () => ({
     createInteraction: createInteractionMock,
@@ -14,6 +24,18 @@ vi.mock("~/composables/useInteractions", () => ({
 
 vi.mock("~/composables/useAppToast", () => ({
   useAppToast: () => ({ showToast: showToastMock }),
+}));
+
+vi.mock("~/composables/useSupabase", () => ({
+  useSupabase: () => ({
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: maybeSingleMock,
+        }),
+      }),
+    }),
+  }),
 }));
 
 import InteractionsAddPage from "~/pages/interactions/add.vue";
@@ -40,6 +62,7 @@ describe("pages/interactions/add.vue", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.clearAllMocks();
+    schoolLookupResult = { status: "contacted", name: "State University" };
   });
 
   const mountPage = () =>
@@ -54,6 +77,35 @@ describe("pages/interactions/add.vue", () => {
 
   it("navigates away and shows no error toast on success", async () => {
     createInteractionMock.mockResolvedValue({ id: "int-1" });
+    const wrapper = mountPage();
+    const form = wrapper.findComponent(InteractionFormStub);
+
+    await form.vm.$emit("submit", samplePayload);
+    await wrapper.vm.$nextTick();
+
+    expect(createInteractionMock).toHaveBeenCalled();
+    expect(showToastMock).not.toHaveBeenCalled();
+  });
+
+  it("shows the auto-advance toast when a researching school gets an interaction", async () => {
+    schoolLookupResult = { status: "researching", name: "Coastal College" };
+    createInteractionMock.mockResolvedValue({ id: "int-2" });
+    const wrapper = mountPage();
+    const form = wrapper.findComponent(InteractionFormStub);
+
+    await form.vm.$emit("submit", samplePayload);
+    await wrapper.vm.$nextTick();
+
+    expect(createInteractionMock).toHaveBeenCalled();
+    expect(showToastMock).toHaveBeenCalledWith(
+      "Coastal College moved to Contacted",
+      "success",
+    );
+  });
+
+  it("does not show the auto-advance toast when the school is already contacted", async () => {
+    schoolLookupResult = { status: "contacted", name: "Coastal College" };
+    createInteractionMock.mockResolvedValue({ id: "int-3" });
     const wrapper = mountPage();
     const form = wrapper.findComponent(InteractionFormStub);
 


### PR DESCRIPTION
Follow-up to the school-status pipeline (#412). When a user logs an interaction against a school still at the pre-contact (`researching`) stage, the DB trigger advances it to `contacted` — this surfaces a "‹School› moved to Contacted" toast (`useAppToast`) so the change isn't silent.

Covers the two manual-log surfaces:
- **school interactions tab** (`pages/schools/[id]/interactions.vue`) — status from the in-scope `schoolData`.
- **standalone `/interactions/add`** — lightweight `status,name` lookup by id before create.

Scope: manual log only. Quick Comm / event quick-log / email-confirmed excluded (own success toast). Matches iOS.

Tests: mounted-page test covers fire (researching) / no-fire (contacted); type-check clean, 87 specs green.

https://claude.ai/code/session_01JrwznWssjrRNVdwJc7KUqv