### PR TITLE
fix(e2e): loopback host carve-out — fixes suite-wide blank authentica…

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,7 +56,6 @@ jobs:
           # so the test project's URL/anon must be present here, not just at run.
           NUXT_PUBLIC_SUPABASE_URL: ${{ secrets.TEST_SUPABASE_URL }}
           NUXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.TEST_SUPABASE_ANON_KEY }}
-          NUXT_PUBLIC_ADMIN_HOST: localhost:3003
 
       - name: Run E2E tests
         run: npm run test:e2e
@@ -66,9 +65,10 @@ jobs:
           NUXT_PUBLIC_SUPABASE_URL: ${{ secrets.TEST_SUPABASE_URL }}
           NUXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.TEST_SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.TEST_SUPABASE_SERVICE_ROLE_KEY }}
-          # Keep admin routes on the local origin; unset defaults to the prod
-          # admin subdomain and bounces every admin spec off localhost.
-          NUXT_PUBLIC_ADMIN_HOST: localhost:3003
+          # Do NOT set NUXT_PUBLIC_ADMIN_HOST here. On the loopback E2E host the
+          # app serves admin + main from one origin (see middleware/host.global
+          # loopback carve-out); setting it to localhost makes every non-admin
+          # page redirect to /admin and render blank.
           NUXT_ADMIN_TOKEN_SECRET: ${{ secrets.NUXT_ADMIN_TOKEN_SECRET }}
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
 
@@ -124,7 +124,6 @@ jobs:
           # ssr:false bakes NUXT_PUBLIC_* into the client bundle at build time.
           NUXT_PUBLIC_SUPABASE_URL: ${{ secrets.TEST_SUPABASE_URL }}
           NUXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.TEST_SUPABASE_ANON_KEY }}
-          NUXT_PUBLIC_ADMIN_HOST: localhost:3003
 
       - name: Run E2E tests (WebKit only)
         run: npm run test:e2e -- --project webkit
@@ -135,9 +134,10 @@ jobs:
           NUXT_PUBLIC_SUPABASE_URL: ${{ secrets.TEST_SUPABASE_URL }}
           NUXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.TEST_SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.TEST_SUPABASE_SERVICE_ROLE_KEY }}
-          # Keep admin routes on the local origin; unset defaults to the prod
-          # admin subdomain and bounces every admin spec off localhost.
-          NUXT_PUBLIC_ADMIN_HOST: localhost:3003
+          # Do NOT set NUXT_PUBLIC_ADMIN_HOST here. On the loopback E2E host the
+          # app serves admin + main from one origin (see middleware/host.global
+          # loopback carve-out); setting it to localhost makes every non-admin
+          # page redirect to /admin and render blank.
           NUXT_ADMIN_TOKEN_SECRET: ${{ secrets.NUXT_ADMIN_TOKEN_SECRET }}
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
 

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -51,7 +51,6 @@ jobs:
           # so the test project's URL/anon must be present here, not just at run.
           NUXT_PUBLIC_SUPABASE_URL: ${{ secrets.TEST_SUPABASE_URL }}
           NUXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.TEST_SUPABASE_ANON_KEY }}
-          NUXT_PUBLIC_ADMIN_HOST: localhost:3003
 
       - name: Run E2E suite with soak specs enabled
         run: npm run test:e2e
@@ -62,7 +61,7 @@ jobs:
           NUXT_PUBLIC_SUPABASE_URL: ${{ secrets.TEST_SUPABASE_URL }}
           NUXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.TEST_SUPABASE_ANON_KEY }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.TEST_SUPABASE_SERVICE_ROLE_KEY }}
-          NUXT_PUBLIC_ADMIN_HOST: localhost:3003
+          # No NUXT_PUBLIC_ADMIN_HOST — see e2e.yml (loopback carve-out).
           NUXT_ADMIN_TOKEN_SECRET: ${{ secrets.NUXT_ADMIN_TOKEN_SECRET }}
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
 

--- a/middleware/host.global.ts
+++ b/middleware/host.global.ts
@@ -7,12 +7,34 @@ import { getPublicRoutes } from "~/types/routes";
 // an infinite loop. "/" is excluded: it should still redirect to /admin.
 const ADMIN_HOST_PUBLIC_PATHS = getPublicRoutes().filter((p) => p !== "/");
 
+/**
+ * A loopback host (local dev / E2E) serves the admin area and the main app from
+ * ONE origin — there is no separate admin subdomain to bounce to. Detect it so
+ * we can skip all cross-host redirects there.
+ */
+function isLoopbackHost(host: string): boolean {
+  return (
+    host === "localhost" ||
+    host.startsWith("localhost:") ||
+    host === "127.0.0.1" ||
+    host.startsWith("127.0.0.1:") ||
+    host.startsWith("[::1]")
+  );
+}
+
 export function resolveHostRedirect(
   host: string,
   path: string,
   adminHost: string,
 ): { type: "external"; to: string } | { type: "internal"; to: string } | null {
   if (host === "") return null;
+
+  // On a loopback host, admin and main share the origin: never cross-redirect.
+  // Without this, /admin bounces off-origin, and if adminHost is configured to
+  // the loopback host every non-admin page redirects to /admin and never
+  // renders (the E2E-suite-wide blank-page failure). Prod hosts are real
+  // domains, so this branch never triggers there.
+  if (isLoopbackHost(host)) return null;
   const onAdminHost = host === adminHost;
   const isAdminPath = path === "/admin" || path.startsWith("/admin/");
 

--- a/tests/unit/middleware/host.spec.ts
+++ b/tests/unit/middleware/host.spec.ts
@@ -56,4 +56,30 @@ describe("resolveHostRedirect", () => {
       to: "/admin",
     });
   });
+
+  // Loopback carve-out: local dev / E2E serve admin and main from ONE origin
+  // (localhost). There is no separate admin subdomain to redirect to, so we must
+  // never cross-redirect — otherwise /admin bounces off-origin and, when
+  // adminHost is (mis)configured to the loopback host, every non-admin page
+  // redirects to /admin and never renders.
+  it("serves /admin in place on a loopback host (no external redirect)", () => {
+    expect(resolveHostRedirect("localhost:3003", "/admin", admin)).toBeNull();
+    expect(
+      resolveHostRedirect("localhost:3003", "/admin/users", admin),
+    ).toBeNull();
+  });
+
+  it("serves non-admin pages in place on a loopback host (no /admin redirect)", () => {
+    expect(resolveHostRedirect("localhost:3003", "/dashboard", admin)).toBeNull();
+    expect(resolveHostRedirect("127.0.0.1:3003", "/schools", admin)).toBeNull();
+  });
+
+  it("does not cross-redirect even if adminHost is set to the loopback host", () => {
+    expect(
+      resolveHostRedirect("localhost:3003", "/dashboard", "localhost:3003"),
+    ).toBeNull();
+    expect(
+      resolveHostRedirect("localhost:3003", "/admin", "localhost:3003"),
+    ).toBeNull();
+  });
 });


### PR DESCRIPTION
…ted pages

Root cause of the ~177 E2E failures (found via local browser repro): setting NUXT_PUBLIC_ADMIN_HOST=localhost:3003 (added to make admin specs resolve) made the app treat the E2E serving host AS the admin subdomain. host.global's resolveHostRedirect then redirected every non-admin authenticated path (dashboard, schools, profile, …) to /admin during initial route resolution, so those pages never rendered — the blank #__nuxt / beforeEach-timeout seen across the suite. /login rendered only because it is an allowlisted public path.

Fix: resolveHostRedirect returns null on a loopback host (localhost/127.0.0.1/ [::1]) — local dev and E2E serve admin + main from ONE origin, so there is no subdomain to cross-redirect to. Prod hosts are real domains, unaffected. This also makes /admin reachable in place locally, so admin specs no longer need the env either. Removed NUXT_PUBLIC_ADMIN_HOST from e2e.yml + soak.yml.

Verified locally against the test project: cold page.goto('/dashboard') and '/schools' now render (h1 present) where before they were blank. host unit tests 13/13.

Claude-Session: https://claude.ai/code/session_018xvbaQXAsF2cFfEKbMxoWk

## Summary

<!-- What does this PR do? 1-3 bullet points. -->

-
-

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Docs / content
- [ ] Tests
- [ ] Chore / dependency update

## Test plan

- [ ] `npm run type-check` passes
- [ ] `npm run test` passes
- [ ] `npm run lint` passes
- [ ] Tested in browser (dev server)

## Docs checklist

- [ ] Updated `/help` docs if this PR changes user-facing behavior

## Security checklist

- [ ] No secrets or credentials in code
- [ ] User input validated with Zod
- [ ] Auth enforced on new API routes (`requireAuth`)
- [ ] No raw `error.message` exposed in API responses
