### PR TITLE
feat(schools): reactivating a not_pursuing school restores its prior stage

### DIFF
--- a/composables/useSchoolStatus.ts
+++ b/composables/useSchoolStatus.ts
@@ -78,6 +78,34 @@ export const useSchoolStatus = () => {
       const previousStatus = fetchedSchool.status;
       const now = new Date().toISOString();
 
+      // Reactivation: moving a school off the not_pursuing off-ramp back into
+      // the funnel restores the stage it was at before, via the
+      // reactivate_school RPC (which performs both the schools update and the
+      // school_status_history insert atomically). The stepper emits
+      // researching for this action; the RPC decides the real restored stage.
+      if (previousStatus === "not_pursuing" && newStatus === "researching") {
+        // reactivate_school is a newer RPC not yet in the generated Supabase
+        // types, so narrow the call to its real contract here.
+        const reactivate = supabase.rpc as unknown as (
+          fn: "reactivate_school",
+          args: { p_school_id: string; p_actor: string },
+        ) => Promise<{ data: School["status"] | null; error: unknown }>;
+
+        const { data: restoredStatus, error: reactivateError } =
+          await reactivate("reactivate_school", {
+            p_school_id: schoolId,
+            p_actor: userStore.user.id,
+          });
+
+        if (reactivateError) throw reactivateError;
+
+        return {
+          ...fetchedSchool,
+          status: restoredStatus ?? newStatus,
+          status_changed_at: now,
+        };
+      }
+
       // Update school status and status_changed_at timestamp
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const updateStatusResponse = await (supabase.from("schools") as any)

--- a/stores/schools.ts
+++ b/stores/schools.ts
@@ -401,6 +401,36 @@ export const useSchoolStore = defineStore("schools", () => {
         (currentSchool as { status: School["status"] } | null)?.status ?? null;
       const now = new Date().toISOString();
 
+      // Reactivation: moving a school off the not_pursuing off-ramp back into
+      // the funnel restores the stage it was at before, via the
+      // reactivate_school RPC (which performs both the schools update and the
+      // school_status_history insert atomically). The stepper emits
+      // researching for this action; the RPC decides the real restored stage.
+      if (previousStatus === "not_pursuing" && newStatus === "researching") {
+        const { data: restoredStatus, error: reactivateError } =
+          await supabaseAny.rpc("reactivate_school", {
+            p_school_id: schoolId,
+            p_actor: userStore.user.id,
+          });
+
+        if (reactivateError) throw reactivateError;
+
+        const index = schools.value.findIndex((s) => s.id === schoolId);
+        const reactivated = {
+          ...(schools.value[index] ?? { id: schoolId }),
+          status: restoredStatus as School["status"],
+          status_changed_at: now,
+        } as School;
+
+        if (index !== -1) {
+          schools.value[index] = reactivated;
+        }
+
+        delete statusHistory.value[schoolId];
+
+        return reactivated;
+      }
+
       // Update school status and status_changed_at timestamp
       const schoolUpdateData = {
         status: newStatus,

--- a/supabase/migrations/20260828000005_reactivate_school_rpc.sql
+++ b/supabase/migrations/20260828000005_reactivate_school_rpc.sql
@@ -1,0 +1,63 @@
+-- Reopen a school from the `not_pursuing` off-ramp, restoring the stage it was
+-- at BEFORE it was marked not_pursuing (from school_status_history) instead of
+-- resetting to researching and losing funnel progress. Falls back to
+-- researching when there is no usable prior stage.
+--
+-- See planning/2026-08-21-school-status-pipeline-spec.md (open question 4).
+
+create or replace function public.reactivate_school(
+  p_school_id uuid,
+  p_actor uuid
+)
+returns public.school_status
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  prev text;
+  restore_status public.school_status;
+begin
+  -- Prior stage = previous_status of the most recent move INTO not_pursuing.
+  select previous_status into prev
+  from public.school_status_history
+  where school_id = p_school_id
+    and new_status = 'not_pursuing'
+  order by changed_at desc
+  limit 1;
+
+  -- Cast the stored text back to the enum; tolerate anything unexpected.
+  begin
+    restore_status := prev::public.school_status;
+  exception when others then
+    restore_status := 'researching'::public.school_status;
+  end;
+
+  -- Only restore into a live progress stage; never a deprecated/off-ramp value.
+  if restore_status is null
+     or restore_status not in (
+       'researching'::public.school_status,
+       'contacted'::public.school_status,
+       'visiting'::public.school_status,
+       'offer_received'::public.school_status,
+       'committed'::public.school_status
+     ) then
+    restore_status := 'researching'::public.school_status;
+  end if;
+
+  update public.schools
+  set status = restore_status,
+      status_changed_at = now(),
+      updated_by = p_actor,
+      updated_at = now()
+  where id = p_school_id;
+
+  insert into public.school_status_history
+    (school_id, previous_status, new_status, changed_by, changed_at, notes)
+  values
+    (p_school_id, 'not_pursuing', restore_status::text, p_actor, now(),
+     'Reactivated from not_pursuing');
+
+  return restore_status;
+end;
+$$;

--- a/tests/unit/composables/useSchoolStatus.spec.ts
+++ b/tests/unit/composables/useSchoolStatus.spec.ts
@@ -23,6 +23,7 @@ const mockQuery = {
 
 const mockSupabase = {
   from: vi.fn().mockReturnValue(mockQuery),
+  rpc: vi.fn(),
 };
 
 vi.mock("~/composables/useSupabase", () => ({
@@ -85,6 +86,7 @@ describe("useSchoolStatus", () => {
     mockQuery.eq.mockReturnThis();
     mockQuery.update.mockReturnThis();
     mockQuery.insert.mockReturnThis();
+    mockSupabase.rpc.mockReset();
   });
 
   it("exports updateStatus, loading, and error", async () => {
@@ -249,6 +251,112 @@ describe("useSchoolStatus", () => {
       await expect(updateStatus(SCHOOL_ID, "contacted")).rejects.toThrow(
         "User not authenticated",
       );
+    });
+  });
+
+  describe("updateStatus — reactivation (not_pursuing → researching)", () => {
+    it("calls the reactivate_school RPC and returns the restored status", async () => {
+      const { useSchoolStatus } = await import("~/composables/useSchoolStatus");
+      const { updateStatus } = useSchoolStatus();
+
+      // Only the fetch .single() runs on the reactivation path.
+      mockQuery.single.mockResolvedValueOnce({
+        data: makeSchool("not_pursuing"),
+        error: null,
+      });
+      mockSupabase.rpc.mockResolvedValueOnce({ data: "visiting", error: null });
+
+      const result = await updateStatus(SCHOOL_ID, "researching");
+
+      expect(mockSupabase.rpc).toHaveBeenCalledWith("reactivate_school", {
+        p_school_id: SCHOOL_ID,
+        p_actor: USER_ID,
+      });
+      // Restored status from the RPC, not the requested "researching".
+      expect(result.status).toBe("visiting");
+    });
+
+    it("does NOT run the normal schools update or history insert on reactivation", async () => {
+      const { useSchoolStatus } = await import("~/composables/useSchoolStatus");
+      const { updateStatus } = useSchoolStatus();
+
+      mockQuery.single.mockResolvedValueOnce({
+        data: makeSchool("not_pursuing"),
+        error: null,
+      });
+      mockSupabase.rpc.mockResolvedValueOnce({
+        data: "researching",
+        error: null,
+      });
+
+      await updateStatus(SCHOOL_ID, "researching");
+
+      // The RPC handles both the schools update and the history insert.
+      expect(mockQuery.update).not.toHaveBeenCalled();
+      expect(mockQuery.insert).not.toHaveBeenCalled();
+      const fromCalls = mockSupabase.from.mock.calls.map(
+        (c: unknown[]) => c[0],
+      );
+      expect(fromCalls).not.toContain("school_status_history");
+    });
+
+    it("throws and sets error.value when the RPC fails", async () => {
+      const { useSchoolStatus } = await import("~/composables/useSchoolStatus");
+      const { updateStatus, error } = useSchoolStatus();
+
+      mockQuery.single.mockResolvedValueOnce({
+        data: makeSchool("not_pursuing"),
+        error: null,
+      });
+      mockSupabase.rpc.mockResolvedValueOnce({
+        data: null,
+        error: new Error("RPC failed"),
+      });
+
+      await expect(updateStatus(SCHOOL_ID, "researching")).rejects.toThrow(
+        "RPC failed",
+      );
+      expect(error.value).toBe("RPC failed");
+    });
+
+    it("does NOT call the RPC on a normal transition (researching → contacted)", async () => {
+      const { useSchoolStatus } = await import("~/composables/useSchoolStatus");
+      const { updateStatus } = useSchoolStatus();
+
+      mockQuery.single
+        .mockResolvedValueOnce({
+          data: makeSchool("researching"),
+          error: null,
+        })
+        .mockResolvedValueOnce({ data: makeSchool("contacted"), error: null });
+      mockQuery.insert.mockResolvedValueOnce({ error: null });
+
+      await updateStatus(SCHOOL_ID, "contacted");
+
+      expect(mockSupabase.rpc).not.toHaveBeenCalled();
+      expect(mockQuery.update).toHaveBeenCalled();
+      const fromCalls = mockSupabase.from.mock.calls.map(
+        (c: unknown[]) => c[0],
+      );
+      expect(fromCalls).toContain("school_status_history");
+    });
+
+    it("does NOT call the RPC when leaving not_pursuing to a non-researching status", async () => {
+      const { useSchoolStatus } = await import("~/composables/useSchoolStatus");
+      const { updateStatus } = useSchoolStatus();
+
+      mockQuery.single
+        .mockResolvedValueOnce({
+          data: makeSchool("not_pursuing"),
+          error: null,
+        })
+        .mockResolvedValueOnce({ data: makeSchool("committed"), error: null });
+      mockQuery.insert.mockResolvedValueOnce({ error: null });
+
+      await updateStatus(SCHOOL_ID, "committed");
+
+      expect(mockSupabase.rpc).not.toHaveBeenCalled();
+      expect(mockQuery.update).toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/stores/schools-status-history.spec.ts
+++ b/tests/unit/stores/schools-status-history.spec.ts
@@ -3,6 +3,9 @@ import { setActivePinia, createPinia } from "pinia";
 import { useSchoolStore } from "~/stores/schools";
 import type { School } from "~/types/models";
 
+// Hoisted so the vi.mock factory below (also hoisted) can close over it.
+const { mockRpc } = vi.hoisted(() => ({ mockRpc: vi.fn() }));
+
 // Mock Supabase
 vi.mock("~/composables/useSupabase", () => ({
   useSupabase: vi.fn(() => {
@@ -66,6 +69,7 @@ vi.mock("~/composables/useSupabase", () => ({
         }
         return {};
       }),
+      rpc: mockRpc,
     };
   }),
 }));
@@ -80,6 +84,7 @@ vi.mock("~/stores/user", () => ({
 describe("Schools Store - Status History (Story 3.4)", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    mockRpc.mockReset();
   });
 
   describe("Store state initialization", () => {
@@ -198,6 +203,106 @@ describe("Schools Store - Status History (Story 3.4)", () => {
       await store.updateStatus("school-1", "committed", "family-123");
 
       expect("school-1" in store.statusHistory).toBe(false);
+    });
+  });
+
+  describe("updateStatus — reactivation (not_pursuing → researching)", () => {
+    // A supabase client whose current school status is not_pursuing, so the
+    // reactivation branch fires. history-insert / schools-update spies let us
+    // assert they are NOT used.
+    const historyInsert = vi.fn().mockResolvedValue({ error: null });
+    const schoolsUpdate = vi.fn().mockReturnThis();
+
+    const notPursuingClient = () => ({
+      from: vi.fn((table: string) => {
+        if (table === "schools") {
+          return {
+            update: schoolsUpdate,
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi
+              .fn()
+              .mockResolvedValue({ data: { status: "not_pursuing" }, error: null }),
+          };
+        }
+        if (table === "school_status_history") {
+          return {
+            insert: historyInsert,
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            order: vi.fn().mockResolvedValue({ data: [], error: null }),
+          };
+        }
+        return {};
+      }),
+      rpc: mockRpc,
+    });
+
+    beforeEach(() => {
+      historyInsert.mockClear();
+      schoolsUpdate.mockClear();
+    });
+
+    it("calls reactivate_school RPC and applies the restored status locally", async () => {
+      const { useSupabase } = await import("~/composables/useSupabase");
+      vi.mocked(useSupabase).mockReturnValueOnce(notPursuingClient() as any);
+      mockRpc.mockResolvedValueOnce({ data: "visiting", error: null });
+
+      const store = useSchoolStore();
+      store.schools = [{ id: "school-1", status: "not_pursuing" } as School];
+
+      const result = await store.updateStatus(
+        "school-1",
+        "researching",
+        "family-123",
+      );
+
+      expect(mockRpc).toHaveBeenCalledWith("reactivate_school", {
+        p_school_id: "school-1",
+        p_actor: "user-1",
+      });
+      expect(result.status).toBe("visiting");
+      expect(store.schools[0].status).toBe("visiting");
+    });
+
+    it("does NOT run the normal schools update or history insert on reactivation", async () => {
+      const { useSupabase } = await import("~/composables/useSupabase");
+      vi.mocked(useSupabase).mockReturnValueOnce(notPursuingClient() as any);
+      mockRpc.mockResolvedValueOnce({ data: "researching", error: null });
+
+      const store = useSchoolStore();
+      store.schools = [{ id: "school-1", status: "not_pursuing" } as School];
+
+      await store.updateStatus("school-1", "researching", "family-123");
+
+      expect(schoolsUpdate).not.toHaveBeenCalled();
+      expect(historyInsert).not.toHaveBeenCalled();
+    });
+
+    it("throws when the RPC fails", async () => {
+      const { useSupabase } = await import("~/composables/useSupabase");
+      vi.mocked(useSupabase).mockReturnValueOnce(notPursuingClient() as any);
+      mockRpc.mockResolvedValueOnce({
+        data: null,
+        error: new Error("RPC failed"),
+      });
+
+      const store = useSchoolStore();
+      store.schools = [{ id: "school-1", status: "not_pursuing" } as School];
+
+      await expect(
+        store.updateStatus("school-1", "researching", "family-123"),
+      ).rejects.toThrow("RPC failed");
+    });
+
+    it("does NOT call the RPC on a normal transition", async () => {
+      // Default mocked client → current status "interested" (not not_pursuing).
+      const store = useSchoolStore();
+      store.schools = [{ id: "school-1", status: "interested" } as School];
+
+      await store.updateStatus("school-1", "contacted", "family-123");
+
+      expect(mockRpc).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Follow-up to the school-status pipeline. Reopening a school from the `not_pursuing` off-ramp used to reset it to `researching`, discarding funnel progress. It now restores the stage the school was at **before** it was parked, via the new `reactivate_school` RPC (reads prior stage from `school_status_history`, falls back to `researching`, and writes its own history row).

- Both status-update paths (`composables/useSchoolStatus` + `stores/schools`) detect the `not_pursuing → researching` transition (the stepper's Reactivate) and call the RPC instead of the normal update + history insert. All other transitions unchanged.
- Includes the RPC migration (already applied to prod).

Tests: type-check clean; 29 status specs green (9 new reactivation cases). Matches iOS.

https://claude.ai/code/session_01JrwznWssjrRNVdwJc7KUqv