### PR TITLE
feat(metrics): multi-sport performance metrics (web parity with iOS #43)

### DIFF
--- a/components/Performance/LogMetricModal.vue
+++ b/components/Performance/LogMetricModal.vue
@@ -13,6 +13,7 @@ import { formatMetricValue } from "~/utils/metricFormat";
 import {
   metricTypesForSport,
   getMetricDef,
+  customMetricKey,
   OTHER_KEY,
 } from "~/utils/metrics/canonical";
 
@@ -88,7 +89,7 @@ const valueStep = computed(() => {
 // custom name when "other" is chosen (mirrors iOS resolvedMetricKey).
 const resolvedMetricKey = computed(() => {
   if (metricType.value !== OTHER_KEY) return metricType.value;
-  return otherName.value.trim().toLowerCase().replace(/\s+/g, "_");
+  return customMetricKey(otherName.value);
 });
 
 // Computed properties

--- a/components/Performance/LogMetricModal.vue
+++ b/components/Performance/LogMetricModal.vue
@@ -9,9 +9,18 @@ import {
 } from "vue";
 import { useEvents } from "~/composables/useEvents";
 import { usePerformance } from "~/composables/usePerformance";
+import { formatMetricValue } from "~/utils/metricFormat";
+import {
+  metricTypesForSport,
+  getMetricDef,
+  OTHER_KEY,
+} from "~/utils/metrics/canonical";
 
 interface Props {
   show: boolean;
+  /** Athlete's primary sport — drives the sport-filtered metric-type list.
+   *  Null/undefined falls back to the baseball vocabulary (no regression). */
+  primarySport?: string | null;
 }
 
 const props = defineProps<Props>();
@@ -26,19 +35,11 @@ const { events, loading: eventsLoading, fetchEvents } = useEvents();
 const { createMetric } = usePerformance();
 
 // Form state
-type MetricType =
-  | "velocity"
-  | "exit_velo"
-  | "sixty_time"
-  | "pop_time"
-  | "batting_avg"
-  | "era"
-  | "strikeouts"
-  | "other";
-const metricType = ref<MetricType | "">("");
+const metricType = ref<string>("");
 const value = ref<number | null>(null);
 const date = ref("");
 const unit = ref("");
+const otherName = ref("");
 const eventId = ref<string | null>(null);
 const verified = ref(false);
 const notes = ref("");
@@ -48,19 +49,15 @@ const error = ref<string | null>(null);
 // Refs for focus management
 const firstInputRef = ref<HTMLElement | null>(null);
 
-// Metric type options (per spec)
-const metricTypes = [
-  { value: "velocity", label: "Fastball Velocity (mph)" },
-  { value: "exit_velo", label: "Exit Velocity (mph)" },
-  { value: "sixty_time", label: "60-Yard Dash (sec)" },
-  { value: "pop_time", label: "Pop Time (sec)" },
-  { value: "batting_avg", label: "Batting Average" },
-  { value: "era", label: "ERA" },
-  { value: "strikeouts", label: "Strikeouts" },
-  { value: "other", label: "Other" },
-] as const;
+// Metric type options, ordered for the athlete's sport (registry-backed; "other" always last).
+const metricTypes = computed(() =>
+  metricTypesForSport(props.primarySport).map((key) => ({
+    value: key,
+    label: getMetricDef(key).label,
+  })),
+);
 
-// Canonical unit vocabulary — no user-created units.
+// Canonical unit vocabulary — free picker, offered only for "other".
 const unitOptions = [
   { value: "", label: "None" },
   { value: "mph", label: "mph" },
@@ -72,34 +69,33 @@ const unitOptions = [
   { value: "%", label: "%" },
 ] as const;
 
-// Fixed unit per metric type; "other" lets the user pick from the vocabulary.
-const unitByMetricType: Record<MetricType, string> = {
-  velocity: "mph",
-  exit_velo: "mph",
-  sixty_time: "sec",
-  pop_time: "sec",
-  batting_avg: "",
-  era: "",
-  strikeouts: "count",
-  other: "",
-};
-
-// Unit is locked to the metric type unless "other" is selected.
+// Unit is locked to the registry's unit unless "other" is selected.
 const unitLocked = computed(
-  () => metricType.value !== "" && metricType.value !== "other",
+  () => metricType.value !== "" && metricType.value !== OTHER_KEY,
 );
 
-// Value precision: batting average and ERA carry 3 decimals (e.g. 0.000, 3.250);
-// everything else is fine at 2.
-const valueStep = computed(() =>
-  metricType.value === "batting_avg" || metricType.value === "era"
-    ? "0.001"
-    : "0.01",
-);
+// Value precision from the registry's format (decimal digits), 2 as a sane default.
+const valueStep = computed(() => {
+  if (!metricType.value || metricType.value === OTHER_KEY) return "0.01";
+  const format = getMetricDef(metricType.value).format;
+  if (format.kind === "decimal" || format.kind === "percent") {
+    return `0.${"0".repeat(format.digits - 1)}1`;
+  }
+  return "1";
+});
+
+// The metric_type persisted on submit: the selected key, or the snake_cased
+// custom name when "other" is chosen (mirrors iOS resolvedMetricKey).
+const resolvedMetricKey = computed(() => {
+  if (metricType.value !== OTHER_KEY) return metricType.value;
+  return otherName.value.trim().toLowerCase().replace(/\s+/g, "_");
+});
 
 // Computed properties
 const isFormValid = computed(() => {
-  return metricType.value && value.value !== null && date.value;
+  if (!metricType.value || value.value === null || !date.value) return false;
+  if (metricType.value === OTHER_KEY) return otherName.value.trim().length > 0;
+  return true;
 });
 
 const sortedEvents = computed(() => {
@@ -130,6 +126,7 @@ const resetForm = () => {
   value.value = null;
   date.value = "";
   unit.value = "";
+  otherName.value = "";
   eventId.value = null;
   verified.value = false;
   notes.value = "";
@@ -144,14 +141,16 @@ const handleSubmit = async () => {
   error.value = null;
 
   try {
+    const metricKey = resolvedMetricKey.value;
     const newMetric = await createMetric({
-      metric_type: metricType.value as MetricType,
+      metric_type: metricKey,
       value: value.value!,
       recorded_date: date.value,
       unit: unit.value || "",
       event_id: eventId.value,
       verified: verified.value,
       notes: notes.value || null,
+      display_value: `${formatMetricValue(metricKey, value.value!)}${unit.value ? ` ${unit.value}` : ""}`,
     });
 
     emit("metric-created", newMetric);
@@ -185,14 +184,19 @@ onBeforeUnmount(() => {
   document.removeEventListener("keydown", handleKeydown);
 });
 
-// Auto-set canonical unit when metric type changes.
+// Auto-set the registry's unit when metric type changes; reset the custom
+// name whenever the selection moves away from "other".
 watch(metricType, (newType) => {
   if (newType === "") {
     unit.value = "";
+    otherName.value = "";
     return;
   }
-  if (newType !== "other") {
-    unit.value = unitByMetricType[newType];
+  if (newType !== OTHER_KEY) {
+    unit.value = getMetricDef(newType).unit;
+    otherName.value = "";
+  } else {
+    unit.value = "";
   }
 });
 
@@ -332,6 +336,24 @@ watch(
                   </option>
                 </select>
               </div>
+            </div>
+
+            <!-- Custom Metric Name (only for "Other") -->
+            <div v-if="metricType === OTHER_KEY" class="mb-4">
+              <label
+                for="otherName"
+                class="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Metric Name <span class="text-red-500">*</span>
+              </label>
+              <input
+                id="otherName"
+                v-model="otherName"
+                type="text"
+                required
+                class="w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-blue-500 focus:ring-1 focus:ring-blue-500"
+                placeholder="e.g. Arm Strength"
+              />
             </div>
 
             <!-- Event Dropdown (full width) -->

--- a/pages/performance/index.vue
+++ b/pages/performance/index.vue
@@ -437,6 +437,7 @@
       <!-- Log Metric Modal -->
       <PerformanceLogMetricModal
         :show="showLogMetricModal"
+        :primary-sport="primarySport"
         @close="showLogMetricModal = false"
         @metric-created="handleMetricCreated"
       />
@@ -459,6 +460,7 @@
 import { ref, onMounted, reactive, computed, defineAsyncComponent } from "vue";
 import { formatMetricValue } from "~/utils/metricFormat";
 import { usePerformance } from "~/composables/usePerformance";
+import { usePreferenceManager } from "~/composables/usePreferenceManager";
 import { useAppToast } from "~/composables/useAppToast";
 import { createClientLogger } from "~/utils/logger";
 import type { PerformanceMetric } from "~/types/models";
@@ -509,6 +511,7 @@ const {
   clearPrimaryMetric,
 } = usePerformance();
 const { showToast } = useAppToast();
+const { playerPrefs, getPlayerDetails } = usePreferenceManager();
 
 const showAddForm = ref(false);
 const showEditForm = ref(false);
@@ -517,6 +520,7 @@ const showLogMetricModal = ref(false);
 const isUpdating = ref(false);
 const editingMetric = ref<PerformanceMetric | null>(null);
 const selectedMetricType = ref("");
+const primarySport = ref<string | null>(null);
 
 const newMetric = reactive({
   metric_type: "",
@@ -842,5 +846,7 @@ const handleUpdateMetric = async () => {
 
 onMounted(async () => {
   await fetchMetrics();
+  await playerPrefs.loadPreferences();
+  primarySport.value = getPlayerDetails()?.primary_sport ?? null;
 });
 </script>

--- a/tests/unit/components/Performance/LogMetricModal.spec.ts
+++ b/tests/unit/components/Performance/LogMetricModal.spec.ts
@@ -109,7 +109,7 @@ describe("LogMetricModal - Form Fields", () => {
     expect(wrapper.find('input[type="checkbox"]').exists()).toBe(true);
   });
 
-  it("has all metric type options", () => {
+  it("has all metric type options, sport-filtered from the registry (default: baseball)", () => {
     const wrapper = mount(LogMetricModal, {
       props: { show: true },
       global: {
@@ -120,28 +120,56 @@ describe("LogMetricModal - Form Fields", () => {
     });
 
     const options = wrapper.find("#metricType").findAll("option");
-    expect(options).toHaveLength(9); // 8 types + empty option
+    expect(options).toHaveLength(13); // 11 baseball types + "other" + empty option
 
-    // Verify spec-compliant options
+    // Verify registry-backed labels (no unit repeated in the label)
     expect(options[0].text()).toBe("Select Metric");
-    expect(options[1].text()).toBe("Fastball Velocity (mph)");
-    expect(options[2].text()).toBe("Exit Velocity (mph)");
-    expect(options[3].text()).toBe("60-Yard Dash (sec)");
-    expect(options[4].text()).toBe("Pop Time (sec)");
-    expect(options[5].text()).toBe("Batting Average");
+    expect(options[1].text()).toBe("Fastball Velocity");
+    expect(options[2].text()).toBe("Exit Velocity");
+    expect(options[3].text()).toBe("Batting Average");
+    expect(options[4].text()).toBe("60-Yard Dash");
+    expect(options[5].text()).toBe("Pop Time");
     expect(options[6].text()).toBe("ERA");
-    expect(options[7].text()).toBe("Strikeouts");
-    expect(options[8].text()).toBe("Other");
+    expect(options[12].text()).toBe("Other Metric");
 
-    // Verify spec-compliant values
+    // Verify registry-ordered values
     expect(options[1].element.value).toBe("velocity");
     expect(options[2].element.value).toBe("exit_velo");
-    expect(options[3].element.value).toBe("sixty_time");
-    expect(options[4].element.value).toBe("pop_time");
-    expect(options[5].element.value).toBe("batting_avg");
+    expect(options[3].element.value).toBe("batting_avg");
+    expect(options[4].element.value).toBe("sixty_time");
+    expect(options[5].element.value).toBe("pop_time");
     expect(options[6].element.value).toBe("era");
-    expect(options[7].element.value).toBe("strikeouts");
-    expect(options[8].element.value).toBe("other");
+    expect(options[12].element.value).toBe("other");
+  });
+
+  it("filters the metric-type list to the athlete's primary sport", () => {
+    const wrapper = mount(LogMetricModal, {
+      props: { show: true, primarySport: "Basketball" },
+      global: {
+        stubs: {
+          Teleport: true,
+        },
+      },
+    });
+
+    const values = wrapper
+      .find("#metricType")
+      .findAll("option")
+      .map((o) => o.element.value);
+    expect(values).toEqual([
+      "",
+      "points_per_game",
+      "rebounds_per_game",
+      "assists_per_game",
+      "field_goal_pct",
+      "three_point_pct",
+      "free_throw_pct",
+      "steals_per_game",
+      "blocks_per_game",
+      "vertical_jump",
+      "other",
+    ]);
+    expect(values).not.toContain("velocity");
   });
 
   it("renders unit as a fixed-vocabulary dropdown (no free text)", () => {
@@ -284,7 +312,58 @@ describe("LogMetricModal - Form Submission", () => {
       event_id: null,
       verified: true,
       notes: "Test note",
+      display_value: "92.0 mph",
     });
+  });
+
+  it("requires a custom name for Other and persists it snake_cased as metric_type", async () => {
+    mockCreateMetric.mockResolvedValue({ id: "123" });
+
+    const wrapper = mount(LogMetricModal, {
+      props: { show: true },
+      global: {
+        stubs: {
+          Teleport: true,
+        },
+      },
+    });
+
+    await wrapper.find("#metricType").setValue("other");
+    await wrapper.find("#value").setValue("80");
+    await wrapper.find("#date").setValue("2025-01-15");
+
+    // No custom name yet: submit disabled
+    expect(
+      wrapper.find('button[type="submit"]').attributes("disabled"),
+    ).toBeDefined();
+
+    await wrapper.find("#otherName").setValue("Arm Strength");
+    expect(
+      wrapper.find('button[type="submit"]').attributes("disabled"),
+    ).toBeUndefined();
+
+    await wrapper.find("form").trigger("submit");
+    await flushPromises();
+
+    expect(mockCreateMetric).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metric_type: "arm_strength",
+        value: 80,
+      }),
+    );
+  });
+
+  it("does not show the custom-name field for a known metric type", () => {
+    const wrapper = mount(LogMetricModal, {
+      props: { show: true },
+      global: {
+        stubs: {
+          Teleport: true,
+        },
+      },
+    });
+
+    expect(wrapper.find("#otherName").exists()).toBe(false);
   });
 
   it("emits metric-created event on successful submission", async () => {

--- a/tests/unit/utils/metrics/canonical.spec.ts
+++ b/tests/unit/utils/metrics/canonical.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyFormat,
+  getMetricDef,
+  getKnownMetricDef,
+  metricTypesForSport,
+  METRIC_DEFS,
+  SPORT_METRICS,
+  OTHER_KEY,
+} from "~/utils/metrics/canonical";
+import { formatMetricValue } from "~/utils/metricFormat";
+import { SPORT_POSITIONS } from "~/utils/positions/canonical";
+
+// Parity with iOS MetricFormatTests / MetricRegistryTests — keep in lockstep.
+describe("applyFormat", () => {
+  it("decimal drops the leading zero", () => {
+    expect(applyFormat({ kind: "decimal", digits: 3, dropLeadingZero: true }, 0.41)).toBe(".410");
+    expect(applyFormat({ kind: "decimal", digits: 3, dropLeadingZero: true }, 1.0)).toBe("1.000");
+  });
+  it("decimal keeps the leading zero", () => {
+    expect(applyFormat({ kind: "decimal", digits: 2, dropLeadingZero: false }, 3.45)).toBe("3.45");
+    expect(applyFormat({ kind: "decimal", digits: 1, dropLeadingZero: false }, 82.3)).toBe("82.3");
+  });
+  it("integer rounds", () => {
+    expect(applyFormat({ kind: "integer" }, 12)).toBe("12");
+    expect(applyFormat({ kind: "integer" }, 12.7)).toBe("13");
+  });
+  it("percent renders the number sign-less", () => {
+    expect(applyFormat({ kind: "percent", digits: 1 }, 45.0)).toBe("45.0");
+    expect(applyFormat({ kind: "percent", digits: 1 }, 82.34)).toBe("82.3");
+  });
+  it("duration renders MM:SS.hh from seconds", () => {
+    expect(applyFormat({ kind: "duration" }, 112.34)).toBe("1:52.34");
+    expect(applyFormat({ kind: "duration" }, 9.41)).toBe("0:09.41");
+    expect(applyFormat({ kind: "duration" }, 581.0)).toBe("9:41.00");
+  });
+});
+
+describe("registry lookups", () => {
+  it("known def resolves; unknown returns undefined via getKnownMetricDef", () => {
+    expect(getKnownMetricDef("velocity")?.label).toBe("Fastball Velocity");
+    expect(getKnownMetricDef("wingspan_reach")).toBeUndefined();
+  });
+  it("getMetricDef is total — unknown key humanizes", () => {
+    const d = getMetricDef("wingspan_reach");
+    expect(d.label).toBe("wingspan reach");
+    expect(d.format).toEqual({ kind: "decimal", digits: 2, dropLeadingZero: false });
+  });
+  it("shared keys have a single def", () => {
+    expect(getMetricDef("goals").label).toBe("Goals");
+    expect(getMetricDef("vertical_jump").label).toBe("Vertical Jump");
+  });
+  it("legacy lowerIsBetter flags", () => {
+    expect(getMetricDef("era").lowerIsBetter).toBe(true);
+    expect(getMetricDef("velocity").lowerIsBetter).toBe(false);
+    expect(getMetricDef("erg_2k").lowerIsBetter).toBe(true);
+  });
+});
+
+describe("formatMetricValue through the registry", () => {
+  it("basketball percent renders 45.0 with % unit", () => {
+    expect(formatMetricValue("field_goal_pct", 45.0)).toBe("45.0");
+    expect(getMetricDef("field_goal_pct").unit).toBe("%");
+  });
+  it("save_pct is baseball-style .915 (not percent)", () => {
+    expect(formatMetricValue("save_pct", 0.915)).toBe(".915");
+  });
+  it("duration sport metric formats", () => {
+    expect(formatMetricValue("race_time", 581.0)).toBe("9:41.00");
+  });
+});
+
+describe("sport orderings", () => {
+  it("basketball order + other appended", () => {
+    const t = metricTypesForSport("Basketball");
+    expect(t[0]).toBe("points_per_game");
+    expect(t[t.length - 1]).toBe(OTHER_KEY);
+  });
+  it("nil sport falls back to baseball + other", () => {
+    const t = metricTypesForSport(null);
+    expect(t[0]).toBe("velocity");
+    expect(t[t.length - 1]).toBe(OTHER_KEY);
+  });
+  it("baseball grew to 11 keys, fielding_pct last", () => {
+    expect(SPORT_METRICS.Baseball).toHaveLength(11);
+    expect(SPORT_METRICS.Baseball[SPORT_METRICS.Baseball.length - 1]).toBe("fielding_pct");
+  });
+  it("all 17 sports present", () => {
+    expect(Object.keys(SPORT_METRICS)).toHaveLength(17);
+  });
+  it("every sport key has a def, and 'other' is never inline", () => {
+    for (const [sport, keys] of Object.entries(SPORT_METRICS)) {
+      expect(keys).not.toContain(OTHER_KEY);
+      for (const key of keys) {
+        expect(getKnownMetricDef(key), `${sport}:${key} missing def`).toBeDefined();
+      }
+    }
+  });
+  it("sport keys match the positions registry exactly", () => {
+    for (const sport of Object.keys(SPORT_METRICS)) {
+      expect(SPORT_POSITIONS[sport], `${sport} not in SPORT_POSITIONS`).toBeDefined();
+    }
+  });
+});
+
+describe("registry integrity", () => {
+  it("has no duplicate keys (construction would throw)", () => {
+    expect(Object.keys(METRIC_DEFS).length).toBeGreaterThan(60);
+  });
+});

--- a/tests/unit/utils/metrics/canonical.spec.ts
+++ b/tests/unit/utils/metrics/canonical.spec.ts
@@ -4,6 +4,7 @@ import {
   getMetricDef,
   getKnownMetricDef,
   metricTypesForSport,
+  customMetricKey,
   METRIC_DEFS,
   SPORT_METRICS,
   OTHER_KEY,
@@ -100,6 +101,16 @@ describe("sport orderings", () => {
     for (const sport of Object.keys(SPORT_METRICS)) {
       expect(SPORT_POSITIONS[sport], `${sport} not in SPORT_POSITIONS`).toBeDefined();
     }
+  });
+});
+
+describe("customMetricKey", () => {
+  it("snake_cases a custom other-name", () => {
+    expect(customMetricKey("Vertical Jump")).toBe("vertical_jump");
+  });
+  it("collapses whitespace runs to a single underscore (iOS parity)", () => {
+    // Byte-identical to iOS MetricFormState.resolvedMetricKey: "Bat  Speed" -> "bat_speed".
+    expect(customMetricKey("  Bat   Speed  ")).toBe("bat_speed");
   });
 });
 

--- a/tests/unit/utils/templateResolver.spec.ts
+++ b/tests/unit/utils/templateResolver.spec.ts
@@ -185,6 +185,20 @@ describe("carryingTool", () => {
     expect(out).toBe("6.71 sixty yard");
   });
 
+  it("uses the registry label for a known metric_type", () => {
+    const out = carryingTool([
+      { metric_type: "batting_avg", display_value: ".410", is_primary: true },
+    ]);
+    expect(out).toBe(".410 Batting Average");
+  });
+
+  it("falls back to a humanized label for an unregistered metric_type", () => {
+    const out = carryingTool([
+      { metric_type: "arm_strength", display_value: "80", is_primary: true },
+    ]);
+    expect(out).toBe("80 arm strength");
+  });
+
   it("returns null when no metric is primary", () => {
     expect(
       carryingTool([

--- a/types/models.ts
+++ b/types/models.ts
@@ -210,15 +210,8 @@ export interface PerformanceMetric {
   id: string;
   user_id?: string;
   recorded_date: string;
-  metric_type:
-    | "velocity"
-    | "exit_velo"
-    | "sixty_time"
-    | "pop_time"
-    | "batting_avg"
-    | "era"
-    | "strikeouts"
-    | "other";
+  /** Sport-agnostic metric key — see utils/metrics/canonical.ts for the vocabulary. */
+  metric_type: string;
   value: number;
   unit: string;
   event_id?: string | null;

--- a/utils/metricFormat.ts
+++ b/utils/metricFormat.ts
@@ -1,32 +1,21 @@
 /**
- * Baseball-convention display formatting for performance-metric values, keyed by metric type.
- * Single source of truth on web; must stay byte-identical to iOS `MetricType.format(_:)`.
+ * Display formatting for performance-metric values, keyed by metric type.
+ * Single source of truth on web; byte-identical to iOS `MetricType.format(_:)`.
  *
- * Rules: batting average → 3 decimals dropping the leading zero (.410); ERA → 2 decimals
- * keeping the leading digit (3.45); velocity / exit velo → 1 decimal (82.3); 60-yard & pop
- * times → 2 decimals (7.23); strikeouts → integer; other → 2 decimals. Unknown/absent types
- * fall back to a plain integer-or-raw string (mirrors the iOS template fallback).
+ * Delegates to the canonical metric registry (`utils/metrics/canonical.ts`):
+ * known types format via their `MetricDef.format` (decimal/integer/percent/
+ * duration), unknown/absent types fall back to a plain integer-or-raw string
+ * (mirrors the iOS template fallback).
  *
  * Number only — callers append the unit.
  */
-const FRACTION_DIGITS: Record<string, number> = {
-  batting_avg: 3,
-  era: 2,
-  sixty_time: 2,
-  pop_time: 2,
-  other: 2,
-  velocity: 1,
-  exit_velo: 1,
-  strikeouts: 0,
-};
+import { applyFormat, getKnownMetricDef } from "./metrics/canonical";
 
 export function formatMetricValue(
   metricType: string | null | undefined,
   value: number,
 ): string {
-  const digits = metricType == null ? undefined : FRACTION_DIGITS[metricType];
-  if (digits === undefined) return String(value); // unknown type: plain integer-or-raw
-  const s = value.toFixed(digits);
-  if (metricType === "batting_avg" && s.startsWith("0.")) return s.slice(1);
-  return s;
+  const def = getKnownMetricDef(metricType);
+  if (!def) return String(value); // unknown type: plain integer-or-raw
+  return applyFormat(def.format, value);
 }

--- a/utils/metrics/canonical.ts
+++ b/utils/metrics/canonical.ts
@@ -1,0 +1,309 @@
+/**
+ * Canonical performance-metric registry — the single source of truth on web.
+ *
+ * Mirrors iOS `MetricRegistry` / `MetricDef` / `Format` byte-identically (same
+ * keys, labels, units, formats, orderings, lowerIsBetter). Keys are stored
+ * verbatim in `performance_metrics.metric_type`. Sport keys match
+ * `SPORT_POSITIONS` in `utils/positions/canonical.ts`.
+ *
+ * Sibling of the positions registry: a `Record<string, ...>` map plus pure
+ * helper functions. Populated for all 17 sports.
+ */
+
+export const OTHER_KEY = "other";
+
+/** How a raw metric value renders (number only — callers append the unit). */
+export type MetricFormat =
+  | { kind: "decimal"; digits: number; dropLeadingZero: boolean }
+  | { kind: "integer" }
+  | { kind: "percent"; digits: number }
+  | { kind: "duration" };
+
+export interface MetricDef {
+  key: string;
+  label: string;
+  unit: string;
+  format: MetricFormat;
+  lowerIsBetter: boolean;
+}
+
+// Format constructors — keep call sites terse and consistent.
+const dec = (digits: number, dropLeadingZero = false): MetricFormat => ({
+  kind: "decimal",
+  digits,
+  dropLeadingZero,
+});
+const int: MetricFormat = { kind: "integer" };
+const pct = (digits: number): MetricFormat => ({ kind: "percent", digits });
+const dur: MetricFormat = { kind: "duration" };
+
+const def = (
+  key: string,
+  label: string,
+  unit: string,
+  format: MetricFormat,
+  lowerIsBetter = false,
+): MetricDef => ({ key, label, unit, format, lowerIsBetter });
+
+/**
+ * Render a raw value to its display string (number only — callers append the
+ * unit). Byte-identical to iOS `Format.apply(_:)`. `percent` renders the number
+ * sign-less (the "%" is the unit); `duration` renders MM:SS.hh from seconds.
+ */
+export function applyFormat(format: MetricFormat, value: number): string {
+  switch (format.kind) {
+    case "decimal": {
+      const s = value.toFixed(format.digits);
+      if (format.dropLeadingZero && s.startsWith("0.")) return s.slice(1);
+      return s;
+    }
+    case "integer":
+      return String(Math.round(value));
+    case "percent":
+      return value.toFixed(format.digits);
+    case "duration": {
+      const totalHundredths = Math.round(value * 100);
+      const minutes = Math.floor(totalHundredths / 6000);
+      const seconds = Math.floor((totalHundredths % 6000) / 100);
+      const hundredths = totalHundredths % 100;
+      const ss = String(seconds).padStart(2, "0");
+      const hh = String(hundredths).padStart(2, "0");
+      return `${minutes}:${ss}.${hh}`;
+    }
+  }
+}
+
+// MARK: Definitions (grouped by sport, mirroring iOS allDefs)
+
+const baseballDefs: MetricDef[] = [
+  def("velocity", "Fastball Velocity", "mph", dec(1)),
+  def("exit_velo", "Exit Velocity", "mph", dec(1)),
+  def("batting_avg", "Batting Average", "", dec(3, true)),
+  def("sixty_time", "60-Yard Dash", "sec", dec(2), true),
+  def("pop_time", "Pop Time", "sec", dec(2), true),
+  def("era", "ERA", "", dec(2), true),
+  def("on_base_pct", "On-Base Percentage", "", dec(3, true)),
+  def("slugging_pct", "Slugging Percentage", "", dec(3, true)),
+  def("whip", "WHIP", "", dec(2), true),
+  def("strikeouts", "Strikeouts", "count", int),
+  def("fielding_pct", "Fielding Percentage", "", dec(3, true)),
+];
+
+const basketballDefs: MetricDef[] = [
+  def("points_per_game", "Points Per Game", "", dec(1)),
+  def("rebounds_per_game", "Rebounds Per Game", "", dec(1)),
+  def("assists_per_game", "Assists Per Game", "", dec(1)),
+  def("field_goal_pct", "Field Goal %", "%", pct(1)),
+  def("three_point_pct", "3-Point %", "%", pct(1)),
+  def("free_throw_pct", "Free Throw %", "%", pct(1)),
+  def("steals_per_game", "Steals Per Game", "", dec(1)),
+  def("blocks_per_game", "Blocks Per Game", "", dec(1)),
+];
+
+const footballDefs: MetricDef[] = [
+  def("forty_time", "40-Yard Dash", "sec", dec(2), true),
+  def("bench_press", "Bench Press", "reps", int),
+  def("broad_jump", "Broad Jump", "in", int),
+  def("shuttle", "Shuttle Run", "sec", dec(2), true),
+  def("three_cone", "3-Cone Drill", "sec", dec(2), true),
+  def("squat", "Squat", "lbs", int),
+  def("passing_yards", "Passing Yards", "yds", int),
+  def("rushing_yards", "Rushing Yards", "yds", int),
+  def("receiving_yards", "Receiving Yards", "yds", int),
+  def("tackles", "Tackles", "count", int),
+];
+
+// Soccer / Lacrosse / Ice Hockey / Field Hockey / Water Polo — non-shared keys.
+const soccerLacrosseHockeyDefs: MetricDef[] = [
+  def("clean_sheets", "Clean Sheets", "count", int),
+  def("minutes_played", "Minutes Played", "count", int),
+  def("ground_balls", "Ground Balls", "count", int),
+  def("points", "Points", "count", int),
+  def("save_pct", "Save %", "", dec(3, true)),
+  def("goals_against_avg", "Goals Against Avg", "", dec(2), true),
+  def("steals", "Steals", "count", int),
+];
+
+const volleyballDefs: MetricDef[] = [
+  def("kills", "Kills", "count", int),
+  def("blocks", "Blocks", "count", int),
+  def("digs", "Digs", "count", int),
+  def("aces", "Aces", "count", int),
+  def("hitting_pct", "Hitting Percentage", "", dec(3, true)),
+];
+
+const trackAndFieldDefs: MetricDef[] = [
+  def("sprint_time", "Sprint Time", "sec", dec(2), true),
+  def("distance_time", "Distance Time", "", dur, true),
+  def("relay_split", "Relay Split", "sec", dec(2), true),
+  def("long_jump", "Long Jump", "m", dec(2)),
+  def("high_jump", "High Jump", "m", dec(2)),
+  def("shot_put", "Shot Put", "m", dec(2)),
+  def("discus", "Discus", "m", dec(2)),
+];
+
+const crossCountryDefs: MetricDef[] = [
+  def("race_time", "Race Time", "", dur, true),
+  def("pace_per_mile", "Pace Per Mile", "", dur, true),
+];
+
+const swimmingDefs: MetricDef[] = [
+  def("event_time", "Event Time", "", dur, true),
+  def("free_50", "50 Free", "sec", dec(2), true),
+  def("free_100", "100 Free", "", dur, true),
+];
+
+const golfDefs: MetricDef[] = [
+  def("scoring_average", "Scoring Average", "strokes", dec(1), true),
+  def("handicap", "Handicap", "", dec(1), true),
+];
+
+// "singles_record" excluded — text field, not a numeric metric.
+const tennisDefs: MetricDef[] = [
+  def("utr_rating", "UTR Rating", "", dec(2)),
+  def("ranking", "Ranking", "", int, true),
+];
+
+// "record" excluded — text field, not a numeric metric.
+const wrestlingDefs: MetricDef[] = [
+  def("pins", "Pins", "count", int),
+  def("takedowns", "Takedowns", "count", int),
+  def("weight_class", "Weight Class", "lbs", int),
+];
+
+const rowingDefs: MetricDef[] = [
+  def("erg_2k", "2K Erg", "", dur, true),
+  def("erg_split", "Erg Split", "", dur, true),
+];
+
+// Shared across sports (goals/assists/saves/vertical_jump — one def each).
+const sharedDefs: MetricDef[] = [
+  def("goals", "Goals", "count", int),
+  def("assists", "Assists", "count", int),
+  def("saves", "Saves", "count", int),
+  def("vertical_jump", "Vertical Jump", "in", dec(1)),
+];
+
+const allDefs: MetricDef[] = [
+  ...baseballDefs,
+  ...basketballDefs,
+  ...footballDefs,
+  ...soccerLacrosseHockeyDefs,
+  ...volleyballDefs,
+  ...trackAndFieldDefs,
+  ...crossCountryDefs,
+  ...swimmingDefs,
+  ...golfDefs,
+  ...tennisDefs,
+  ...wrestlingDefs,
+  ...rowingDefs,
+  ...sharedDefs,
+  def(OTHER_KEY, "Other Metric", "", dec(2)),
+];
+
+/** All metric definitions, keyed by metric_type. A duplicate key throws. */
+export const METRIC_DEFS: Record<string, MetricDef> = allDefs.reduce(
+  (acc, d) => {
+    if (acc[d.key]) throw new Error(`Duplicate metric def key: ${d.key}`);
+    acc[d.key] = d;
+    return acc;
+  },
+  {} as Record<string, MetricDef>,
+);
+
+// MARK: Sport orderings (NOT including "other"; metricTypesForSport appends it)
+
+const baseball = [
+  "velocity",
+  "exit_velo",
+  "batting_avg",
+  "sixty_time",
+  "pop_time",
+  "era",
+  "on_base_pct",
+  "slugging_pct",
+  "whip",
+  "strikeouts",
+  "fielding_pct",
+] as const;
+
+/** Ordered metric keys per sport. Sport keys match SPORT_POSITIONS. */
+export const SPORT_METRICS: Record<string, readonly string[]> = {
+  // Baseball/Softball intentionally share one ordering (identical vocabularies).
+  Baseball: baseball,
+  Softball: baseball,
+  Basketball: [
+    "points_per_game",
+    "rebounds_per_game",
+    "assists_per_game",
+    "field_goal_pct",
+    "three_point_pct",
+    "free_throw_pct",
+    "steals_per_game",
+    "blocks_per_game",
+    "vertical_jump",
+  ],
+  Football: [
+    "forty_time",
+    "vertical_jump",
+    "bench_press",
+    "broad_jump",
+    "shuttle",
+    "three_cone",
+    "squat",
+    "passing_yards",
+    "rushing_yards",
+    "receiving_yards",
+    "tackles",
+  ],
+  Soccer: ["goals", "assists", "saves", "clean_sheets", "minutes_played"],
+  Volleyball: ["kills", "assists", "blocks", "digs", "aces", "hitting_pct"],
+  "Track & Field": [
+    "sprint_time",
+    "distance_time",
+    "relay_split",
+    "long_jump",
+    "high_jump",
+    "shot_put",
+    "discus",
+  ],
+  "Cross Country": ["race_time", "pace_per_mile"],
+  Swimming: ["event_time", "free_50", "free_100"],
+  Golf: ["scoring_average", "handicap"],
+  Tennis: ["utr_rating", "ranking"],
+  Wrestling: ["pins", "takedowns", "weight_class"],
+  Lacrosse: ["goals", "assists", "ground_balls", "saves"],
+  "Ice Hockey": ["points", "goals", "assists", "save_pct", "goals_against_avg"],
+  "Field Hockey": ["goals", "assists", "saves"],
+  Rowing: ["erg_2k", "erg_split"],
+  "Water Polo": ["goals", "assists", "saves", "steals"],
+};
+
+/** Fallback order for nil/unknown sports: all legacy baseball keys. */
+const defaultOrder = baseball;
+
+/** The def for a known key, or undefined when the key is unregistered. */
+export function getKnownMetricDef(key: string | null | undefined): MetricDef | undefined {
+  if (!key) return undefined;
+  return METRIC_DEFS[key];
+}
+
+/**
+ * The def for a key, always non-null: unknown keys synthesize a fallback
+ * (humanized label, no unit, 2-decimal). Mirrors iOS `MetricRegistry.def(for:)`.
+ */
+export function getMetricDef(key: string | null | undefined): MetricDef {
+  const known = getKnownMetricDef(key);
+  if (known) return known;
+  const label = (key ?? "").replace(/_/g, " ").trim();
+  return def(key ?? "", label, "", dec(2));
+}
+
+/**
+ * Ordered metric keys offered for a sport, with "other" appended. Nil/unknown
+ * sport falls back to the baseball order. Mirrors iOS `types(forSport:)`.
+ */
+export function metricTypesForSport(sport: string | null | undefined): string[] {
+  const base = (sport && SPORT_METRICS[sport]) || defaultOrder;
+  return [...base, OTHER_KEY];
+}

--- a/utils/metrics/canonical.ts
+++ b/utils/metrics/canonical.ts
@@ -307,3 +307,13 @@ export function metricTypesForSport(sport: string | null | undefined): string[] 
   const base = (sport && SPORT_METRICS[sport]) || defaultOrder;
   return [...base, OTHER_KEY];
 }
+
+/**
+ * The persisted metric_type for a custom "other" name: trimmed, lowercased,
+ * with runs of whitespace collapsed to a single underscore ("Bat  Speed" ->
+ * "bat_speed"). Byte-identical to iOS `MetricFormState.resolvedMetricKey` so a
+ * custom metric gets the same key on both platforms.
+ */
+export function customMetricKey(name: string): string {
+  return name.trim().toLowerCase().replace(/\s+/g, "_");
+}

--- a/utils/templateResolver.ts
+++ b/utils/templateResolver.ts
@@ -19,6 +19,7 @@
  */
 
 import { formatMetricValue } from "./metricFormat";
+import { getKnownMetricDef } from "./metrics/canonical";
 
 export type Row = Record<string, unknown>;
 
@@ -111,8 +112,11 @@ const MONTHS = [
   "Dec",
 ];
 
-const humanizeMetricLabel = (metricType?: string | null): string =>
-  (metricType ?? "").replace(/_/g, " ").trim();
+const humanizeMetricLabel = (metricType?: string | null): string => {
+  const def = getKnownMetricDef(metricType);
+  if (def) return def.label;
+  return (metricType ?? "").replace(/_/g, " ").trim();
+};
 
 const metricDisplay = (m: MetricRow): string => {
   if (m.display_value && m.display_value.trim()) return m.display_value.trim();


### PR DESCRIPTION
## Summary

Web half of **multi-sport performance metrics** — cross-platform parity with iOS PR #43 (candrikanich/recruiting-compass-ios). Previously web metrics were baseball-only: a closed 8-key `metric_type` union and a `FRACTION_DIGITS` formatter, with non-baseball athletes forced into a generic `other` type.

Now web has a **canonical metric registry** mirroring `utils/positions/canonical.ts`, shared **byte-identical with iOS** (`MetricRegistry`/`MetricDef`/`Format`).

## What changed

- **New `utils/metrics/canonical.ts`** — `MetricFormat` (decimal/integer/percent/duration), `MetricDef`, `METRIC_DEFS` (66 defs), `SPORT_METRICS` (17 sports, keys matching `SPORT_POSITIONS`), and pure helpers `getMetricDef` / `getKnownMetricDef` / `metricTypesForSport` / `applyFormat` / `customMetricKey`. Byte-identical to the iOS registry (verified against the iOS source in review).
- **`utils/metricFormat.ts`** — `formatMetricValue` now consults the registry (adds `.duration` MM:SS.hh + `.percent`). The 8 legacy keys format identically; unknown keys keep the `String(value)` fallback.
- **`types/models.ts`** — `PerformanceMetric.metric_type` widened from the closed 8-key union to `string` (registry is now the vocabulary; arbitrary sport keys valid).
- **`components/Performance/LogMetricModal.vue`** — metric-type list from `metricTypesForSport(primarySport)`; unit locked from the registry; `other` gets a custom-name field (persisted as a snake_cased key via `customMetricKey`, so custom metrics stop rendering as "other"); `primary_sport` threaded from `pages/performance/index.vue` via the existing `usePreferenceManager` (no new API); `display_value` now computed via `formatMetricValue` on submit.
- **`utils/templateResolver.ts`** — `humanizeMetricLabel` uses the registry label (`batting_avg` → "Batting Average") for `{{metrics}}` / `{{carryingTool}}`.

## Cross-platform parity

- Registry (keys/labels/units/formats/orderings) verified **byte-identical** to iOS in review.
- **Custom-key parity fix:** iOS was replacing single spaces while web collapsed whitespace runs — `"Bat  Speed"` → `bat__speed` (iOS) vs `bat_speed` (web). Both now collapse runs via the shared `customMetricKey` semantics (iOS PR #43 fixed to match), so a custom `other` metric gets the same `metric_type` key on both platforms. Locked with tests on both sides.

## Test plan

- New `tests/unit/utils/metrics/canonical.spec.ts` (applyFormat incl. duration/percent, all-17-sports integrity, dedupe/typo guard, sport-key match vs positions, customMetricKey whitespace-collapse) + extended `metricFormat.spec.ts` + `LogMetricModal.spec.ts` + `templateResolver.spec.ts`.
- `npx vitest run` on all affected specs green; `npx nuxi typecheck` exit 0.

## Tracked follow-ups (non-blocking, symmetric with iOS)

- The **categorized Performance surfaces** (timeline `powerMetrics`/`speedMetrics`/etc., radar chart, `getUnit`, `performanceExport`, `textTemplates`) still use hardcoded baseball-only maps — a non-baseball metric logged via the new modal won't categorize there yet. Same limitation exists on iOS (analytics still baseball-keyed). Fast-follow to make the display/categorization surfaces sport-aware on both platforms.
- **Percent rendering spacing** (`45.0 %` vs `45.0%`) deferred: to be set canonically across all render sites on both platforms in one pass, rather than per-site now.

Mirrors iOS PR #43.
