### PR TITLE
feat(profile): slug-based Prep Baseball Report profile links

### DIFF
--- a/components/Settings/PlayerDetailsAthleticsTab.vue
+++ b/components/Settings/PlayerDetailsAthleticsTab.vue
@@ -279,17 +279,75 @@
               />
             </a>
           </div>
-          <div>
+          <div class="md:col-span-3">
             <label
               class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
-              >Prep Baseball ID</label
+              >Prep Baseball Report Profile</label
             >
-            <input
-              v-model="form.prep_baseball_id"
-              @blur="triggerSave"
-              placeholder="ID Number"
-              class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl font-medium"
-            />
+            <div class="grid grid-cols-1 sm:grid-cols-[7rem_1fr] gap-3">
+              <select
+                v-model="form.prep_baseball_state"
+                :disabled="isParentRole"
+                @change="triggerSave"
+                class="w-full px-3 py-3 bg-slate-50 border border-slate-200 rounded-xl font-medium text-slate-700"
+                aria-label="Prep Baseball Report state"
+              >
+                <option value="">State</option>
+                <option
+                  v-for="opt in prepBaseballStateOptions"
+                  :key="opt.code"
+                  :value="opt.code"
+                >
+                  {{ opt.code }}
+                </option>
+              </select>
+              <input
+                v-model="form.prep_baseball_id"
+                :disabled="isParentRole"
+                @blur="triggerSave"
+                placeholder="e.g. owen-andrikanich"
+                class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl font-medium"
+              />
+            </div>
+
+            <p
+              v-if="
+                !isParentRole &&
+                suggestedPrepBaseballSlug &&
+                form.prep_baseball_id !== suggestedPrepBaseballSlug
+              "
+              class="mt-1.5 ml-1 text-xs text-slate-500"
+            >
+              Suggested name:
+              <button
+                type="button"
+                @click="applySuggestedPrepBaseballSlug"
+                class="font-mono font-medium text-blue-600 hover:text-blue-700 hover:underline"
+              >
+                {{ suggestedPrepBaseballSlug }}
+              </button>
+            </p>
+
+            <p v-if="prepBaseballPreviewUrl" class="mt-1.5 ml-1 text-xs">
+              <span class="text-slate-500">Your profile link: </span>
+              <a
+                :href="prepBaseballPreviewUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-1 font-medium text-blue-600 hover:text-blue-700 break-all"
+              >
+                {{ prepBaseballPreviewUrl }}
+                <UIcon
+                  name="i-heroicons-arrow-top-right-on-square"
+                  class="w-3 h-3 shrink-0"
+                />
+              </a>
+            </p>
+            <p v-else class="mt-1.5 ml-1 text-xs text-slate-400">
+              Pick your state and enter the name from your profile URL. Example:
+              <span class="font-mono">{{ prepBaseballExampleUrl }}</span>
+            </p>
+
             <a
               href="https://www.prepbaseballreport.com/"
               target="_blank"
@@ -441,12 +499,20 @@ import type { PlayerDetails } from "~/types/models";
 import { useVideoLinks } from "~/composables/useVideoLinks";
 import { useAppToast } from "~/composables/useAppToast";
 import { abbreviatePosition } from "~/utils/positions/canonical";
+import {
+  buildPrepBaseballUrl,
+  slugifyPlayerName,
+  normalizeStateCode,
+  US_STATE_OPTIONS,
+} from "~/utils/recruitingLinks";
 
 const props = defineProps<{
   form: PlayerDetails;
   isParentRole: boolean;
   isBaseballOrSoftball: boolean;
   availablePositions: string[];
+  playerName: string;
+  homeState: string;
   triggerSave: () => void;
   togglePosition: (pos: string) => void;
   isPositionSelected: (pos: string) => boolean;
@@ -457,6 +523,35 @@ const props = defineProps<{
 
 const heightFeet = defineModel<number | undefined>("heightFeet");
 const heightInches = defineModel<number | undefined>("heightInches");
+
+// --- Prep Baseball Report profile link (state + name-slug -> URL) ---
+const prepBaseballStateOptions = US_STATE_OPTIONS;
+const suggestedPrepBaseballSlug = computed(() =>
+  slugifyPlayerName(props.playerName),
+);
+const prepBaseballPreviewUrl = computed(() =>
+  buildPrepBaseballUrl(
+    props.form.prep_baseball_state,
+    props.form.prep_baseball_id,
+  ),
+);
+const prepBaseballExampleUrl =
+  "https://www.prepbaseballreport.com/profiles/OH/owen-andrikanich";
+
+// Pre-select the athlete's home state (high-confidence guess) when no PBR
+// state is set yet; the athlete can change it if their profile is filed
+// elsewhere. Persisted on next save once they fill the name-slug.
+onMounted(() => {
+  if (!props.isParentRole && !props.form.prep_baseball_state) {
+    const code = normalizeStateCode(props.homeState);
+    if (code) props.form.prep_baseball_state = code;
+  }
+});
+
+function applySuggestedPrepBaseballSlug() {
+  props.form.prep_baseball_id = suggestedPrepBaseballSlug.value;
+  props.triggerSave();
+}
 
 const sportLabel = computed(() =>
   props.form.primary_sport

--- a/components/profile/PublicProfileCard.vue
+++ b/components/profile/PublicProfileCard.vue
@@ -3,6 +3,7 @@
 import { computed } from "vue";
 import type { PublicProfileData } from "~/types/models";
 import { formatPositionsShort } from "~/utils/positions/canonical";
+import { buildPrepBaseballUrl } from "~/utils/recruitingLinks";
 import {
   openTwitter,
   openInstagram,
@@ -43,6 +44,13 @@ const primaryPositionLabel = computed(() =>
     props.profile.athletic?.primary_sport,
     props.profile.athletic?.positions,
     props.profile.athletic?.primary_position,
+  ),
+);
+
+const prepBaseballUrl = computed(() =>
+  buildPrepBaseballUrl(
+    props.profile.athletic?.prep_baseball_state,
+    props.profile.athletic?.prep_baseball_id,
   ),
 );
 
@@ -290,7 +298,7 @@ function formatGPA(gpa: number | undefined): string {
           profile.athletic &&
           (profile.athletic.ncaa_id ||
             profile.athletic.perfect_game_id ||
-            profile.athletic.prep_baseball_id)
+            prepBaseballUrl)
         "
         class="px-6 py-5"
       >
@@ -321,13 +329,16 @@ function formatGPA(gpa: number | undefined): string {
               >
             </dd>
           </div>
-          <div
-            v-if="profile.athletic.prep_baseball_id"
-            class="flex justify-between"
-          >
+          <div v-if="prepBaseballUrl" class="flex justify-between">
             <dt class="text-gray-500">Prep Baseball</dt>
-            <dd class="font-mono font-medium text-gray-900">
-              {{ profile.athletic.prep_baseball_id }}
+            <dd class="font-medium">
+              <a
+                :href="prepBaseballUrl"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="text-blue-600 hover:text-blue-800 hover:underline font-mono"
+                >View profile</a
+              >
             </dd>
           </div>
         </dl>

--- a/composables/usePlayerDetailsForm.ts
+++ b/composables/usePlayerDetailsForm.ts
@@ -76,6 +76,7 @@ export function usePlayerDetailsForm() {
     ncaa_id: "",
     perfect_game_id: "",
     prep_baseball_id: "",
+    prep_baseball_state: "",
     twitter_handle: "",
     instagram_handle: "",
     tiktok_handle: "",
@@ -119,6 +120,8 @@ export function usePlayerDetailsForm() {
   // table, location store). Fetched once in load(); they don't change while the
   // athlete edits player details, but the score stays reactive to form edits.
   const hasHighlightVideo = computed(() => videoLinks.value.length > 0);
+  const homeState = computed(() => getHomeLocation.value?.state ?? "");
+
   const hasHomeLocation = ref(false);
 
   const profileCompleteness = computed(() =>
@@ -434,6 +437,7 @@ export function usePlayerDetailsForm() {
     THROWS_OPTIONS,
     CAMPUS_SIZE_OPTIONS,
     COST_SENSITIVITY_OPTIONS,
+    homeState,
     load,
   };
 }

--- a/composables/useTemplateResolver.ts
+++ b/composables/useTemplateResolver.ts
@@ -18,6 +18,7 @@ import {
   primaryAndSecondary,
   abbreviatePosition,
 } from "~/utils/positions/canonical";
+import { buildPrepBaseballUrl } from "~/utils/recruitingLinks";
 import type { CommunicationTemplate } from "~/types/models";
 
 const logger = createClientLogger("useTemplateResolver");
@@ -234,6 +235,15 @@ export const useTemplateResolver = () => {
       // Absolute so the link is clickable in the email/SMS sent to a coach
       // (parity with iOS TemplateContextBuilder.publicProfileBase).
       if (slug) derived.profileLink = `${PUBLIC_PROFILE_BASE}/p/${slug}`;
+
+      // Prep Baseball Report profile URL, built from the athlete's stored
+      // state + name-slug; omitted when either is missing so the variable
+      // renders as nothing rather than a broken link.
+      const prepBaseballLink = buildPrepBaseballUrl(
+        ctx.prefs.prep_baseball_state as string | undefined,
+        ctx.prefs.prep_baseball_id as string | undefined,
+      );
+      if (prepBaseballLink) derived.prepBaseballLink = prepBaseballLink;
 
       const { data: transcriptRow } = (await supabase
         .from("documents")

--- a/pages/settings/player-details.vue
+++ b/pages/settings/player-details.vue
@@ -143,6 +143,8 @@
             :is-parent-role="isReadOnly"
             :is-baseball-or-softball="isBaseballOrSoftball"
             :available-positions="availablePositions"
+            :player-name="userStore.user?.full_name ?? ''"
+            :home-state="homeState"
             :trigger-save="triggerSave"
             :toggle-position="togglePosition"
             :is-position-selected="isPositionSelected"
@@ -418,6 +420,7 @@ const {
   THROWS_OPTIONS,
   CAMPUS_SIZE_OPTIONS,
   COST_SENSITIVITY_OPTIONS,
+  homeState,
   load,
 } = usePlayerDetailsForm();
 

--- a/server/agent-content/profile.ts
+++ b/server/agent-content/profile.ts
@@ -1,4 +1,5 @@
 import type { PublicProfileData } from "~/types/models";
+import { buildPrepBaseballUrl } from "~/utils/recruitingLinks";
 
 function formatHeight(inches: number): string {
   const ft = Math.floor(inches / 12);
@@ -38,8 +39,12 @@ export function renderProfileMarkdown(
     if (a.ncaa_id) items.push(`- **NCAA ID:** ${a.ncaa_id}`);
     if (a.perfect_game_id)
       items.push(`- **Perfect Game ID:** ${a.perfect_game_id}`);
-    if (a.prep_baseball_id)
-      items.push(`- **Prep Baseball ID:** ${a.prep_baseball_id}`);
+    const prepBaseballUrl = buildPrepBaseballUrl(
+      a.prep_baseball_state,
+      a.prep_baseball_id,
+    );
+    if (prepBaseballUrl)
+      items.push(`- **Prep Baseball Report:** ${prepBaseballUrl}`);
     if (items.length) {
       lines.push("## Athletic");
       lines.push("");

--- a/server/api/public/profile/[slug].get.ts
+++ b/server/api/public/profile/[slug].get.ts
@@ -164,6 +164,9 @@ export default defineEventHandler(async (event) => {
                 (details.perfect_game_id as string | undefined) || undefined,
               prep_baseball_id:
                 (details.prep_baseball_id as string | undefined) || undefined,
+              prep_baseball_state:
+                (details.prep_baseball_state as string | undefined) ||
+                undefined,
             }
           : null,
       film: profile.show_film ? videoLinks : null,

--- a/supabase/migrations/20260822000000_prep_baseball_link_variable.sql
+++ b/supabase/migrations/20260822000000_prep_baseball_link_variable.sql
@@ -1,0 +1,23 @@
+-- Register the computed {{prepBaseballLink}} template variable so coach-outreach
+-- email/text templates can embed the athlete's Prep Baseball Report profile URL.
+--
+-- The value is derived in useTemplateResolver from the player-prefs
+-- prep_baseball_state (2-letter code) + prep_baseball_id (name-slug); it is
+-- omitted when either is missing, so the variable renders as nothing rather
+-- than a broken link.
+INSERT INTO public.template_variables
+  (key, label, description, category, source_type, source_path, is_required_default, example, sort_order)
+VALUES
+  ('prepBaseballLink',
+   'Prep Baseball Link',
+   'Prep Baseball Report profile URL; renders as nothing unless the athlete has set both their state and profile name.',
+   'player', 'computed', NULL, false,
+   'https://www.prepbaseballreport.com/profiles/OH/owen-andrikanich', 46)
+ON CONFLICT (key) DO UPDATE SET
+  label = excluded.label,
+  description = excluded.description,
+  category = excluded.category,
+  source_type = excluded.source_type,
+  source_path = excluded.source_path,
+  example = excluded.example,
+  sort_order = excluded.sort_order;

--- a/tests/unit/composables/useTemplateResolver.spec.ts
+++ b/tests/unit/composables/useTemplateResolver.spec.ts
@@ -44,6 +44,8 @@ const h = vi.hoisted(() => {
           twelfth_grade_coach: "Dave Reilly",
           primary_position: "Shortstop",
           positions: ["Shortstop", "Second Base"],
+          prep_baseball_id: "jordan-ellis",
+          prep_baseball_state: "OH",
         },
       },
       error: null,
@@ -134,6 +136,9 @@ describe("useTemplateResolver", () => {
       expect(ctx.derived?.position).toBe("SS/2B");
       expect(ctx.derived?.positionSecondary).toBe("2B");
       expect(ctx.derived?.profileLink).toBe("https://myrecruitingcompass.com/p/jordan");
+      expect(ctx.derived?.prepBaseballLink).toBe(
+        "https://www.prepbaseballreport.com/profiles/OH/jordan-ellis",
+      );
       expect(ctx.derived?.hsCoachName).toBe("Dave Reilly");
       expect(ctx.derived?.transcriptLink).toBe(
         "https://files.example/transcript.pdf",

--- a/tests/unit/utils/recruitingLinks.spec.ts
+++ b/tests/unit/utils/recruitingLinks.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import {
+  slugifyPlayerName,
+  normalizeStateCode,
+  buildPrepBaseballUrl,
+} from "~/utils/recruitingLinks";
+
+describe("slugifyPlayerName", () => {
+  it("kebab-cases a first + last name", () => {
+    expect(slugifyPlayerName("Owen Andrikanich")).toBe("owen-andrikanich");
+  });
+  it("collapses extra whitespace", () => {
+    expect(slugifyPlayerName("  Owen   Andrikanich  ")).toBe(
+      "owen-andrikanich",
+    );
+  });
+  it("strips apostrophes and periods", () => {
+    expect(slugifyPlayerName("O'Brien Jr.")).toBe("obrien-jr");
+  });
+  it("strips other punctuation to dashes and collapses them", () => {
+    expect(slugifyPlayerName("Mary-Kate  O'Neil")).toBe("mary-kate-oneil");
+  });
+  it("returns empty string for empty/whitespace input", () => {
+    expect(slugifyPlayerName("   ")).toBe("");
+    expect(slugifyPlayerName("")).toBe("");
+  });
+});
+
+describe("normalizeStateCode", () => {
+  it("passes through a valid 2-letter code", () => {
+    expect(normalizeStateCode("OH")).toBe("OH");
+  });
+  it("uppercases a lowercase code", () => {
+    expect(normalizeStateCode("oh")).toBe("OH");
+  });
+  it("maps a full state name to its code", () => {
+    expect(normalizeStateCode("Ohio")).toBe("OH");
+    expect(normalizeStateCode("north carolina")).toBe("NC");
+  });
+  it("trims surrounding whitespace", () => {
+    expect(normalizeStateCode("  OH  ")).toBe("OH");
+  });
+  it("returns null for an unknown value", () => {
+    expect(normalizeStateCode("ZZ")).toBeNull();
+    expect(normalizeStateCode("Narnia")).toBeNull();
+    expect(normalizeStateCode("")).toBeNull();
+    expect(normalizeStateCode(undefined)).toBeNull();
+  });
+});
+
+describe("buildPrepBaseballUrl", () => {
+  it("builds the canonical profile URL", () => {
+    expect(buildPrepBaseballUrl("OH", "owen-andrikanich")).toBe(
+      "https://www.prepbaseballreport.com/profiles/OH/owen-andrikanich",
+    );
+  });
+  it("normalizes state and slug before building", () => {
+    expect(buildPrepBaseballUrl("Ohio", "Owen Andrikanich")).toBe(
+      "https://www.prepbaseballreport.com/profiles/OH/owen-andrikanich",
+    );
+  });
+  it("returns null when state is missing or invalid", () => {
+    expect(buildPrepBaseballUrl("", "owen-andrikanich")).toBeNull();
+    expect(buildPrepBaseballUrl("Narnia", "owen-andrikanich")).toBeNull();
+    expect(buildPrepBaseballUrl(undefined, "owen-andrikanich")).toBeNull();
+  });
+  it("returns null when slug is missing", () => {
+    expect(buildPrepBaseballUrl("OH", "")).toBeNull();
+    expect(buildPrepBaseballUrl("OH", "   ")).toBeNull();
+    expect(buildPrepBaseballUrl("OH", undefined)).toBeNull();
+  });
+});

--- a/types/models.ts
+++ b/types/models.ts
@@ -375,7 +375,8 @@ export interface PlayerDetails {
   act_score?: number;
   ncaa_id?: string;
   perfect_game_id?: string;
-  prep_baseball_id?: string;
+  prep_baseball_id?: string; // Prep Baseball Report profile name-slug (e.g. "owen-andrikanich")
+  prep_baseball_state?: string; // 2-letter state code the PBR profile is filed under
   // Social Media
   twitter_handle?: string;
   instagram_handle?: string;
@@ -466,6 +467,7 @@ export interface PublicProfileData {
     ncaa_id?: string;
     perfect_game_id?: string;
     prep_baseball_id?: string;
+    prep_baseball_state?: string;
   } | null;
   /** null when show_film is false */
   film: VideoLink[] | null;

--- a/utils/preferenceValidation.ts
+++ b/utils/preferenceValidation.ts
@@ -118,6 +118,7 @@ export function validatePlayerDetails(data: unknown): PlayerDetails | null {
     ncaa_id: toString(obj.ncaa_id),
     perfect_game_id: toString(obj.perfect_game_id),
     prep_baseball_id: toString(obj.prep_baseball_id),
+    prep_baseball_state: toString(obj.prep_baseball_state),
     twitter_handle: toString(obj.twitter_handle),
     instagram_handle: toString(obj.instagram_handle),
     tiktok_handle: toString(obj.tiktok_handle),

--- a/utils/recruitingLinks.ts
+++ b/utils/recruitingLinks.ts
@@ -1,0 +1,116 @@
+/**
+ * Builders for external recruiting-database profile links.
+ *
+ * Prep Baseball Report profile URLs are slug-based, not ID-based:
+ *   https://www.prepbaseballreport.com/profiles/{STATE}/{name-slug}
+ * e.g. https://www.prepbaseballreport.com/profiles/OH/owen-andrikanich
+ *
+ * The stored `prep_baseball_id` now holds the name-slug; `prep_baseball_state`
+ * holds the 2-letter state code the athlete's profile lives under (PBR files
+ * profiles by state, which can differ from the athlete's home state).
+ */
+
+const PREP_BASEBALL_BASE = "https://www.prepbaseballreport.com/profiles";
+
+/** name -> 2-letter code, plus every code mapped to itself for pass-through. */
+const STATE_NAME_TO_CODE: Record<string, string> = {
+  alabama: "AL",
+  alaska: "AK",
+  arizona: "AZ",
+  arkansas: "AR",
+  california: "CA",
+  colorado: "CO",
+  connecticut: "CT",
+  delaware: "DE",
+  "district of columbia": "DC",
+  florida: "FL",
+  georgia: "GA",
+  hawaii: "HI",
+  idaho: "ID",
+  illinois: "IL",
+  indiana: "IN",
+  iowa: "IA",
+  kansas: "KS",
+  kentucky: "KY",
+  louisiana: "LA",
+  maine: "ME",
+  maryland: "MD",
+  massachusetts: "MA",
+  michigan: "MI",
+  minnesota: "MN",
+  mississippi: "MS",
+  missouri: "MO",
+  montana: "MT",
+  nebraska: "NE",
+  nevada: "NV",
+  "new hampshire": "NH",
+  "new jersey": "NJ",
+  "new mexico": "NM",
+  "new york": "NY",
+  "north carolina": "NC",
+  "north dakota": "ND",
+  ohio: "OH",
+  oklahoma: "OK",
+  oregon: "OR",
+  pennsylvania: "PA",
+  "rhode island": "RI",
+  "south carolina": "SC",
+  "south dakota": "SD",
+  tennessee: "TN",
+  texas: "TX",
+  utah: "UT",
+  vermont: "VT",
+  virginia: "VA",
+  washington: "WA",
+  "west virginia": "WV",
+  wisconsin: "WI",
+  wyoming: "WY",
+};
+
+const STATE_CODES = new Set(Object.values(STATE_NAME_TO_CODE));
+
+/** Dropdown options: { code, name } sorted by name, for state <select>s. */
+export const US_STATE_OPTIONS: ReadonlyArray<{ code: string; name: string }> =
+  Object.entries(STATE_NAME_TO_CODE)
+    .map(([name, code]) => ({
+      code,
+      name: name.replace(/\b\w/g, (c) => c.toUpperCase()),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+/** Kebab-case a player name for use as a PBR profile slug. */
+export function slugifyPlayerName(name: string | undefined | null): string {
+  if (!name) return "";
+  return name
+    .toLowerCase()
+    .replace(/['".]/g, "") // drop apostrophes/periods entirely (O'Brien -> obrien)
+    .replace(/[^a-z0-9]+/g, "-") // any other run of non-alphanumerics -> single dash
+    .replace(/^-+|-+$/g, ""); // trim leading/trailing dashes
+}
+
+/** Normalize a state name or code to a valid 2-letter USPS code, or null. */
+export function normalizeStateCode(
+  input: string | undefined | null,
+): string | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const upper = trimmed.toUpperCase();
+  if (STATE_CODES.has(upper)) return upper;
+  return STATE_NAME_TO_CODE[trimmed.toLowerCase()] ?? null;
+}
+
+/**
+ * Build a Prep Baseball Report profile URL from a state and name-slug.
+ * Returns null unless both a valid state and a non-empty slug are present.
+ */
+export function buildPrepBaseballUrl(
+  state: string | undefined | null,
+  slug: string | undefined | null,
+): string | null {
+  const code = normalizeStateCode(state);
+  if (!code) return null;
+  const normalizedSlug = slugifyPlayerName(slug);
+  if (!normalizedSlug) return null;
+  return `${PREP_BASEBALL_BASE}/${code}/${normalizedSlug}`;
+}

--- a/utils/templateVariables.ts
+++ b/utils/templateVariables.ts
@@ -89,6 +89,13 @@ export const AVAILABLE_VARIABLES: TemplateVariable[] = [
     description: "All video links, one per line (Title (PLATFORM): url)",
     example: "Senior Highlights (HUDL): https://www.hudl.com/video/12345",
   },
+  {
+    name: "Prep Baseball Link",
+    key: "prepBaseballLink",
+    description:
+      "Prep Baseball Report profile URL; renders as nothing unless the athlete has set both state and profile name",
+    example: "https://www.prepbaseballreport.com/profiles/OH/owen-andrikanich",
+  },
 ];
 
 /**


### PR DESCRIPTION
## Summary

Prep Baseball Report profile URLs changed from ID-based to slug-based (`/profiles/{STATE}/{name-slug}`, e.g. `https://www.prepbaseballreport.com/profiles/OH/owen-andrikanich`). This makes the app store + render the new shape and surface it as a clickable link everywhere recruiting IDs appear.

- Repurpose `prep_baseball_id` as the name-slug; add `prep_baseball_state` (2-letter code).
- New pure `utils/recruitingLinks.ts`: `buildPrepBaseballUrl`, `slugifyPlayerName`, `normalizeStateCode`, `US_STATE_OPTIONS` (14 unit tests).
- Athletics settings input: state dropdown (prefilled from home location, editable) + name-slug field (suggests kebab of player name) + **live sample link** + example URL.
- Public profile card + agent-content (LLM): PBR now a clickable profile link (was plain text).
- New `{{prepBaseballLink}}` template variable for coach **email/text** outreach — resolver derivation + `template_variables` registry row (migration).

NCAA left as plain text (no public profile page yet). Perfect Game already linked — untouched.

## Migrations

`20260822000000_prep_baseball_link_variable.sql` — seeds the registry row. **Already applied** to prod (`xpxzhqghxecsjhvklsqg`) and the E2E test DB (`ahpethltxopkjxxzwmmb`); idempotent (`ON CONFLICT DO UPDATE`).

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [x] `npm run audit:tokens` — 0 errors
- [x] Unit: new `recruitingLinks.spec.ts` (14) + resolver `prepBaseballLink` assertion; full suite 8066 pass (7 failures pre-exist on develop, unrelated)
- [ ] Browser verify: set PBR state+name in settings → confirm live link + public profile render

https://claude.ai/code/session_015DYLgGWsVKLNR47PV3xQBs