### PR TITLE
feat(metrics): sport-agnostic performance UI — Phase 1

### DIFF
--- a/components/Dashboard/PerformanceSummary.vue
+++ b/components/Dashboard/PerformanceSummary.vue
@@ -29,7 +29,7 @@
         >
           <div class="flex items-start justify-between mb-2">
             <span class="text-2xl">{{
-              getMetricEmoji(metric.metric_type)
+              getMetricIcon(metric.metric_type)
             }}</span>
             <span
               v-if="getTrend(metric.metric_type)"
@@ -102,6 +102,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { formatMetricValue } from "~/utils/metricFormat";
+import { getMetricDef } from "~/utils/metrics/canonical";
 import type { PerformanceMetric } from "~/types/models";
 
 interface Props {
@@ -169,31 +170,9 @@ const formatDate = (dateString: string) => {
   return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 };
 
-const getMetricEmoji = (type: string) => {
-  const emojiMap: Record<string, string> = {
-    velocity: "⚡",
-    exit_velo: "💥",
-    sixty_time: "🏃",
-    pop_time: "🎯",
-    batting_avg: "🏏",
-    era: "🎪",
-    strikeouts: "⚾",
-    other: "📈",
-  };
-  return emojiMap[type] || "📊";
-};
+// Sport-aware per-metric emoji from the canonical registry (neutral default
+// for unknown/humanized keys).
+const getMetricIcon = (type: string) => getMetricDef(type).icon;
 
-const getMetricLabel = (type: string) => {
-  const labels: Record<string, string> = {
-    velocity: "Fastball Velocity",
-    exit_velo: "Exit Velocity",
-    sixty_time: "60-Yard Dash",
-    pop_time: "Pop Time",
-    batting_avg: "Batting Avg",
-    era: "ERA",
-    strikeouts: "Strikeouts",
-    other: "Other",
-  };
-  return labels[type] || type;
-};
+const getMetricLabel = (type: string) => getMetricDef(type).label;
 </script>

--- a/components/Performance/MetricCategoryChart.vue
+++ b/components/Performance/MetricCategoryChart.vue
@@ -56,6 +56,7 @@ import {
 } from "chart.js";
 import "chartjs-adapter-date-fns";
 import type { PerformanceMetric, Event } from "~/types/models";
+import { getMetricDef } from "~/utils/metrics/canonical";
 
 ChartJS.register(
   CategoryScale,
@@ -92,19 +93,7 @@ const toggleMetric = (type: string) => {
   }
 };
 
-const getMetricLabel = (type: string): string => {
-  const labels: Record<string, string> = {
-    velocity: "Fastball Velocity",
-    exit_velo: "Exit Velocity",
-    sixty_time: "60-Yard Dash",
-    pop_time: "Pop Time",
-    batting_avg: "Batting Average",
-    era: "ERA",
-    strikeouts: "Strikeouts",
-    other: "Other Metric",
-  };
-  return labels[type] || type;
-};
+const getMetricLabel = (type: string): string => getMetricDef(type).label;
 
 const getMetricColor = (type: string): string => {
   const colors: Record<string, string> = {
@@ -246,18 +235,11 @@ const chartOptions = computed(() => ({
   },
 }));
 
+// Y-axis label derived from the first metric type's registry def (sport-agnostic).
 const getYAxisLabel = (): string => {
-  switch (props.category) {
-    case "power":
-      return "Velocity (mph)";
-    case "speed":
-      return "Time (seconds)";
-    case "hitting":
-      return "Batting Average";
-    case "pitching":
-      return "Value";
-    default:
-      return "Value";
-  }
+  const first = props.metricTypes[0];
+  if (!first) return "Value";
+  const def = getMetricDef(first);
+  return def.unit ? `${def.label} (${def.unit})` : def.label;
 };
 </script>

--- a/components/Performance/PerformanceChart.vue
+++ b/components/Performance/PerformanceChart.vue
@@ -105,6 +105,7 @@ import {
 } from "chart.js";
 import "chartjs-adapter-date-fns";
 import { usePerformanceAnalytics } from "~/composables/usePerformanceAnalytics";
+import { getMetricDef } from "~/utils/metrics/canonical";
 import type { Performance } from "~/types/models";
 import StatCard from "./StatCard.vue";
 import ComparisonCard from "./ComparisonCard.vue";
@@ -125,7 +126,9 @@ interface Props {
   title: string;
   metrics: any[];
   metricTypes: string[];
-  category: "power" | "speed" | "hitting" | "pitching";
+  /** Legacy baseball category — retained for compatibility, no longer drives
+   *  units/labels (those come from the metric registry). */
+  category?: "power" | "speed" | "hitting" | "pitching";
   showComparison?: boolean;
 }
 
@@ -147,33 +150,12 @@ const toggleMetric = (type: string) => {
   }
 };
 
-const getMetricLabel = (type: string): string => {
-  const labels: Record<string, string> = {
-    velocity: "Fastball Velocity",
-    exit_velo: "Exit Velocity",
-    sixty_time: "60-Yard Dash",
-    pop_time: "Pop Time",
-    batting_avg: "Batting Average",
-    era: "ERA",
-    strikeouts: "Strikeouts",
-    other: "Other Metric",
-  };
-  return labels[type] || type;
-};
+const getMetricLabel = (type: string): string => getMetricDef(type).label;
 
+// Unit for the stat cards, sourced from the first metric type's registry def.
 const getUnit = (): string => {
-  switch (props.category) {
-    case "power":
-      return "mph";
-    case "speed":
-      return "sec";
-    case "hitting":
-      return "avg";
-    case "pitching":
-      return "val";
-    default:
-      return "val";
-  }
+  const first = props.metricTypes[0];
+  return first ? getMetricDef(first).unit : "";
 };
 
 const getMetricColor = (type: string): string => {
@@ -366,18 +348,11 @@ const chartOptions = computed(() => ({
   },
 }));
 
+// Y-axis label derived from the first metric type's registry def (sport-agnostic).
 const getYAxisLabel = (): string => {
-  switch (props.category) {
-    case "power":
-      return "Velocity (mph)";
-    case "speed":
-      return "Time (seconds)";
-    case "hitting":
-      return "Batting Average";
-    case "pitching":
-      return "Value";
-    default:
-      return "Value";
-  }
+  const first = props.metricTypes[0];
+  if (!first) return "Value";
+  const def = getMetricDef(first);
+  return def.unit ? `${def.label} (${def.unit})` : def.label;
 };
 </script>

--- a/components/Performance/PerformanceDashboard.vue
+++ b/components/Performance/PerformanceDashboard.vue
@@ -53,73 +53,17 @@
       </div>
     </div>
 
-    <!-- Metric Categories Summary -->
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-      <!-- Power Metrics Summary -->
-      <div class="rounded-lg shadow-sm p-6 bg-white">
-        <h3 class="text-lg font-semibold mb-4 text-slate-900">Power Metrics</h3>
-        <div class="space-y-3">
-          <MetricSummaryRow
-            label="Fastball Velocity"
-            :value="getMetricStats('velocity')"
-            unit="mph"
-          />
-          <MetricSummaryRow
-            label="Exit Velocity"
-            :value="getMetricStats('exit_velo')"
-            unit="mph"
-          />
-        </div>
-      </div>
-
-      <!-- Speed Metrics Summary -->
-      <div class="rounded-lg shadow-sm p-6 bg-white">
-        <h3 class="text-lg font-semibold mb-4 text-slate-900">Speed Metrics</h3>
-        <div class="space-y-3">
-          <MetricSummaryRow
-            label="60-Yard Dash"
-            :value="getMetricStats('sixty_time')"
-            unit="sec"
-          />
-          <MetricSummaryRow
-            label="Pop Time"
-            :value="getMetricStats('pop_time')"
-            unit="sec"
-          />
-        </div>
-      </div>
-
-      <!-- Hitting Metrics Summary -->
-      <div class="rounded-lg shadow-sm p-6 bg-white">
-        <h3 class="text-lg font-semibold mb-4 text-slate-900">
-          Hitting Metrics
-        </h3>
-        <div class="space-y-3">
-          <MetricSummaryRow
-            label="Batting Average"
-            :value="getMetricStats('batting_avg')"
-            unit="avg"
-          />
-        </div>
-      </div>
-
-      <!-- Pitching Metrics Summary -->
-      <div class="rounded-lg shadow-sm p-6 bg-white">
-        <h3 class="text-lg font-semibold mb-4 text-slate-900">
-          Pitching Metrics
-        </h3>
-        <div class="space-y-3">
-          <MetricSummaryRow
-            label="ERA"
-            :value="getMetricStats('era')"
-            unit="era"
-          />
-          <MetricSummaryRow
-            label="Strikeouts"
-            :value="getMetricStats('strikeouts')"
-            unit="k"
-          />
-        </div>
+    <!-- Metric Summary (registry-driven, sport-agnostic) -->
+    <div v-if="summaryMetricTypes.length > 0" class="rounded-lg shadow-sm p-6 bg-white">
+      <h3 class="text-lg font-semibold mb-4 text-slate-900">Metric Summary</h3>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-3">
+        <MetricSummaryRow
+          v-for="type in summaryMetricTypes"
+          :key="type"
+          :label="getMetricLabel(type)"
+          :value="getMetricStats(type)"
+          :unit="getUnit(type)"
+        />
       </div>
     </div>
 
@@ -158,12 +102,20 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { formatMetricValue } from "~/utils/metricFormat";
+import {
+  metricTypesForSport,
+  getMetricDef,
+  OTHER_KEY,
+} from "~/utils/metrics/canonical";
 import { usePerformanceAnalytics } from "~/composables/usePerformanceAnalytics";
 import type { Performance } from "~/types/models";
 import MetricSummaryRow from "./MetricSummaryRow.vue";
 
 interface Props {
   metrics: any[];
+  /** Athlete's primary sport — drives the registry-backed metric summary.
+   *  Null/undefined falls back to the baseball vocabulary (no regression). */
+  primarySport?: string | null;
 }
 
 const props = defineProps<Props>();
@@ -224,33 +176,25 @@ const getMetricStats = (type: string) => {
   return formatMetricValue(type, latest);
 };
 
-const getMetricLabel = (type: string): string => {
-  const labels: Record<string, string> = {
-    velocity: "Fastball Velocity",
-    exit_velo: "Exit Velocity",
-    sixty_time: "60-Yard Dash",
-    pop_time: "Pop Time",
-    batting_avg: "Batting Average",
-    era: "ERA",
-    strikeouts: "Strikeouts",
-    other: "Other Metric",
-  };
-  return labels[type] || type;
-};
+const getMetricLabel = (type: string): string => getMetricDef(type).label;
 
-const getUnit = (type: string): string => {
-  const units: Record<string, string> = {
-    velocity: "mph",
-    exit_velo: "mph",
-    sixty_time: "sec",
-    pop_time: "sec",
-    batting_avg: "avg",
-    era: "era",
-    strikeouts: "k",
-    other: "val",
-  };
-  return units[type] || "val";
-};
+const getUnit = (type: string): string => getMetricDef(type).unit;
+
+// Registry-driven metric summary for the athlete's sport: only the metric
+// types they have actually recorded, ordered by the sport's registry ordering.
+// No invented baseball categories — the registry has no category metadata, so
+// we group generically (one row per recorded metric type).
+const summaryMetricTypes = computed(() => {
+  const recorded = new Set(props.metrics.map((m) => m.metric_type));
+  const ordered = metricTypesForSport(props.primarySport).filter(
+    (type) => type !== OTHER_KEY && recorded.has(type),
+  );
+  // Include any recorded custom/off-sport keys the registry ordering omits.
+  const extras = Array.from(recorded).filter(
+    (type) => type && !ordered.includes(type as string),
+  ) as string[];
+  return [...ordered, ...extras];
+});
 
 const getTrendColorClass = (): string => {
   const trend = overallTrend.value.toLowerCase();

--- a/components/Performance/PerformanceRadarChart.vue
+++ b/components/Performance/PerformanceRadarChart.vue
@@ -53,6 +53,7 @@ import {
   Legend,
 } from "chart.js";
 import type { PerformanceMetric } from "~/types/models";
+import { getMetricDef } from "~/utils/metrics/canonical";
 
 ChartJS.register(
   RadialLinearScale,
@@ -69,32 +70,12 @@ interface Props {
 
 const props = defineProps<Props>();
 
-const metricTypes = [
-  "velocity",
-  "exit_velo",
-  "sixty_time",
-  "pop_time",
-  "batting_avg",
-  "era",
-  "strikeouts",
-  "other",
-];
+// Whatever metric types the athlete actually has recorded — sport-agnostic.
+const metricTypes = computed(() => Object.keys(props.latestMetrics));
 
 const hasMetrics = computed(() => Object.keys(props.latestMetrics).length > 0);
 
-const getMetricLabel = (type: string): string => {
-  const labels: Record<string, string> = {
-    velocity: "Velocity",
-    exit_velo: "Exit Velo",
-    sixty_time: "60-Yard",
-    pop_time: "Pop Time",
-    batting_avg: "Batting Avg",
-    era: "ERA",
-    strikeouts: "Strikeouts",
-    other: "Other",
-  };
-  return labels[type] || type;
-};
+const getMetricLabel = (type: string): string => getMetricDef(type).label;
 
 const getMetricColor = (type: string): string => {
   const colors: Record<string, string> = {
@@ -117,7 +98,7 @@ const radarData = computed(() => {
   const backgroundColor: string[] = [];
   const borderColors: string[] = [];
 
-  metricTypes.forEach((type) => {
+  metricTypes.value.forEach((type) => {
     if (props.latestMetrics[type]) {
       labels.push(getMetricLabel(type));
       const value = props.latestMetrics[type].value;

--- a/components/Search/AdvancedFilters.vue
+++ b/components/Search/AdvancedFilters.vue
@@ -105,9 +105,9 @@
           class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
         >
           <option value="">All Sports</option>
-          <option value="baseball">Baseball</option>
-          <option value="softball">Softball</option>
-          <option value="other">Other</option>
+          <option v-for="sport in sportOptions" :key="sport" :value="sport">
+            {{ sport }}
+          </option>
         </select>
       </div>
 
@@ -239,13 +239,13 @@
           class="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
         >
           <option value="">All Metrics</option>
-          <option value="velocity">Velocity</option>
-          <option value="exit_velo">Exit Velocity</option>
-          <option value="sixty_time">60-Yard Dash</option>
-          <option value="pop_time">Pop Time</option>
-          <option value="batting_avg">Batting Average</option>
-          <option value="era">ERA</option>
-          <option value="strikeouts">Strikeouts</option>
+          <option
+            v-for="opt in metricTypeOptions"
+            :key="opt.value"
+            :value="opt.value"
+          >
+            {{ opt.label }}
+          </option>
         </select>
       </div>
 
@@ -281,11 +281,39 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
+import { SPORT_POSITIONS } from "~/utils/positions/canonical";
+import {
+  SPORT_METRICS,
+  getMetricDef,
+  OTHER_KEY,
+} from "~/utils/metrics/canonical";
+
 interface Props {
   filters: any;
   searchType: string;
   isFiltering: boolean;
 }
+
+// Full sport list from the registry (17 sports) — no baseball-only options.
+const sportOptions = computed(() => Object.keys(SPORT_POSITIONS));
+
+// Full union of metric types across every sport (deduped, ordered), labelled
+// via the registry. Every metric is reachable regardless of the viewer's sport.
+const metricTypeOptions = computed(() => {
+  const seen = new Set<string>();
+  const keys: string[] = [];
+  for (const list of Object.values(SPORT_METRICS)) {
+    for (const key of list) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        keys.push(key);
+      }
+    }
+  }
+  keys.push(OTHER_KEY);
+  return keys.map((key) => ({ value: key, label: getMetricDef(key).label }));
+});
 
 const emit = defineEmits<{
   "update:filters": [filters: any];

--- a/composables/useEventMetricsSection.ts
+++ b/composables/useEventMetricsSection.ts
@@ -3,6 +3,7 @@ import { usePerformance } from "~/composables/usePerformance";
 import { useAppToast } from "~/composables/useAppToast";
 import { createClientLogger } from "~/utils/logger";
 import type { Event, PerformanceMetric } from "~/types/models";
+import { getMetricDef } from "~/utils/metrics/canonical";
 
 const logger = createClientLogger("EventDetail");
 
@@ -29,19 +30,7 @@ export function useEventMetricsSection(
     verified: false,
   });
 
-  const getMetricLabel = (type: string): string => {
-    const labels: Record<string, string> = {
-      velocity: "Fastball Velocity",
-      exit_velo: "Exit Velocity",
-      sixty_time: "60-Yard Dash",
-      pop_time: "Pop Time",
-      batting_avg: "Batting Average",
-      era: "ERA",
-      strikeouts: "Strikeouts",
-      other: "Other Metric",
-    };
-    return labels[type] || type;
-  };
+  const getMetricLabel = (type: string): string => getMetricDef(type).label;
 
   const loadEventMetrics = async () => {
     try {
@@ -57,15 +46,8 @@ export function useEventMetricsSection(
     try {
       metricLoading.value = true;
       await createMetric({
-        metric_type: newMetric.metric_type as
-          | "velocity"
-          | "exit_velo"
-          | "sixty_time"
-          | "pop_time"
-          | "batting_avg"
-          | "era"
-          | "strikeouts"
-          | "other",
+        // metric_type is a registry key (any of 17 sports), not a baseball union.
+        metric_type: newMetric.metric_type,
         value: newMetric.value!,
         recorded_date: event.value!.start_date,
         unit: newMetric.unit || "unit",

--- a/pages/analytics/index.vue
+++ b/pages/analytics/index.vue
@@ -94,7 +94,7 @@
         <ScatterChart
           title="Performance Correlation Analysis"
           :datasets="chartData.performanceData"
-          x-label="Exit Velocity (mph)"
+          :x-label="performanceScatterXLabel"
           y-label="Distance (feet)"
           chart-height="400px"
           :show-stats="true"
@@ -144,6 +144,7 @@ import StatCard from "~/components/Analytics/StatCard.vue";
 import PieChart from "~/components/Analytics/PieChart.vue";
 import FunnelChart from "~/components/Analytics/FunnelChart.vue";
 import ScatterChart from "~/components/Analytics/ScatterChart.vue";
+import { getMetricDef } from "~/utils/metrics/canonical";
 import { useDashboardData } from "~/composables/useDashboardData";
 import { useFamilyCtx } from "~/composables/useFamilyCtx";
 import { createClientLogger } from "~/utils/logger";
@@ -164,6 +165,12 @@ const activeFamily = useFamilyCtx();
 const userStore = useUserStore();
 
 const { allSchools, allOffers, schoolCount, interactionCount } = dashboardData;
+
+// Scatter x-axis label sourced from the metric registry (not a baseball literal).
+const performanceScatterXLabel = computed(() => {
+  const def = getMetricDef("exit_velo");
+  return def.unit ? `${def.label} (${def.unit})` : def.label;
+});
 
 const stats = computed(() => ({
   totalSchools: schoolCount.value,

--- a/pages/events/[id].vue
+++ b/pages/events/[id].vue
@@ -349,14 +349,13 @@
                   class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
                 >
                   <option value="">Select Metric</option>
-                  <option value="velocity">Fastball Velocity (mph)</option>
-                  <option value="exit_velo">Exit Velocity (mph)</option>
-                  <option value="sixty_time">60-Yard Dash (sec)</option>
-                  <option value="pop_time">Pop Time (sec)</option>
-                  <option value="batting_avg">Batting Average</option>
-                  <option value="era">ERA</option>
-                  <option value="strikeouts">Strikeouts</option>
-                  <option value="other">Other</option>
+                  <option
+                    v-for="opt in metricTypeOptions"
+                    :key="opt.value"
+                    :value="opt.value"
+                  >
+                    {{ opt.label }}
+                  </option>
                 </select>
               </div>
 
@@ -391,7 +390,7 @@
                   id="unit"
                   v-model="newMetric.unit"
                   type="text"
-                  placeholder="e.g., mph, sec, avg"
+                  placeholder="e.g., mph, sec, m"
                   class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500"
                 />
               </div>
@@ -503,8 +502,10 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, defineAsyncComponent } from "vue";
+import { onMounted, computed, ref, defineAsyncComponent } from "vue";
 import { useRoute, useRouter } from "vue-router";
+import { usePreferenceManager } from "~/composables/usePreferenceManager";
+import { metricTypesForSport, getMetricDef } from "~/utils/metrics/canonical";
 import ExportButton from "~/components/Performance/ExportButton.vue";
 const ExportModal = defineAsyncComponent(
   () => import("~/components/Performance/ExportModal.vue"),
@@ -582,6 +583,19 @@ const {
 const { showQuickLogModal, quickLogData, handleQuickLogInteraction } =
   useEventQuickLog(eventId, event);
 
+// Metric-type dropdown options, ordered for the athlete's sport (registry-backed).
+const { playerPrefs, getPlayerDetails } = usePreferenceManager();
+const primarySport = ref<string | null>(null);
+const metricTypeOptions = computed(() =>
+  metricTypesForSport(primarySport.value).map((key) => {
+    const def = getMetricDef(key);
+    return {
+      value: key,
+      label: def.unit ? `${def.label} (${def.unit})` : def.label,
+    };
+  }),
+);
+
 const markAsAttended = () =>
   markEventAttended(() => {
     // Show quick interaction logging modal
@@ -600,5 +614,7 @@ onMounted(async () => {
     await loadEventMetrics();
     await loadCoaches();
   }
+  await playerPrefs.loadPreferences();
+  primarySport.value = getPlayerDetails()?.primary_sport ?? null;
 });
 </script>

--- a/pages/performance/index.vue
+++ b/pages/performance/index.vue
@@ -45,7 +45,7 @@
     <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <!-- Performance Dashboard (Analytics Overview) -->
       <div v-if="metrics.length > 0" class="mb-8">
-        <PerformanceDashboard :metrics="metrics" />
+        <PerformanceDashboard :metrics="metrics" :primary-sport="primarySport" />
       </div>
 
       <!-- Metric Charts -->
@@ -310,14 +310,13 @@
                   class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 >
                   <option value="">Select Metric</option>
-                  <option value="velocity">Fastball Velocity (mph)</option>
-                  <option value="exit_velo">Exit Velocity (mph)</option>
-                  <option value="sixty_time">60-Yard Dash (sec)</option>
-                  <option value="pop_time">Pop Time (sec)</option>
-                  <option value="batting_avg">Batting Average</option>
-                  <option value="era">ERA</option>
-                  <option value="strikeouts">Strikeouts</option>
-                  <option value="other">Other</option>
+                  <option
+                    v-for="opt in metricTypeOptions"
+                    :key="opt.value"
+                    :value="opt.value"
+                  >
+                    {{ opt.label }}
+                  </option>
                 </select>
               </div>
 
@@ -459,6 +458,10 @@
 <script setup lang="ts">
 import { ref, onMounted, reactive, computed, defineAsyncComponent } from "vue";
 import { formatMetricValue } from "~/utils/metricFormat";
+import {
+  metricTypesForSport,
+  getMetricDef,
+} from "~/utils/metrics/canonical";
 import { usePerformance } from "~/composables/usePerformance";
 import { usePreferenceManager } from "~/composables/usePreferenceManager";
 import { useAppToast } from "~/composables/useAppToast";
@@ -583,8 +586,8 @@ const metricTrends = computed(() => {
       const firstAvg = first3.reduce((a, b) => a + b, 0) / first3.length;
       const lastAvg = last3.reduce((a, b) => a + b, 0) / last3.length;
 
-      // For metrics like 60-time, ERA, lower is better; for velocity, exit velo, higher is better
-      const lowerIsBetter = ["sixty_time", "pop_time", "era"].includes(type);
+      // Direction ("lower is better") comes from the metric registry, per sport.
+      const lowerIsBetter = getMetricDef(type).lowerIsBetter;
       let trend: "improving" | "declining" | "stable";
 
       if (lowerIsBetter) {
@@ -696,19 +699,18 @@ const chartOptions = {
   },
 };
 
-const getMetricLabel = (type: string): string => {
-  const labels: Record<string, string> = {
-    velocity: "Fastball Velocity",
-    exit_velo: "Exit Velocity",
-    sixty_time: "60-Yard Dash",
-    pop_time: "Pop Time",
-    batting_avg: "Batting Average",
-    era: "ERA",
-    strikeouts: "Strikeouts",
-    other: "Other Metric",
-  };
-  return labels[type] || type;
-};
+const getMetricLabel = (type: string): string => getMetricDef(type).label;
+
+// Metric-type dropdown options, ordered for the athlete's sport (registry-backed).
+const metricTypeOptions = computed(() =>
+  metricTypesForSport(primarySport.value).map((key) => {
+    const def = getMetricDef(key);
+    return {
+      value: key,
+      label: def.unit ? `${def.label} (${def.unit})` : def.label,
+    };
+  }),
+);
 
 const formatDate = (dateStr: string): string => {
   const date = new Date(dateStr);
@@ -722,15 +724,8 @@ const formatDate = (dateStr: string): string => {
 const handleAddMetric = async () => {
   try {
     await createMetric({
-      metric_type: newMetric.metric_type as
-        | "velocity"
-        | "exit_velo"
-        | "sixty_time"
-        | "pop_time"
-        | "batting_avg"
-        | "era"
-        | "strikeouts"
-        | "other",
+      // metric_type is a registry key (any of 17 sports), not a baseball union.
+      metric_type: newMetric.metric_type,
       value: newMetric.value!,
       recorded_date: newMetric.recorded_date,
       unit: newMetric.unit || "unit",

--- a/pages/performance/timeline.vue
+++ b/pages/performance/timeline.vue
@@ -45,41 +45,23 @@
 
       <!-- Charts -->
       <div v-else class="space-y-8">
-        <!-- Power Metrics Chart -->
+        <!-- One chart per recorded metric type, ordered by the athlete's sport
+             (registry-driven; no hard-coded baseball categories). -->
         <PerformanceChart
-          title="Power Metrics"
-          :metrics="powerMetrics"
-          :metric-types="['velocity', 'exit_velo']"
-          category="power"
+          v-for="section in chartSections"
+          :key="section.type"
+          :title="section.title"
+          :metrics="section.metrics"
+          :metric-types="[section.type]"
           :show-comparison="true"
         />
 
-        <!-- Speed Metrics Chart -->
-        <PerformanceChart
-          title="Speed Metrics"
-          :metrics="speedMetrics"
-          :metric-types="['sixty_time', 'pop_time']"
-          category="speed"
-          :show-comparison="true"
-        />
-
-        <!-- Hitting & Pitching (2-column grid) -->
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-          <PerformanceChart
-            title="Hitting Metrics"
-            :metrics="hittingMetrics"
-            :metric-types="['batting_avg']"
-            category="hitting"
-            :show-comparison="false"
-          />
-
-          <PerformanceChart
-            title="Pitching Metrics"
-            :metrics="pitchingMetrics"
-            :metric-types="['era', 'strikeouts']"
-            category="pitching"
-            :show-comparison="false"
-          />
+        <!-- Empty state -->
+        <div
+          v-if="chartSections.length === 0"
+          class="bg-white rounded-lg shadow-sm p-12 text-center text-slate-600"
+        >
+          No performance metrics recorded yet
         </div>
 
         <!-- Radar Chart: Current Performance Snapshot -->
@@ -102,6 +84,8 @@
 import { ref, computed, onMounted, watch, defineAsyncComponent } from "vue";
 import { usePerformance } from "~/composables/usePerformance";
 import { useEvents } from "~/composables/useEvents";
+import { usePreferenceManager } from "~/composables/usePreferenceManager";
+import { metricTypesForSport, getMetricDef } from "~/utils/metrics/canonical";
 const ExportModal = defineAsyncComponent(
   () => import("~/components/Performance/ExportModal.vue"),
 );
@@ -130,25 +114,28 @@ const filteredMetrics = computed(() => {
   return metrics.value.filter((m) => m.verified);
 });
 
-// Computed: Categorize metrics
-const powerMetrics = computed(() =>
-  filteredMetrics.value.filter((m) =>
-    ["velocity", "exit_velo"].includes(m.metric_type),
-  ),
-);
-const speedMetrics = computed(() =>
-  filteredMetrics.value.filter((m) =>
-    ["sixty_time", "pop_time"].includes(m.metric_type),
-  ),
-);
-const hittingMetrics = computed(() =>
-  filteredMetrics.value.filter((m) => m.metric_type === "batting_avg"),
-);
-const pitchingMetrics = computed(() =>
-  filteredMetrics.value.filter((m) =>
-    ["era", "strikeouts"].includes(m.metric_type),
-  ),
-);
+// Athlete's primary sport — drives the registry-backed chart grouping.
+const { playerPrefs, getPlayerDetails } = usePreferenceManager();
+const primarySport = ref<string | null>(null);
+
+// Computed: one chart section per recorded metric type, ordered by the sport's
+// registry ordering (recorded custom/off-sport keys appended). No baseball
+// categories — the registry has no category metadata, so grouping is generic
+// (one section per metric type), titled from the registry label.
+const chartSections = computed(() => {
+  const recorded = new Set(filteredMetrics.value.map((m) => m.metric_type));
+  const ordered = metricTypesForSport(primarySport.value).filter((type) =>
+    recorded.has(type),
+  );
+  const extras = Array.from(recorded).filter(
+    (type) => type && !ordered.includes(type),
+  );
+  return [...ordered, ...extras].map((type) => ({
+    type,
+    title: getMetricDef(type).label,
+    metrics: filteredMetrics.value.filter((m) => m.metric_type === type),
+  }));
+});
 
 // Computed: Filter events by date range
 const filteredEvents = computed(() => {
@@ -161,34 +148,18 @@ const filteredEvents = computed(() => {
   );
 });
 
-// Computed: Latest metrics by type for radar
+// Computed: Latest metric per recorded type, for the radar snapshot.
 const latestMetricsByType = computed(() => {
   const latest: Record<string, PerformanceMetric> = {};
-  const allTypes = [
-    "velocity",
-    "exit_velo",
-    "sixty_time",
-    "pop_time",
-    "batting_avg",
-    "era",
-    "strikeouts",
-    "other",
-  ];
-
-  allTypes.forEach((type) => {
-    const metricsOfType = filteredMetrics.value
-      .filter((m) => m.metric_type === type)
-      .sort(
-        (a, b) =>
-          new Date(b.recorded_date).getTime() -
-          new Date(a.recorded_date).getTime(),
-      );
-
-    if (metricsOfType.length > 0) {
-      latest[type] = metricsOfType[0];
+  const sorted = [...filteredMetrics.value].sort(
+    (a, b) =>
+      new Date(b.recorded_date).getTime() - new Date(a.recorded_date).getTime(),
+  );
+  for (const metric of sorted) {
+    if (!latest[metric.metric_type]) {
+      latest[metric.metric_type] = metric;
     }
-  });
-
+  }
   return latest;
 });
 
@@ -284,6 +255,8 @@ onMounted(async () => {
     }),
     fetchEvents(),
   ]);
+  await playerPrefs.loadPreferences();
+  primarySport.value = getPlayerDetails()?.primary_sport ?? null;
 });
 
 // Watchers

--- a/tests/unit/components/PerformanceChart.spec.ts
+++ b/tests/unit/components/PerformanceChart.spec.ts
@@ -207,12 +207,12 @@ describe("PerformanceChart", () => {
       expect(wrapper.vm.getMetricLabel("sixty_time")).toBe("60-Yard Dash");
     });
 
-    it("should return correct units for category", () => {
-      expect(wrapper.vm.getUnit()).toBe("mph"); // power category
+    it("should return the registry unit for the first metric type", () => {
+      expect(wrapper.vm.getUnit()).toBe("mph"); // velocity → mph
     });
 
-    it("should return correct y-axis label based on category", () => {
-      expect(wrapper.vm.getYAxisLabel()).toBe("Velocity (mph)");
+    it("should return a registry-derived y-axis label", () => {
+      expect(wrapper.vm.getYAxisLabel()).toBe("Fastball Velocity (mph)");
     });
   });
 
@@ -232,7 +232,7 @@ describe("PerformanceChart", () => {
       });
 
       expect(wrapper.vm.getUnit()).toBe("sec");
-      expect(wrapper.vm.getYAxisLabel()).toBe("Time (seconds)");
+      expect(wrapper.vm.getYAxisLabel()).toBe("60-Yard Dash (sec)");
     });
 
     it("should render hitting metrics", async () => {
@@ -244,7 +244,8 @@ describe("PerformanceChart", () => {
         ],
       });
 
-      expect(wrapper.vm.getUnit()).toBe("avg");
+      // batting_avg is a unitless ratio in the registry.
+      expect(wrapper.vm.getUnit()).toBe("");
     });
 
     it("should render pitching metrics", async () => {
@@ -254,7 +255,8 @@ describe("PerformanceChart", () => {
         metrics: [createMockMetric({ metric_type: "era", value: 2.85 })],
       });
 
-      expect(wrapper.vm.getUnit()).toBe("val");
+      // ERA is unitless in the registry.
+      expect(wrapper.vm.getUnit()).toBe("");
     });
   });
 

--- a/tests/unit/components/PerformanceDashboard.spec.ts
+++ b/tests/unit/components/PerformanceDashboard.spec.ts
@@ -89,24 +89,18 @@ describe("PerformanceDashboard", () => {
     });
   });
 
-  describe("metric categories", () => {
-    it("should render power metrics section", () => {
-      expect(wrapper.text()).toContain("Power Metrics");
-      expect(wrapper.text()).toContain("Fastball Velocity");
-      expect(wrapper.text()).toContain("Exit Velocity");
+  describe("metric summary (registry-driven)", () => {
+    it("should render a single registry-driven summary section", () => {
+      expect(wrapper.text()).toContain("Metric Summary");
+      // No invented baseball category headers.
+      expect(wrapper.text()).not.toContain("Power Metrics");
+      expect(wrapper.text()).not.toContain("Pitching Metrics");
     });
 
-    it("should render speed metrics section", () => {
-      expect(wrapper.text()).toContain("Speed Metrics");
-      expect(wrapper.text()).toContain("60-Yard Dash");
-    });
-
-    it("should render hitting metrics section", () => {
-      expect(wrapper.text()).toContain("Hitting Metrics");
-    });
-
-    it("should render pitching metrics section", () => {
-      expect(wrapper.text()).toContain("Pitching Metrics");
+    it("should render one summary row per recorded metric type", () => {
+      // Recorded types: velocity, exit_velo, sixty_time → 3 rows.
+      const rows = wrapper.findAll(".metric-summary-row");
+      expect(rows.length).toBe(3);
     });
   });
 
@@ -179,10 +173,11 @@ describe("PerformanceDashboard", () => {
       expect(wrapper.vm.getMetricLabel("sixty_time")).toBe("60-Yard Dash");
     });
 
-    it("should return correct units", () => {
+    it("should return registry units", () => {
       expect(wrapper.vm.getUnit("velocity")).toBe("mph");
       expect(wrapper.vm.getUnit("sixty_time")).toBe("sec");
-      expect(wrapper.vm.getUnit("batting_avg")).toBe("avg");
+      // batting_avg is a unitless ratio in the registry.
+      expect(wrapper.vm.getUnit("batting_avg")).toBe("");
     });
   });
 

--- a/tests/unit/utils/metrics/canonical.spec.ts
+++ b/tests/unit/utils/metrics/canonical.spec.ts
@@ -104,6 +104,26 @@ describe("sport orderings", () => {
   });
 });
 
+describe("metric icons", () => {
+  it("sport-specific keys carry a non-default emoji", () => {
+    expect(getMetricDef("points_per_game").icon).toBe("🏀");
+    expect(getMetricDef("goals").icon).toBe("⚽");
+    expect(getMetricDef("passing_yards").icon).toBe("🏈");
+    expect(getMetricDef("event_time").icon).toBe("🏊");
+    expect(getMetricDef("scoring_average").icon).toBe("⛳");
+    expect(getMetricDef("velocity").icon).toBe("🔥");
+  });
+  it("unknown/humanized keys fall back to the neutral default", () => {
+    expect(getMetricDef("wingspan_reach").icon).toBe("📊");
+    expect(getMetricDef(OTHER_KEY).icon).toBe("📊");
+  });
+  it("every registered def has a non-empty icon", () => {
+    for (const d of Object.values(METRIC_DEFS)) {
+      expect(d.icon, `${d.key} missing icon`).toBeTruthy();
+    }
+  });
+});
+
 describe("customMetricKey", () => {
   it("snake_cases a custom other-name", () => {
     expect(customMetricKey("Vertical Jump")).toBe("vertical_jump");

--- a/tests/unit/utils/textTemplates.spec.ts
+++ b/tests/unit/utils/textTemplates.spec.ts
@@ -229,8 +229,10 @@ describe("getMetricLabel", () => {
     expect(getMetricLabel("other")).toBe("Other Metric");
   });
 
-  it("returns the raw type string for unknown metric type", () => {
-    expect(getMetricLabel("custom_metric")).toBe("custom_metric");
+  it("returns a humanized label for unknown metric type", () => {
+    // Registry synthesizes a fallback label (underscores → spaces) so no
+    // athlete ever sees a raw metric key.
+    expect(getMetricLabel("custom_metric")).toBe("custom metric");
   });
 
   it("returns the raw type string for empty string", () => {

--- a/utils/metrics/canonical.ts
+++ b/utils/metrics/canonical.ts
@@ -25,7 +25,13 @@ export interface MetricDef {
   unit: string;
   format: MetricFormat;
   lowerIsBetter: boolean;
+  /** Per-metric display emoji. Mirrors iOS `MetricDef.icon` (SF Symbol there,
+   * emoji here — the values are intentionally per-platform). */
+  icon: string;
 }
+
+/** Neutral fallback emoji for keys without a specific icon. */
+const DEFAULT_ICON = "📊";
 
 // Format constructors — keep call sites terse and consistent.
 const dec = (digits: number, dropLeadingZero = false): MetricFormat => ({
@@ -43,7 +49,102 @@ const def = (
   unit: string,
   format: MetricFormat,
   lowerIsBetter = false,
-): MetricDef => ({ key, label, unit, format, lowerIsBetter });
+): MetricDef => ({ key, label, unit, format, lowerIsBetter, icon: DEFAULT_ICON });
+
+/**
+ * Central emoji per metric key across all 17 sports. Keeps every icon surface
+ * sport-aware without a baseball-only branch. Mirrors iOS
+ * `MetricRegistry.iconByKey` (SF Symbols there, emoji here — values are
+ * intentionally per-platform). Unlisted keys fall back to `DEFAULT_ICON`.
+ */
+const ICON_BY_KEY: Record<string, string> = {
+  // Baseball / Softball
+  velocity: "🔥",
+  exit_velo: "🔥",
+  batting_avg: "🏏",
+  sixty_time: "⏱️",
+  pop_time: "⏱️",
+  era: "⚾",
+  on_base_pct: "🎯",
+  slugging_pct: "🎯",
+  whip: "⚾",
+  strikeouts: "💪",
+  fielding_pct: "🧤",
+  // Basketball
+  points_per_game: "🏀",
+  rebounds_per_game: "🔄",
+  assists_per_game: "🤝",
+  field_goal_pct: "🎯",
+  three_point_pct: "🎯",
+  free_throw_pct: "🎯",
+  steals_per_game: "🖐️",
+  blocks_per_game: "🚫",
+  vertical_jump: "⬆️",
+  // Football
+  forty_time: "⏱️",
+  bench_press: "💪",
+  broad_jump: "↔️",
+  shuttle: "⏱️",
+  three_cone: "⏱️",
+  squat: "💪",
+  passing_yards: "🏈",
+  rushing_yards: "🏃",
+  receiving_yards: "🏈",
+  tackles: "🛡️",
+  // Soccer / Lacrosse / Ice Hockey / Field Hockey / Water Polo
+  goals: "⚽",
+  assists: "🤝",
+  saves: "🧤",
+  clean_sheets: "🛡️",
+  minutes_played: "⏰",
+  ground_balls: "🥍",
+  points: "⭐",
+  save_pct: "🎯",
+  goals_against_avg: "🥅",
+  steals: "🖐️",
+  // Volleyball
+  kills: "💥",
+  blocks: "🚫",
+  digs: "🖐️",
+  aces: "⚡",
+  hitting_pct: "🎯",
+  // Track & Field
+  sprint_time: "🏃",
+  distance_time: "🏃",
+  relay_split: "⏱️",
+  long_jump: "↔️",
+  high_jump: "⬆️",
+  shot_put: "🔵",
+  discus: "🥏",
+  // Cross Country
+  race_time: "🏃",
+  pace_per_mile: "⏱️",
+  // Swimming
+  event_time: "🏊",
+  free_50: "🏊",
+  free_100: "🏊",
+  // Golf
+  scoring_average: "⛳",
+  handicap: "🏌️",
+  // Tennis
+  utr_rating: "🎾",
+  ranking: "🔢",
+  // Wrestling
+  pins: "🤼",
+  takedowns: "🤼",
+  weight_class: "⚖️",
+  // Rowing
+  erg_2k: "🚣",
+  erg_split: "⏱️",
+  // Fallback bucket
+  other: DEFAULT_ICON,
+};
+
+/** Apply the central icon map over a def, keeping every other field. */
+const withIcon = (d: MetricDef): MetricDef => ({
+  ...d,
+  icon: ICON_BY_KEY[d.key] ?? d.icon,
+});
 
 /**
  * Render a raw value to its display string (number only — callers append the
@@ -205,7 +306,7 @@ const allDefs: MetricDef[] = [
 export const METRIC_DEFS: Record<string, MetricDef> = allDefs.reduce(
   (acc, d) => {
     if (acc[d.key]) throw new Error(`Duplicate metric def key: ${d.key}`);
-    acc[d.key] = d;
+    acc[d.key] = withIcon(d);
     return acc;
   },
   {} as Record<string, MetricDef>,

--- a/utils/performanceExport.ts
+++ b/utils/performanceExport.ts
@@ -1,5 +1,6 @@
 import type { PerformanceMetric } from "~/types/models";
 import { createClientLogger } from "~/utils/logger";
+import { getMetricDef } from "~/utils/metrics/canonical";
 
 const logger = createClientLogger("performanceExport");
 
@@ -172,16 +173,4 @@ const formatDate = (date: string): string => {
   });
 };
 
-const getMetricLabel = (type: string): string => {
-  const labels: Record<string, string> = {
-    velocity: "Fastball Velocity",
-    exit_velo: "Exit Velocity",
-    sixty_time: "60-Yard Dash",
-    pop_time: "Pop Time",
-    batting_avg: "Batting Average",
-    era: "ERA",
-    strikeouts: "Strikeouts",
-    other: "Other Metric",
-  };
-  return labels[type] || type;
-};
+const getMetricLabel = (type: string): string => getMetricDef(type).label;

--- a/utils/textTemplates.ts
+++ b/utils/textTemplates.ts
@@ -1,4 +1,5 @@
 import type { PerformanceMetric, Event } from "~/types/models";
+import { getMetricDef } from "~/utils/metrics/canonical";
 
 /**
  * Generate coach-friendly email template for performance metrics
@@ -89,18 +90,7 @@ Generated: ${new Date().toLocaleDateString()}
 };
 
 /**
- * Get metric label for display
+ * Get metric label for display, sourced from the sport-agnostic registry so
+ * non-baseball metrics render their real label (never a raw key).
  */
-export const getMetricLabel = (type: string): string => {
-  const labels: Record<string, string> = {
-    velocity: "Fastball Velocity",
-    exit_velo: "Exit Velocity",
-    sixty_time: "60-Yard Dash",
-    pop_time: "Pop Time",
-    batting_avg: "Batting Average",
-    era: "ERA",
-    strikeouts: "Strikeouts",
-    other: "Other Metric",
-  };
-  return labels[type] || type;
-};
+export const getMetricLabel = (type: string): string => getMetricDef(type).label;


### PR DESCRIPTION
## Phase 1 of the baseball-deprecation effort

App is sport-agnostic (17 sports) but the whole performance/analytics UI hand-rolled baseball-only metric maps. This routes every surface through the sport registry (`utils/metrics/canonical.ts`).

### Changes
- **All metric label/unit lookups** now use `getMetricDef()`: `PerformanceDashboard`, `Radar/Chart/CategoryChart`, `PerformanceSummary`, `pages/performance/*`, `events/[id]`, `analytics`, `performanceExport`, `textTemplates`.
- **Metric icon** — `MetricDef` gains an emoji `icon` field + `ICON_BY_KEY` across all 17 sports; `PerformanceSummary` renders it instead of a single generic emoji. Presentational (emoji here / SF Symbol on iOS), not string-identical to iOS; data fields stay byte-identical.
- **metric_type union** — `useEventMetricsSection` + `pages/performance` drop the closed baseball union so non-baseball keys type-check.
- **Search filters** — `AdvancedFilters` sport + metric filters populate from the registry (all 17 sports / full metric union), not baseball/softball/other.
- **Hitting/Pitching panels** → generic per-metric grouping ordered by the sport's registry (registry has no category metadata yet — follow-up).

### Test plan
- `npm run type-check` 0, `npm run lint` 0.
- Affected vitest suites green (+3 new icon assertions). Pre-existing `TimelineStatPills.spec.ts` ×4 failures unrelated.

Paired with iOS PR (same Phase 1).

https://claude.ai/code/session_01CDcodSBGGkT2H1MpTqbmRs