### PR TITLE
test: fix 7 pre-existing unit failures blocking CI

### DIFF
--- a/components/Timeline/TimelineStatPills.vue
+++ b/components/Timeline/TimelineStatPills.vue
@@ -27,6 +27,7 @@
       </div>
       <div class="h-1.5 bg-slate-100 rounded-full overflow-hidden">
         <div
+          data-testid="status-dot"
           class="h-full transition-all duration-300"
           :class="statusBarClass"
           :style="{ width: `${statusScore}%` }"
@@ -58,6 +59,7 @@
       </div>
       <div class="h-1.5 bg-slate-100 rounded-full overflow-hidden">
         <div
+          data-testid="task-bar"
           class="h-full bg-blue-500 transition-all duration-300"
           :style="{ width: `${taskPercent}%` }"
         />

--- a/tests/unit/components/Timeline/TimelineStatPills.spec.ts
+++ b/tests/unit/components/Timeline/TimelineStatPills.spec.ts
@@ -46,7 +46,10 @@ describe("TimelineStatPills", () => {
 
   it("computes task progress percentage correctly", () => {
     const wrapper = mount(TimelineStatPills, { props: defaultProps });
-    expect(wrapper.text()).toContain("33%");
+    // 8/24 = 33%, rendered as the task bar's width.
+    expect(wrapper.find("[data-testid='task-bar']").attributes("style")).toContain(
+      "width: 33%",
+    );
   });
 
   it("handles zero tasks gracefully", () => {

--- a/tests/unit/server/api/admin/cron-trigger.post.spec.ts
+++ b/tests/unit/server/api/admin/cron-trigger.post.spec.ts
@@ -7,8 +7,11 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const fetchMock = vi.fn();
-vi.stubGlobal("$fetch", fetchMock);
+// The handler invokes the cron job in-process via useNitroApp().localFetch
+// (not a relative $fetch — see trigger.post.ts), so mock that path and have it
+// resolve a Response-like { ok, json() }.
+const localFetchMock = vi.fn();
+vi.stubGlobal("useNitroApp", () => ({ localFetch: localFetchMock }));
 
 const { requireAdmin, logAdminAction } = vi.hoisted(() => ({
   requireAdmin: vi.fn(async (e: any) => {
@@ -33,7 +36,9 @@ import handler from "~/server/api/admin/cron/trigger.post";
 const mkEvent = (body: any) => ({ context: {}, _body: body, node: { req: {} } }) as any;
 
 beforeEach(() => {
-  fetchMock.mockReset().mockResolvedValue({ ok: true });
+  localFetchMock
+    .mockReset()
+    .mockResolvedValue({ ok: true, json: async () => ({ ran: true }) });
   requireAdmin.mockClear();
   logAdminAction.mockClear();
   process.env.CRON_SECRET = "secret-x";
@@ -43,7 +48,7 @@ describe("POST /api/admin/cron/trigger", () => {
   it("triggers a safe job with the cron secret and audits it", async () => {
     const res = await handler(mkEvent({ jobName: "health-ping" }));
     expect(res).toMatchObject({ ok: true, jobName: "health-ping", dryRun: false });
-    expect(fetchMock).toHaveBeenCalledWith(
+    expect(localFetchMock).toHaveBeenCalledWith(
       "/api/cron/health-ping",
       expect.objectContaining({ headers: expect.objectContaining({ "x-cron-secret": "secret-x" }) }),
     );
@@ -61,7 +66,7 @@ describe("POST /api/admin/cron/trigger", () => {
         expect.objectContaining({ action: "cron.trigger", meta: { jobName: job, blocked: true } }),
       );
     }
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(localFetchMock).not.toHaveBeenCalled();
   });
 
   it("403s an unknown job", async () => {
@@ -71,9 +76,10 @@ describe("POST /api/admin/cron/trigger", () => {
   it("forces dryRun for orphaned-storage-sweep even if body says false", async () => {
     const res = await handler(mkEvent({ jobName: "orphaned-storage-sweep", dryRun: false }));
     expect(res.dryRun).toBe(true);
-    expect(fetchMock).toHaveBeenCalledWith(
-      "/api/cron/orphaned-storage-sweep",
-      expect.objectContaining({ query: { dryRun: 1 } }),
+    // dryRun is encoded in the URL, not a `query` option.
+    expect(localFetchMock).toHaveBeenCalledWith(
+      "/api/cron/orphaned-storage-sweep?dryRun=1",
+      expect.objectContaining({ method: "GET" }),
     );
   });
 });

--- a/tests/unit/stores/coaches.spec.ts
+++ b/tests/unit/stores/coaches.spec.ts
@@ -226,7 +226,7 @@ describe("useCoachStore", () => {
       await coachStore.fetchCoachesBySchools(["school-1"]);
 
       expect(mockQuery.select).toHaveBeenCalledWith(
-        "id, school_id, first_name, last_name, email, last_contact_date, role",
+        "id, school_id, first_name, last_name, email, phone, twitter_handle, instagram_handle, last_contact_date, role",
       );
     });
 


### PR DESCRIPTION
## Summary

Seven unit tests were red on `develop`, blocking CI on every open PR. Each is a **test drifted behind an intentional, already-shipped impl change** — no production regression. Fixes realign the assertions (plus two `data-testid` hooks).

| Spec | Shipped change it lagged | Fix |
|---|---|---|
| `admin/cron-trigger.post.spec.ts` (×2) | handler migrated `$fetch` → `useNitroApp().localFetch` (`33392454`) | mock/assert `localFetch`; dryRun is URL-encoded, not a `query` opt |
| `stores/coaches.spec.ts` (×1) | `fetchCoachesBySchools` select widened with `phone, twitter_handle, instagram_handle` | update expected column string |
| `Timeline/TimelineStatPills.spec.ts` (×4) | card redesign (`4410df20`): status dot → icon+bar, % text dropped | restore `data-testid` on status/task bars; assert bar width for % |

## Test plan

- [x] 3 fixed files: 46/46 pass
- [x] Full suite: 8084 pass, 0 fail (`Test Files 526 passed`)
- [x] `npm run type-check` clean
- [x] `npm run lint` clean

Unblocks PR #422 (green CI on develop).

https://claude.ai/code/session_015DYLgGWsVKLNR47PV3xQBs