### PR TITLE
feat: per-sport athlete attributes + recruiting services (Phase 3)

### DIFF
--- a/components/Settings/PlayerDetailsAthleticsTab.vue
+++ b/components/Settings/PlayerDetailsAthleticsTab.vue
@@ -67,70 +67,34 @@
         {{ sportLabel }}
       </h2>
 
-      <!-- Bats/Throws (Sport Specific) -->
-      <div
-        v-if="isBaseballOrSoftball"
-        class="grid grid-cols-1 md:grid-cols-2 gap-8"
-      >
-        <div class="grid grid-cols-2 gap-4">
-          <div>
-            <label
-              class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
-              >Bats</label
-            >
-            <div class="flex p-1 bg-slate-100 rounded-xl">
-              <button
-                v-for="opt in batsOptions"
-                :key="opt.value"
-                type="button"
-                @click="
-                  form.bats = opt.value;
-                  triggerSave();
-                "
-                :class="[
-                  'flex-1 py-1.5 text-xs font-bold rounded-lg transition-all',
-                  form.bats === opt.value
-                    ? 'bg-white text-blue-600 shadow-sm'
-                    : 'text-slate-500 hover:text-slate-700',
-                ]"
-              >
-                {{ opt.label }}
-              </button>
-            </div>
-          </div>
-          <div>
-            <label
-              class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
-              >Throws</label
-            >
-            <div class="flex p-1 bg-slate-100 rounded-xl">
-              <button
-                v-for="opt in throwsOptions"
-                :key="opt.value"
-                type="button"
-                @click="
-                  form.throws = opt.value;
-                  triggerSave();
-                "
-                :class="[
-                  'flex-1 py-1.5 text-xs font-bold rounded-lg transition-all',
-                  form.throws === opt.value
-                    ? 'bg-white text-blue-600 shadow-sm'
-                    : 'text-slate-500 hover:text-slate-700',
-                ]"
-              >
-                {{ opt.label }}
-              </button>
-            </div>
-          </div>
+      <!-- Sport attributes (registry-driven: bats/throws for baseball, shooting
+           hand for basketball, etc. — gated by sport and, where set, position). -->
+      <div v-if="attributes.length" class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div v-for="a in attributes" :key="a.key">
+          <label
+            class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
+            >{{ a.label }}</label
+          >
+          <select
+            :value="attrValue(a.key)"
+            :disabled="isParentRole"
+            @change="
+              setAttrValue(a.key, ($event.target as HTMLSelectElement).value)
+            "
+            :aria-label="a.label"
+            class="w-full px-3 py-3 bg-slate-50 border border-slate-200 rounded-xl focus-visible:ring-2 focus-visible:ring-blue-500 font-medium text-slate-700"
+          >
+            <option value="">—</option>
+            <option v-for="opt in a.options" :key="opt" :value="opt">
+              {{ a.optionLabels[opt] }}
+            </option>
+          </select>
         </div>
       </div>
 
       <!-- Positions -->
       <div
-        :class="
-          isBaseballOrSoftball ? 'mt-8 pt-8 border-t border-slate-100' : ''
-        "
+        :class="attributes.length ? 'mt-8 pt-8 border-t border-slate-100' : ''"
       >
         <label
           class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-4 ml-1"
@@ -254,114 +218,70 @@
             />
           </a>
         </div>
-        <template v-if="isBaseballOrSoftball">
-          <div>
-            <label
-              class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
-              >Perfect Game ID</label
-            >
-            <input
-              v-model="form.perfect_game_id"
-              @blur="triggerSave"
-              placeholder="ID Number"
-              class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl font-medium"
-            />
-            <a
-              href="https://www.perfectgame.org/"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center gap-1 mt-1.5 ml-1 text-xs font-medium text-blue-600 hover:text-blue-700"
-            >
-              Get your Perfect Game profile
-              <UIcon
-                name="i-heroicons-arrow-top-right-on-square"
-                class="w-3 h-3"
-              />
-            </a>
-          </div>
-          <div class="md:col-span-3">
-            <label
-              class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
-              >Prep Baseball Report Profile</label
-            >
-            <div class="grid grid-cols-1 sm:grid-cols-[7rem_1fr] gap-3">
-              <select
-                v-model="form.prep_baseball_state"
-                :disabled="isParentRole"
-                @change="triggerSave"
-                class="w-full px-3 py-3 bg-slate-50 border border-slate-200 rounded-xl font-medium text-slate-700"
-                aria-label="Prep Baseball Report state"
-              >
-                <option value="">State</option>
-                <option
-                  v-for="opt in prepBaseballStateOptions"
-                  :key="opt.code"
-                  :value="opt.code"
-                >
-                  {{ opt.code }}
-                </option>
-              </select>
-              <input
-                v-model="form.prep_baseball_id"
-                :disabled="isParentRole"
-                @blur="triggerSave"
-                placeholder="e.g. owen-andrikanich"
-                class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl font-medium"
-              />
-            </div>
-
-            <p
-              v-if="
-                !isParentRole &&
-                suggestedPrepBaseballSlug &&
-                form.prep_baseball_id !== suggestedPrepBaseballSlug
+        <!-- Recruiting services (registry-driven, gated by primary sport). -->
+        <div v-for="svc in services" :key="svc.key">
+          <label
+            class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1"
+            >{{ svc.label }}</label
+          >
+          <!-- Prep Baseball Report: pick the filing state; the profile slug is
+               derived from the athlete's name, so the link builds itself. -->
+          <template v-if="svc.linkKind === 'prepBaseball'">
+            <select
+              :value="prepBaseballState"
+              :disabled="isParentRole"
+              @change="
+                setPrepBaseballState(($event.target as HTMLSelectElement).value)
               "
-              class="mt-1.5 ml-1 text-xs text-slate-500"
+              aria-label="Prep Baseball Report state"
+              class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl font-medium text-slate-700"
             >
-              Suggested name:
-              <button
-                type="button"
-                @click="applySuggestedPrepBaseballSlug"
-                class="font-mono font-medium text-blue-600 hover:text-blue-700 hover:underline"
+              <option value="">State</option>
+              <option
+                v-for="opt in US_STATE_OPTIONS"
+                :key="opt.code"
+                :value="opt.code"
               >
-                {{ suggestedPrepBaseballSlug }}
-              </button>
-            </p>
-
+                {{ opt.name }}
+              </option>
+            </select>
             <p v-if="prepBaseballPreviewUrl" class="mt-1.5 ml-1 text-xs">
               <span class="text-slate-500">Your profile link: </span>
               <a
                 :href="prepBaseballPreviewUrl"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="inline-flex items-center gap-1 font-medium text-blue-600 hover:text-blue-700 break-all"
+                class="text-blue-600 hover:text-blue-700 break-all"
+                >{{ prepBaseballPreviewUrl }}</a
               >
-                {{ prepBaseballPreviewUrl }}
-                <UIcon
-                  name="i-heroicons-arrow-top-right-on-square"
-                  class="w-3 h-3 shrink-0"
-                />
-              </a>
             </p>
-            <p v-else class="mt-1.5 ml-1 text-xs text-slate-400">
-              Pick your state and enter the name from your profile URL. Example:
-              <span class="font-mono">{{ prepBaseballExampleUrl }}</span>
-            </p>
-
-            <a
-              href="https://www.prepbaseballreport.com/"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center gap-1 mt-1.5 ml-1 text-xs font-medium text-blue-600 hover:text-blue-700"
-            >
-              Get your Prep Baseball Report profile
-              <UIcon
-                name="i-heroicons-arrow-top-right-on-square"
-                class="w-3 h-3"
-              />
-            </a>
-          </div>
-        </template>
+          </template>
+          <input
+            v-else
+            :value="serviceValue(svc.key)"
+            :disabled="isParentRole"
+            :type="svc.valueKind === 'url' ? 'url' : 'text'"
+            :placeholder="svc.placeholder"
+            @input="
+              setServiceValue(svc.key, ($event.target as HTMLInputElement).value)
+            "
+            @blur="triggerSave"
+            :aria-label="svc.label"
+            class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl font-medium"
+          />
+          <a
+            :href="svc.signupUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="inline-flex items-center gap-1 mt-1.5 ml-1 text-xs font-medium text-blue-600 hover:text-blue-700"
+          >
+            Get your profile
+            <UIcon
+              name="i-heroicons-arrow-top-right-on-square"
+              class="w-3 h-3"
+            />
+          </a>
+        </div>
       </div>
     </div>
 
@@ -499,17 +419,17 @@ import type { PlayerDetails } from "~/types/models";
 import { useVideoLinks } from "~/composables/useVideoLinks";
 import { useAppToast } from "~/composables/useAppToast";
 import { abbreviatePosition } from "~/utils/positions/canonical";
+import { attributesForSport } from "~/utils/attributes/canonical";
+import { servicesForSport } from "~/utils/services/canonical";
 import {
-  buildPrepBaseballUrl,
-  slugifyPlayerName,
-  normalizeStateCode,
   US_STATE_OPTIONS,
+  normalizeStateCode,
+  buildPrepBaseballUrl,
 } from "~/utils/recruitingLinks";
 
 const props = defineProps<{
   form: PlayerDetails;
   isParentRole: boolean;
-  isBaseballOrSoftball: boolean;
   availablePositions: string[];
   playerName: string;
   homeState: string;
@@ -517,41 +437,59 @@ const props = defineProps<{
   togglePosition: (pos: string) => void;
   isPositionSelected: (pos: string) => boolean;
   movePosition: (index: number, direction: "up" | "down") => void;
-  batsOptions: readonly { value: "R" | "L" | "S"; label: string }[];
-  throwsOptions: readonly { value: "R" | "L"; label: string }[];
 }>();
 
 const heightFeet = defineModel<number | undefined>("heightFeet");
 const heightInches = defineModel<number | undefined>("heightInches");
 
-// --- Prep Baseball Report profile link (state + name-slug -> URL) ---
-const prepBaseballStateOptions = US_STATE_OPTIONS;
-const suggestedPrepBaseballSlug = computed(() =>
-  slugifyPlayerName(props.playerName),
+// The athlete's primary position (positions[0], with the legacy scalar as a
+// fallback) — used to apply an attribute's optional position gate.
+const primaryPosition = computed(
+  () => props.form.positions?.[0] ?? props.form.primary_position ?? "",
 );
-const prepBaseballPreviewUrl = computed(() =>
-  buildPrepBaseballUrl(
-    props.form.prep_baseball_state,
-    props.form.prep_baseball_id,
+
+// Attributes offered for the sport, minus any whose position gate excludes the
+// athlete's primary position. Empty for sports without laterality attributes.
+const attributes = computed(() =>
+  attributesForSport(props.form.primary_sport).filter(
+    (a) => !a.positions || a.positions.includes(primaryPosition.value),
   ),
 );
-const prepBaseballExampleUrl =
-  "https://www.prepbaseballreport.com/profiles/OH/owen-andrikanich";
 
-// Pre-select the athlete's home state (high-confidence guess) when no PBR
-// state is set yet; the athlete can change it if their profile is filed
-// elsewhere. Persisted on next save once they fill the name-slug.
-onMounted(() => {
-  if (!props.isParentRole && !props.form.prep_baseball_state) {
-    const code = normalizeStateCode(props.homeState);
-    if (code) props.form.prep_baseball_state = code;
-  }
-});
+// Recruiting services offered for the sport (NCSA everywhere, Hudl for team
+// sports, Perfect Game / Prep Baseball for baseball & softball).
+const services = computed(() => servicesForSport(props.form.primary_sport));
 
-function applySuggestedPrepBaseballSlug() {
-  props.form.prep_baseball_id = suggestedPrepBaseballSlug.value;
+// Dynamic-key access into the flat player-details record. Mutating props.form
+// is the established pattern here (the parent owns the reactive object and
+// autosaves it); attribute changes save immediately, service text saves on blur.
+const formRecord = computed(
+  () => props.form as unknown as Record<string, unknown>,
+);
+const attrValue = (key: string) =>
+  (formRecord.value[key] as string | undefined) ?? "";
+const setAttrValue = (key: string, value: string) => {
+  formRecord.value[key] = value || undefined;
   props.triggerSave();
-}
+};
+const serviceValue = (key: string) =>
+  (formRecord.value[key] as string | undefined) ?? "";
+const setServiceValue = (key: string, value: string) => {
+  formRecord.value[key] = value;
+};
+
+// Prep Baseball Report: the athlete picks the state their profile is filed
+// under; the slug comes from their name, so the link resolves automatically.
+const prepBaseballState = computed(
+  () => (formRecord.value.prep_baseball_state as string | undefined) ?? "",
+);
+const setPrepBaseballState = (value: string) => {
+  formRecord.value.prep_baseball_state = value || undefined;
+  props.triggerSave();
+};
+const prepBaseballPreviewUrl = computed(() =>
+  buildPrepBaseballUrl(prepBaseballState.value, props.playerName),
+);
 
 const sportLabel = computed(() =>
   props.form.primary_sport
@@ -575,6 +513,20 @@ const { showToast } = useAppToast();
 
 onMounted(() => {
   videoLinks.load();
+
+  // Pre-seed the PBR state with the athlete's home state (a high-confidence
+  // guess) when it's offered for this sport and not already set.
+  const offersPrepBaseball = services.value.some(
+    (s) => s.linkKind === "prepBaseball",
+  );
+  if (
+    offersPrepBaseball &&
+    !props.isParentRole &&
+    !prepBaseballState.value
+  ) {
+    const code = normalizeStateCode(props.homeState);
+    if (code) formRecord.value.prep_baseball_state = code;
+  }
 });
 
 const newLinkPlatform = ref<"hudl" | "youtube" | "vimeo" | "other">("hudl");

--- a/components/profile/ProfilePreview.vue
+++ b/components/profile/ProfilePreview.vue
@@ -66,6 +66,9 @@ const previewData = computed<PublicProfileData>(() => ({
             (props.details.perfect_game_id as string | undefined) || undefined,
           prep_baseball_id:
             (props.details.prep_baseball_id as string | undefined) || undefined,
+          prep_baseball_state:
+            (props.details.prep_baseball_state as string | undefined) ||
+            undefined,
         }
       : null,
   film: props.settings.show_film ? filmLinks.value : null,

--- a/components/profile/PublicProfileCard.vue
+++ b/components/profile/PublicProfileCard.vue
@@ -3,7 +3,10 @@
 import { computed } from "vue";
 import type { PublicProfileData } from "~/types/models";
 import { formatPositionsShort } from "~/utils/positions/canonical";
-import { buildPrepBaseballUrl } from "~/utils/recruitingLinks";
+import {
+  servicesForSport,
+  serviceProfileUrl,
+} from "~/utils/services/canonical";
 import {
   openTwitter,
   openInstagram,
@@ -47,12 +50,34 @@ const primaryPositionLabel = computed(() =>
   ),
 );
 
-const prepBaseballUrl = computed(() =>
-  buildPrepBaseballUrl(
-    props.profile.athletic?.prep_baseball_state,
-    props.profile.athletic?.prep_baseball_id,
-  ),
-);
+// Recruiting-service rows for the athlete's sport (NCAA ID is handled
+// separately — it is an eligibility-center id, not a registry service).
+const recruitingServices = computed(() => {
+  const a = props.profile.athletic;
+  if (!a) return [];
+  const record = a as Record<string, unknown>;
+  const state =
+    typeof record.prep_baseball_state === "string"
+      ? record.prep_baseball_state
+      : undefined;
+  const name = props.profile.playerName;
+  return servicesForSport(a.primary_sport)
+    .map((def) => {
+      const raw = record[def.key];
+      const value = typeof raw === "string" ? raw : "";
+      const url = serviceProfileUrl(def, { value, state, name });
+      // PBR link is built from state + name, so its row appears whenever that
+      // URL resolves (the stored id is irrelevant); the athlete's name is the
+      // link text. Every other service still keys on its stored value.
+      if (def.linkKind === "prepBaseball") {
+        if (!url) return null;
+        return { key: def.key, label: def.label, value: name, url };
+      }
+      if (!value) return null;
+      return { key: def.key, label: def.label, value, url };
+    })
+    .filter((s): s is NonNullable<typeof s> => s !== null);
+});
 
 const HEADER_GRADIENTS: Record<string, string> = {
   slate: "bg-gradient-to-br from-slate-800 to-slate-700",
@@ -296,9 +321,7 @@ function formatGPA(gpa: number | undefined): string {
       <section
         v-if="
           profile.athletic &&
-          (profile.athletic.ncaa_id ||
-            profile.athletic.perfect_game_id ||
-            prepBaseballUrl)
+          (profile.athletic.ncaa_id || recruitingServices.length)
         "
         class="px-6 py-5"
       >
@@ -315,30 +338,23 @@ function formatGPA(gpa: number | undefined): string {
             </dd>
           </div>
           <div
-            v-if="profile.athletic.perfect_game_id"
+            v-for="svc in recruitingServices"
+            :key="svc.key"
             class="flex justify-between"
           >
-            <dt class="text-gray-500">Perfect Game</dt>
+            <dt class="text-gray-500">{{ svc.label }}</dt>
             <dd class="font-medium">
               <a
-                :href="`https://www.perfectgame.org/Players/Playerprofile.aspx?ID=${profile.athletic.perfect_game_id}`"
+                v-if="svc.url"
+                :href="svc.url"
                 target="_blank"
                 rel="noopener noreferrer"
                 class="text-blue-600 hover:text-blue-800 hover:underline font-mono"
-                >{{ profile.athletic.perfect_game_id }}</a
+                >{{ svc.value }}</a
               >
-            </dd>
-          </div>
-          <div v-if="prepBaseballUrl" class="flex justify-between">
-            <dt class="text-gray-500">Prep Baseball</dt>
-            <dd class="font-medium">
-              <a
-                :href="prepBaseballUrl"
-                target="_blank"
-                rel="noopener noreferrer"
-                class="text-blue-600 hover:text-blue-800 hover:underline font-mono"
-                >View profile</a
-              >
+              <span v-else class="font-mono text-gray-900">{{
+                svc.value
+              }}</span>
             </dd>
           </div>
         </dl>

--- a/composables/useProfile.ts
+++ b/composables/useProfile.ts
@@ -3,6 +3,8 @@ import { useSupabase } from "./useSupabase";
 import { useUserStore } from "~/stores/user";
 import { createClientLogger } from "~/utils/logger";
 import { compressImage, validateImageFile } from "~/utils/image/compressImage";
+import { ALL_ATTRIBUTE_DEFS } from "~/utils/attributes/canonical";
+import { ALL_SERVICE_DEFS } from "~/utils/services/canonical";
 import type { PreferenceHistoryEntry } from "~/types/models";
 
 export interface UploadResult {
@@ -20,24 +22,28 @@ export interface FormattedHistoryEntry extends PreferenceHistoryEntry {
   }>;
 }
 
+// Attribute (bats/throws/…) and service (perfect_game_id/…) labels come from
+// the canonical registries so edit-history labels stay in sync with the form.
+const REGISTRY_FIELD_LABELS: Record<string, string> = {
+  ...Object.fromEntries(ALL_ATTRIBUTE_DEFS.map((d) => [d.key, d.label])),
+  ...Object.fromEntries(ALL_SERVICE_DEFS.map((s) => [s.key, s.label])),
+};
+
 /**
- * Field labels for profile edit history
+ * Field labels for profile edit history. Registry-sourced attribute/service
+ * labels are merged in last so they win over any local copy.
  */
 const FIELD_LABELS: Record<string, string> = {
   graduation_year: "Graduation Year",
   high_school: "High School",
   club_team: "Club/Travel Team",
   positions: "Positions",
-  bats: "Bats",
-  throws: "Throws",
   height_inches: "Height",
   weight_lbs: "Weight",
   gpa: "GPA",
   sat_score: "SAT Score",
   act_score: "ACT Score",
   ncaa_id: "NCAA ID",
-  perfect_game_id: "Perfect Game ID",
-  prep_baseball_id: "Prep Baseball ID",
   twitter_handle: "Twitter Handle",
   instagram_handle: "Instagram Handle",
   tiktok_handle: "TikTok Handle",
@@ -61,6 +67,7 @@ const FIELD_LABELS: Record<string, string> = {
   travel_team_year: "Travel Team Year",
   travel_team_name: "Travel Team Name",
   travel_team_coach: "Travel Team Coach",
+  ...REGISTRY_FIELD_LABELS,
 };
 
 const logger = createClientLogger("useProfile");

--- a/composables/useProfileEditHistory.ts
+++ b/composables/useProfileEditHistory.ts
@@ -4,25 +4,31 @@ import { useUserStore } from "~/stores/user";
 import type { PreferenceHistoryEntry } from "~/types/models";
 import type { FormattedHistoryEntry } from "./useProfile";
 import { createClientLogger } from "~/utils/logger";
+import { ALL_ATTRIBUTE_DEFS } from "~/utils/attributes/canonical";
+import { ALL_SERVICE_DEFS } from "~/utils/services/canonical";
+
+// Attribute (bats/throws/…) and service (perfect_game_id/…) labels come from
+// the canonical registries so edit-history labels stay in sync with the form.
+const REGISTRY_FIELD_LABELS: Record<string, string> = {
+  ...Object.fromEntries(ALL_ATTRIBUTE_DEFS.map((d) => [d.key, d.label])),
+  ...Object.fromEntries(ALL_SERVICE_DEFS.map((s) => [s.key, s.label])),
+};
 
 /**
- * Map database field names to human-readable labels
+ * Map database field names to human-readable labels. Registry-sourced
+ * attribute/service labels are merged in last so they win over any local copy.
  */
 const FIELD_LABELS: Record<string, string> = {
   graduation_year: "Graduation Year",
   high_school: "High School",
   club_team: "Club/Travel Team",
   positions: "Positions",
-  bats: "Bats",
-  throws: "Throws",
   height_inches: "Height",
   weight_lbs: "Weight",
   gpa: "GPA",
   sat_score: "SAT Score",
   act_score: "ACT Score",
   ncaa_id: "NCAA ID",
-  perfect_game_id: "Perfect Game ID",
-  prep_baseball_id: "Prep Baseball ID",
   twitter_handle: "Twitter Handle",
   instagram_handle: "Instagram Handle",
   tiktok_handle: "TikTok Handle",
@@ -46,6 +52,7 @@ const FIELD_LABELS: Record<string, string> = {
   travel_team_year: "Travel Team Year",
   travel_team_name: "Travel Team Name",
   travel_team_coach: "Travel Team Coach",
+  ...REGISTRY_FIELD_LABELS,
 };
 
 const logger = createClientLogger("useProfileEditHistory");

--- a/pages/settings/player-details.vue
+++ b/pages/settings/player-details.vue
@@ -141,7 +141,6 @@
           <PlayerDetailsAthleticsTab
             :form="form"
             :is-parent-role="isReadOnly"
-            :is-baseball-or-softball="isBaseballOrSoftball"
             :available-positions="availablePositions"
             :player-name="userStore.user?.full_name ?? ''"
             :home-state="homeState"
@@ -149,8 +148,6 @@
             :toggle-position="togglePosition"
             :is-position-selected="isPositionSelected"
             :move-position="movePosition"
-            :bats-options="BATS_OPTIONS"
-            :throws-options="THROWS_OPTIONS"
             v-model:height-feet="heightFeet"
             v-model:height-inches="heightInches"
           />
@@ -398,7 +395,6 @@ const {
   heightFeet,
   heightInches,
   availablePositions,
-  isBaseballOrSoftball,
   profileCompleteness,
   isSaving,
   saving,
@@ -416,8 +412,6 @@ const {
   handleSocialBlur,
   socialInputs,
   gradeLevels,
-  BATS_OPTIONS,
-  THROWS_OPTIONS,
   CAMPUS_SIZE_OPTIONS,
   COST_SENSITIVITY_OPTIONS,
   homeState,

--- a/server/agent-content/profile.ts
+++ b/server/agent-content/profile.ts
@@ -1,5 +1,8 @@
 import type { PublicProfileData } from "~/types/models";
-import { buildPrepBaseballUrl } from "~/utils/recruitingLinks";
+import {
+  servicesForSport,
+  serviceProfileUrl,
+} from "~/utils/services/canonical";
 
 function formatHeight(inches: number): string {
   const ft = Math.floor(inches / 12);
@@ -37,14 +40,30 @@ export function renderProfileMarkdown(
     if (a.weight_lbs !== undefined)
       items.push(`- **Weight:** ${a.weight_lbs} lbs`);
     if (a.ncaa_id) items.push(`- **NCAA ID:** ${a.ncaa_id}`);
-    if (a.perfect_game_id)
-      items.push(`- **Perfect Game ID:** ${a.perfect_game_id}`);
-    const prepBaseballUrl = buildPrepBaseballUrl(
-      a.prep_baseball_state,
-      a.prep_baseball_id,
-    );
-    if (prepBaseballUrl)
-      items.push(`- **Prep Baseball Report:** ${prepBaseballUrl}`);
+    // Recruiting services for the athlete's sport (link when the registry
+    // supplies one, otherwise the raw id/value).
+    const serviceRecord = a as unknown as Record<string, unknown>;
+    const pbrState =
+      typeof serviceRecord.prep_baseball_state === "string"
+        ? serviceRecord.prep_baseball_state
+        : undefined;
+    for (const def of servicesForSport(a.primary_sport)) {
+      const raw = serviceRecord[def.key];
+      const value = typeof raw === "string" ? raw : "";
+      const url = serviceProfileUrl(def, {
+        value,
+        state: pbrState,
+        name: profile.playerName,
+      });
+      // PBR link comes from state + name, not the stored id — emit it whenever
+      // the URL resolves. Other services still key on their stored value.
+      if (def.linkKind === "prepBaseball") {
+        if (url) items.push(`- **${def.label}:** ${url}`);
+        continue;
+      }
+      if (!value) continue;
+      items.push(`- **${def.label}:** ${url ?? value}`);
+    }
     if (items.length) {
       lines.push("## Athletic");
       lines.push("");

--- a/server/api/public/profile/[slug].get.ts
+++ b/server/api/public/profile/[slug].get.ts
@@ -160,6 +160,8 @@ export default defineEventHandler(async (event) => {
               height_inches: details.height_inches as number | undefined,
               weight_lbs: details.weight_lbs as number | undefined,
               ncaa_id: (details.ncaa_id as string | undefined) || undefined,
+              ncsa_id: (details.ncsa_id as string | undefined) || undefined,
+              hudl_url: (details.hudl_url as string | undefined) || undefined,
               perfect_game_id:
                 (details.perfect_game_id as string | undefined) || undefined,
               prep_baseball_id:

--- a/types/models.ts
+++ b/types/models.ts
@@ -366,14 +366,33 @@ export interface PlayerDetails {
   nces_school_id?: string; // NCES school identifier; null if free-text entry was used
   club_team?: string;
   positions?: string[];
+  // Per-sport athlete attributes (registry: utils/attributes/canonical.ts).
+  // Flat keys in user_preferences.data; each shown only for its sport(s).
   bats?: "L" | "R" | "S";
   throws?: "L" | "R";
+  shooting_hand?: "L" | "R"; // Basketball
+  dominant_foot?: "L" | "R" | "Both"; // Soccer
+  hitting_hand?: "L" | "R"; // Volleyball
+  racket_hand?: "L" | "R"; // Tennis
+  backhand_style?: "one" | "two"; // Tennis
+  golf_handedness?: "L" | "R"; // Golf
+  dominant_hand?: "L" | "R"; // Lacrosse
+  shoots?: "L" | "R"; // Ice Hockey
+  catches?: "L" | "R"; // Ice Hockey (Goalie)
+  wp_dominant_hand?: "L" | "R"; // Water Polo
+  rowing_side?: "port" | "starboard" | "both" | "cox"; // Rowing
+  rowing_discipline?: "sweep" | "scull" | "both"; // Rowing
+  throwing_hand?: "L" | "R"; // Football (Quarterback)
+  kicking_foot?: "L" | "R"; // Football (Kicker/Punter)
   height_inches?: number;
   weight_lbs?: number;
   gpa?: number;
   sat_score?: number;
   act_score?: number;
   ncaa_id?: string;
+  // Recruiting services (registry: utils/services/canonical.ts).
+  ncsa_id?: string; // NCSA (all sports)
+  hudl_url?: string; // Hudl profile URL (team sports)
   perfect_game_id?: string;
   prep_baseball_id?: string; // Prep Baseball Report profile name-slug (e.g. "owen-andrikanich")
   prep_baseball_state?: string; // 2-letter state code the PBR profile is filed under
@@ -465,6 +484,8 @@ export interface PublicProfileData {
     height_inches?: number;
     weight_lbs?: number;
     ncaa_id?: string;
+    ncsa_id?: string;
+    hudl_url?: string;
     perfect_game_id?: string;
     prep_baseball_id?: string;
     prep_baseball_state?: string;

--- a/utils/attributes/canonical.test.ts
+++ b/utils/attributes/canonical.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { attributesForSport, ATTRIBUTES_BY_SPORT } from "./canonical";
+
+const keys = (sport: string | null | undefined) =>
+  attributesForSport(sport).map((a) => a.key);
+
+describe("attributesForSport", () => {
+  it("returns bats + throws for baseball and softball", () => {
+    expect(keys("Baseball")).toEqual(["bats", "throws"]);
+    expect(keys("Softball")).toEqual(["bats", "throws"]);
+    const bats = attributesForSport("Baseball")[0];
+    expect(bats.options).toEqual(["L", "R", "S"]);
+    expect(bats.optionLabels).toEqual({ L: "Left", R: "Right", S: "Switch" });
+    expect(bats.positions).toBeUndefined();
+  });
+
+  it("returns shooting_hand for basketball", () => {
+    expect(keys("Basketball")).toEqual(["shooting_hand"]);
+  });
+
+  it("returns shoots (ungated) always and catches gated to Goalie for ice hockey", () => {
+    const defs = attributesForSport("Ice Hockey");
+    expect(defs.map((a) => a.key)).toEqual(["shoots", "catches"]);
+    const shoots = defs.find((a) => a.key === "shoots")!;
+    const catches = defs.find((a) => a.key === "catches")!;
+    expect(shoots.positions).toBeUndefined();
+    expect(catches.positions).toEqual(["Goalie"]);
+  });
+
+  it("gates football throwing_hand to Quarterback and kicking_foot to Kicker/Punter", () => {
+    const defs = attributesForSport("Football");
+    const throwing = defs.find((a) => a.key === "throwing_hand")!;
+    const kicking = defs.find((a) => a.key === "kicking_foot")!;
+    expect(throwing.positions).toEqual(["Quarterback"]);
+    expect(kicking.positions).toEqual(["Kicker", "Punter"]);
+  });
+
+  it("uses closed token sets for the multi-option attributes", () => {
+    const rowing = attributesForSport("Rowing");
+    const side = rowing.find((a) => a.key === "rowing_side")!;
+    expect(side.options).toEqual(["port", "starboard", "both", "cox"]);
+    const tennis = attributesForSport("Tennis");
+    const backhand = tennis.find((a) => a.key === "backhand_style")!;
+    expect(backhand.options).toEqual(["one", "two"]);
+  });
+
+  it("returns [] for sports without attributes", () => {
+    expect(attributesForSport("Wrestling")).toEqual([]);
+    expect(attributesForSport("Track & Field")).toEqual([]);
+  });
+
+  it("returns [] for nil / unknown sport", () => {
+    expect(attributesForSport(null)).toEqual([]);
+    expect(attributesForSport(undefined)).toEqual([]);
+    expect(attributesForSport("")).toEqual([]);
+    expect(attributesForSport("Quidditch")).toEqual([]);
+  });
+
+  it("options and optionLabels agree for every def", () => {
+    for (const defs of Object.values(ATTRIBUTES_BY_SPORT)) {
+      for (const d of defs) {
+        expect(d.options).toEqual(Object.keys(d.optionLabels));
+      }
+    }
+  });
+});

--- a/utils/attributes/canonical.ts
+++ b/utils/attributes/canonical.ts
@@ -1,0 +1,129 @@
+/**
+ * Canonical athlete-attribute registry — the single source of truth on web.
+ *
+ * Per-sport handedness / laterality attributes (bats, throws, shooting hand,
+ * dominant foot, …) stored as flat keys in `user_preferences.data` (category
+ * `player`). Mirrors iOS `AthleteAttributes` byte-identically: same keys, option
+ * tokens, position-gate label strings, and which sports expose which attribute.
+ *
+ * Sibling of the positions/metrics registries: a `Record<string, ...>` map keyed
+ * by the same sport labels as `SPORT_POSITIONS`, plus a pure `attributesForSport`
+ * helper returning `[]` for a nil/unknown sport (no baseball fallback).
+ */
+
+export interface AttributeDef {
+  /** Flat key stored in `user_preferences.data`. */
+  key: string;
+  label: string;
+  /** Persisted option tokens (order = display order). */
+  options: readonly string[];
+  /** Token → display label. */
+  optionLabels: Record<string, string>;
+  /**
+   * When set, the attribute renders only if the athlete's primary position is
+   * in this list. Values are canonical position LABELS from `SPORT_POSITIONS`.
+   */
+  positions?: readonly string[];
+}
+
+const attr = (
+  key: string,
+  label: string,
+  optionLabels: Record<string, string>,
+  positions?: readonly string[],
+): AttributeDef => ({
+  key,
+  label,
+  options: Object.keys(optionLabels),
+  optionLabels,
+  ...(positions ? { positions } : {}),
+});
+
+// --- Reusable attribute defs (Baseball/Softball share bats + throws) ---
+const bats = attr("bats", "Bats", { L: "Left", R: "Right", S: "Switch" });
+const throws = attr("throws", "Throws", { L: "Left", R: "Right" });
+
+/** Attribute definitions per sport. Sport keys match `SPORT_POSITIONS`. */
+export const ATTRIBUTES_BY_SPORT: Record<string, readonly AttributeDef[]> = {
+  Baseball: [bats, throws],
+  Softball: [bats, throws],
+  Basketball: [
+    attr("shooting_hand", "Shooting Hand", { L: "Left", R: "Right" }),
+  ],
+  Soccer: [
+    attr("dominant_foot", "Dominant Foot", {
+      L: "Left",
+      R: "Right",
+      Both: "Both",
+    }),
+  ],
+  Volleyball: [attr("hitting_hand", "Hitting Arm", { L: "Left", R: "Right" })],
+  Tennis: [
+    attr("racket_hand", "Plays", { L: "Left-handed", R: "Right-handed" }),
+    attr("backhand_style", "Backhand", {
+      one: "One-handed",
+      two: "Two-handed",
+    }),
+  ],
+  Golf: [
+    attr("golf_handedness", "Plays", { L: "Left-handed", R: "Right-handed" }),
+  ],
+  Lacrosse: [attr("dominant_hand", "Dominant Hand", { L: "Left", R: "Right" })],
+  "Ice Hockey": [
+    attr("shoots", "Shoots", { L: "Left", R: "Right" }),
+    attr("catches", "Catches (Goalie)", { L: "Left", R: "Right" }, ["Goalie"]),
+  ],
+  "Water Polo": [
+    attr("wp_dominant_hand", "Dominant Hand", { L: "Left", R: "Right" }),
+  ],
+  Rowing: [
+    attr("rowing_side", "Rigging Side", {
+      port: "Port",
+      starboard: "Starboard",
+      both: "Both",
+      cox: "Coxswain",
+    }),
+    attr("rowing_discipline", "Discipline", {
+      sweep: "Sweep",
+      scull: "Sculling",
+      both: "Both",
+    }),
+  ],
+  Football: [
+    attr("throwing_hand", "Throwing Hand", { L: "Left", R: "Right" }, [
+      "Quarterback",
+    ]),
+    attr("kicking_foot", "Kicking Foot", { L: "Left", R: "Right" }, [
+      "Kicker",
+      "Punter",
+    ]),
+  ],
+  // No attributes: Track & Field, Cross Country, Swimming, Wrestling,
+  // Field Hockey — intentionally absent (returns [] via attributesForSport).
+};
+
+/** Every attribute def, de-duplicated by key (bats/throws appear twice). */
+export const ALL_ATTRIBUTE_DEFS: readonly AttributeDef[] = (() => {
+  const seen = new Set<string>();
+  const out: AttributeDef[] = [];
+  for (const defs of Object.values(ATTRIBUTES_BY_SPORT)) {
+    for (const d of defs) {
+      if (seen.has(d.key)) continue;
+      seen.add(d.key);
+      out.push(d);
+    }
+  }
+  return out;
+})();
+
+/**
+ * Attribute definitions offered for a sport. A nil or unrecognized sport
+ * returns an EMPTY array (no baseball fallback) — mirrors `attributesForSport`
+ * on iOS and the positions/metrics helpers.
+ */
+export function attributesForSport(
+  sport?: string | null,
+): readonly AttributeDef[] {
+  if (!sport) return [];
+  return ATTRIBUTES_BY_SPORT[sport] ?? [];
+}

--- a/utils/services/canonical.test.ts
+++ b/utils/services/canonical.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect } from "vitest";
+import {
+  servicesForSport,
+  serviceProfileUrl,
+  ALL_SERVICE_DEFS,
+} from "./canonical";
+
+const keys = (sport: string | null | undefined) =>
+  servicesForSport(sport).map((s) => s.key);
+
+const ALL_SPORTS = [
+  "Baseball",
+  "Softball",
+  "Basketball",
+  "Football",
+  "Soccer",
+  "Volleyball",
+  "Track & Field",
+  "Swimming",
+  "Cross Country",
+  "Tennis",
+  "Golf",
+  "Lacrosse",
+  "Field Hockey",
+  "Ice Hockey",
+  "Wrestling",
+  "Rowing",
+  "Water Polo",
+];
+
+const HUDL_SPORTS = [
+  "Football",
+  "Basketball",
+  "Volleyball",
+  "Soccer",
+  "Lacrosse",
+  "Ice Hockey",
+  "Field Hockey",
+  "Water Polo",
+  "Wrestling",
+];
+
+describe("servicesForSport", () => {
+  it("offers NCSA for every sport", () => {
+    for (const sport of ALL_SPORTS) {
+      expect(keys(sport)).toContain("ncsa_id");
+    }
+  });
+
+  it("offers Hudl only for its sport list", () => {
+    for (const sport of ALL_SPORTS) {
+      const hasHudl = keys(sport).includes("hudl_url");
+      expect(hasHudl).toBe(HUDL_SPORTS.includes(sport));
+    }
+  });
+
+  it("offers Perfect Game and Prep Baseball only for baseball and softball", () => {
+    for (const sport of ALL_SPORTS) {
+      const k = keys(sport);
+      const expected = sport === "Baseball" || sport === "Softball";
+      expect(k.includes("perfect_game_id")).toBe(expected);
+      expect(k.includes("prep_baseball_id")).toBe(expected);
+    }
+  });
+
+  it("orders services ncsa → hudl → perfect_game → prep_baseball", () => {
+    expect(keys("Baseball")).toEqual([
+      "ncsa_id",
+      "perfect_game_id",
+      "prep_baseball_id",
+    ]);
+    expect(keys("Football")).toEqual(["ncsa_id", "hudl_url"]);
+    expect(keys("Golf")).toEqual(["ncsa_id"]);
+  });
+
+  it("returns [] for nil / unknown sport", () => {
+    expect(servicesForSport(null)).toEqual([]);
+    expect(servicesForSport(undefined)).toEqual([]);
+    expect(servicesForSport("")).toEqual([]);
+    expect(servicesForSport("Quidditch")).toEqual([]);
+  });
+
+  it("uses the exact Perfect Game urlTemplate", () => {
+    const pg = ALL_SERVICE_DEFS.find((s) => s.key === "perfect_game_id")!;
+    expect(pg.urlTemplate).toBe(
+      "https://www.perfectgame.org/Players/Playerprofile.aspx?ID={value}",
+    );
+    expect(pg.signupUrl).toBe("https://www.perfectgame.org/");
+  });
+});
+
+describe("serviceProfileUrl", () => {
+  const pg = ALL_SERVICE_DEFS.find((s) => s.key === "perfect_game_id")!;
+  const hudl = ALL_SERVICE_DEFS.find((s) => s.key === "hudl_url")!;
+  const prep = ALL_SERVICE_DEFS.find((s) => s.key === "prep_baseball_id")!;
+
+  it("builds an id link from the urlTemplate", () => {
+    expect(serviceProfileUrl(pg, "12345")).toBe(
+      "https://www.perfectgame.org/Players/Playerprofile.aspx?ID=12345",
+    );
+  });
+
+  it("returns the stored value itself for url-kind services", () => {
+    expect(serviceProfileUrl(hudl, "https://hudl.com/profile/abc")).toBe(
+      "https://hudl.com/profile/abc",
+    );
+  });
+
+  it("returns null for an empty / blank value", () => {
+    expect(serviceProfileUrl(pg, "")).toBeNull();
+    expect(serviceProfileUrl(pg, "   ")).toBeNull();
+    expect(serviceProfileUrl(hudl, undefined)).toBeNull();
+    expect(serviceProfileUrl(hudl, null)).toBeNull();
+  });
+
+  it("trims the value before substituting", () => {
+    expect(serviceProfileUrl(pg, "  99 ")).toBe(
+      "https://www.perfectgame.org/Players/Playerprofile.aspx?ID=99",
+    );
+  });
+
+  it("tags each def with the right linkKind", () => {
+    expect(pg.linkKind).toBe("template");
+    expect(hudl.linkKind).toBe("url");
+    expect(prep.linkKind).toBe("prepBaseball");
+    expect(prep.urlTemplate).toBeUndefined();
+  });
+
+  describe("prepBaseball kind", () => {
+    it("builds the slug-based URL from state + name (ignores the id value)", () => {
+      expect(
+        serviceProfileUrl(prep, {
+          value: "ignored-id",
+          state: "OH",
+          name: "Owen Andrikanich",
+        }),
+      ).toBe("https://www.prepbaseballreport.com/profiles/OH/owen-andrikanich");
+    });
+
+    it("normalizes a full state name before building", () => {
+      expect(
+        serviceProfileUrl(prep, { state: "Ohio", name: "Owen Andrikanich" }),
+      ).toBe("https://www.prepbaseballreport.com/profiles/OH/owen-andrikanich");
+    });
+
+    it("returns null when the state is missing or invalid", () => {
+      expect(serviceProfileUrl(prep, { name: "Owen Andrikanich" })).toBeNull();
+      expect(
+        serviceProfileUrl(prep, { state: "Narnia", name: "Owen Andrikanich" }),
+      ).toBeNull();
+    });
+
+    it("returns null when the name is missing or blank", () => {
+      expect(serviceProfileUrl(prep, { state: "OH" })).toBeNull();
+      expect(serviceProfileUrl(prep, { state: "OH", name: "   " })).toBeNull();
+    });
+
+    it("returns null when only a bare value string is passed (no state/name)", () => {
+      expect(serviceProfileUrl(prep, "owen-andrikanich")).toBeNull();
+    });
+  });
+});

--- a/utils/services/canonical.ts
+++ b/utils/services/canonical.ts
@@ -1,0 +1,180 @@
+/**
+ * Canonical recruiting-service registry — the single source of truth on web.
+ *
+ * Third-party recruiting profiles (NCSA, Hudl, Perfect Game, Prep Baseball
+ * Report) whose IDs / URLs are stored as flat keys in `user_preferences.data`
+ * (category `player`). Mirrors iOS `RecruitingServices` byte-identically: same
+ * keys, `valueKind`, `urlTemplate`, signup URLs, and which sports expose which
+ * service. Existing keys `perfect_game_id` / `prep_baseball_id` are reused
+ * verbatim (no data migration).
+ *
+ * Sibling of the positions/metrics/attributes registries: pure definitions plus
+ * a `servicesForSport` helper returning `[]` for a nil/unknown sport.
+ */
+
+import { buildPrepBaseballUrl } from "~/utils/recruitingLinks";
+
+/**
+ * How a service's public-profile link is derived from its stored value:
+ * - `template` — `urlTemplate.replace('{value}', value)` (Perfect Game).
+ * - `url` — the stored value is itself the full profile URL (Hudl).
+ * - `prepBaseball` — built from the athlete's `prep_baseball_state` + name
+ *   (NOT the stored id), via `buildPrepBaseballUrl`.
+ * Defaults to `template` when omitted.
+ */
+export type ServiceLinkKind = "template" | "url" | "prepBaseball";
+
+export interface ServiceDef {
+  /** Flat key stored in `user_preferences.data`. */
+  key: string;
+  label: string;
+  /** `id` stores an identifier; `url` stores a full profile URL. */
+  valueKind: "id" | "url";
+  /** When set, the public profile link is `urlTemplate.replace('{value}', v)`. */
+  urlTemplate?: string;
+  /** How the profile link is built from context. Defaults to `template`. */
+  linkKind?: ServiceLinkKind;
+  /** "Get your profile" sign-up destination. */
+  signupUrl: string;
+  placeholder: string;
+}
+
+/** Context for `serviceProfileUrl`; a bare string is treated as `{ value }`. */
+export interface ServiceUrlContext {
+  value?: string | null;
+  /** PBR only: US state (name or 2-letter code) the profile is filed under. */
+  state?: string | null;
+  /** PBR only: the athlete's name, slugified into the profile URL. */
+  name?: string | null;
+}
+
+/** All 17 sports (keys match `SPORT_POSITIONS`). */
+const ALL_SPORTS: readonly string[] = [
+  "Baseball",
+  "Softball",
+  "Basketball",
+  "Football",
+  "Soccer",
+  "Volleyball",
+  "Track & Field",
+  "Swimming",
+  "Cross Country",
+  "Tennis",
+  "Golf",
+  "Lacrosse",
+  "Field Hockey",
+  "Ice Hockey",
+  "Wrestling",
+  "Rowing",
+  "Water Polo",
+];
+
+const HUDL_SPORTS: readonly string[] = [
+  "Football",
+  "Basketball",
+  "Volleyball",
+  "Soccer",
+  "Lacrosse",
+  "Ice Hockey",
+  "Field Hockey",
+  "Water Polo",
+  "Wrestling",
+];
+
+const BASEBALL_SOFTBALL: readonly string[] = ["Baseball", "Softball"];
+
+const NCSA: ServiceDef = {
+  key: "ncsa_id",
+  label: "NCSA",
+  valueKind: "id",
+  signupUrl: "https://www.ncsasports.org/",
+  placeholder: "ID Number",
+};
+
+const HUDL: ServiceDef = {
+  key: "hudl_url",
+  label: "Hudl",
+  valueKind: "url",
+  linkKind: "url",
+  signupUrl: "https://www.hudl.com/",
+  placeholder: "Profile URL",
+};
+
+const PERFECT_GAME: ServiceDef = {
+  key: "perfect_game_id",
+  label: "Perfect Game",
+  valueKind: "id",
+  linkKind: "template",
+  urlTemplate:
+    "https://www.perfectgame.org/Players/Playerprofile.aspx?ID={value}",
+  signupUrl: "https://www.perfectgame.org/",
+  placeholder: "ID Number",
+};
+
+// PBR profiles are slug-based (/profiles/{STATE}/{name-slug}), so the link is
+// built from the athlete's state + name — not the stored id. `urlTemplate` is
+// intentionally omitted.
+const PREP_BASEBALL: ServiceDef = {
+  key: "prep_baseball_id",
+  label: "Prep Baseball Report",
+  valueKind: "id",
+  linkKind: "prepBaseball",
+  signupUrl: "https://www.prepbaseballreport.com/",
+  placeholder: "ID Number",
+};
+
+/** Service → the sports that expose it, in display order. */
+const SERVICE_MEMBERSHIP: ReadonlyArray<{
+  def: ServiceDef;
+  sports: readonly string[];
+}> = [
+  { def: NCSA, sports: ALL_SPORTS },
+  { def: HUDL, sports: HUDL_SPORTS },
+  { def: PERFECT_GAME, sports: BASEBALL_SOFTBALL },
+  { def: PREP_BASEBALL, sports: BASEBALL_SOFTBALL },
+];
+
+/** Every service def, once each (for label lookups). */
+export const ALL_SERVICE_DEFS: readonly ServiceDef[] = SERVICE_MEMBERSHIP.map(
+  (m) => m.def,
+);
+
+/**
+ * Recruiting services offered for a sport, in display order. A nil or
+ * unrecognized sport returns an EMPTY array — mirrors iOS `servicesForSport`.
+ */
+export function servicesForSport(sport?: string | null): readonly ServiceDef[] {
+  if (!sport) return [];
+  return SERVICE_MEMBERSHIP.filter((m) => m.sports.includes(sport)).map(
+    (m) => m.def,
+  );
+}
+
+/**
+ * Public-profile link for a service, dispatched on `def.linkKind`:
+ * - `template` → `urlTemplate.replace('{value}', value)` (null without a value
+ *   or a template — e.g. NCSA, a signup-only id)
+ * - `url` → the stored value itself
+ * - `prepBaseball` → `buildPrepBaseballUrl(state, name)` (ignores `value`)
+ *
+ * `ctx` may be a bare value string (back-compat for the id/url kinds) or a full
+ * `{ value, state, name }` context (required for `prepBaseball`).
+ */
+export function serviceProfileUrl(
+  def: ServiceDef,
+  ctx: string | ServiceUrlContext | null | undefined,
+): string | null {
+  const context: ServiceUrlContext =
+    typeof ctx === "string" || ctx == null ? { value: ctx } : ctx;
+  const kind = def.linkKind ?? "template";
+
+  if (kind === "prepBaseball") {
+    return buildPrepBaseballUrl(context.state, context.name);
+  }
+
+  const v = (context.value ?? "").trim();
+  if (!v) return null;
+  if (kind === "url") return v;
+  if (def.urlTemplate) return def.urlTemplate.replace("{value}", v);
+  return null;
+}

--- a/utils/validation/schemas.ts
+++ b/utils/validation/schemas.ts
@@ -294,8 +294,23 @@ export const offerSchema = z
 export const playerDetailsSchema = z.object({
   graduation_year: graduationYearSchema,
   positions: z.array(z.string()).default([]),
+  // Per-sport athlete attributes (registry: utils/attributes/canonical.ts).
   bats: z.enum(["L", "R", "S"]).nullable().optional(),
   throws: z.enum(["L", "R"]).nullable().optional(),
+  shooting_hand: z.enum(["L", "R"]).nullable().optional(),
+  dominant_foot: z.enum(["L", "R", "Both"]).nullable().optional(),
+  hitting_hand: z.enum(["L", "R"]).nullable().optional(),
+  racket_hand: z.enum(["L", "R"]).nullable().optional(),
+  backhand_style: z.enum(["one", "two"]).nullable().optional(),
+  golf_handedness: z.enum(["L", "R"]).nullable().optional(),
+  dominant_hand: z.enum(["L", "R"]).nullable().optional(),
+  shoots: z.enum(["L", "R"]).nullable().optional(),
+  catches: z.enum(["L", "R"]).nullable().optional(),
+  wp_dominant_hand: z.enum(["L", "R"]).nullable().optional(),
+  rowing_side: z.enum(["port", "starboard", "both", "cox"]).nullable().optional(),
+  rowing_discipline: z.enum(["sweep", "scull", "both"]).nullable().optional(),
+  throwing_hand: z.enum(["L", "R"]).nullable().optional(),
+  kicking_foot: z.enum(["L", "R"]).nullable().optional(),
   height_inches: heightSchema,
   weight_lbs: weightSchema,
   gpa: gpaSchema,
@@ -311,7 +326,11 @@ export const playerDetailsSchema = z.object({
   facebook_handle: facebookHandleSchema,
   share_contact_with_coaches: z.boolean().default(false),
   ncaa_id: sanitizedTextSchema(50),
+  // Recruiting services (registry: utils/services/canonical.ts).
+  ncsa_id: sanitizedTextSchema(50),
+  hudl_url: urlSchema.nullable().optional(),
   perfect_game_id: sanitizedTextSchema(50),
+  prep_baseball_id: sanitizedTextSchema(100),
   showcase_id: sanitizedTextSchema(50),
 });
 


### PR DESCRIPTION
## Phase 3 of the baseball-deprecation effort

Sport-agnostic replacement for the baseball-only bats/throws + Perfect Game/Prep Baseball fields. Two new registries mirroring metrics/positions canonical, **byte-identical with iOS**. **Zero DB migration** — values are flat keys in `user_preferences.data` (category player).

### utils/attributes/canonical.ts (Registry A)
16 per-sport laterality/stance attributes across 11 sports; position-gated catches→Goalie, throwing_hand→QB, kicking_foot→K/P; Track/CC/Swimming/Wrestling/Field Hockey have none.

### utils/services/canonical.ts (Registry B)
NCSA (all 17), Hudl (9 sports, url kind), Perfect Game (urlTemplate), Prep Baseball Report. `ServiceLinkKind {template,url,prepBaseball}`; PBR link restored through the registry via `buildPrepBaseballUrl` (state + name slug), matching iOS byte-for-byte.

### UI
`PlayerDetailsAthleticsTab` renders both registries by sport (position-gated), dropping the `isBaseballOrSoftball` special-case; PBR row keeps the state select. Public card + agent markdown + public API emit registry-driven service links. `types/models.ts` + `schemas.ts` gain the new fields (enums where closed); edit-history labels sourced from the registries.

### Test plan
- `type-check` 0, `lint` 0.
- attributes + services (incl. prepBaseball) + recruitingLinks + agent-markdown + ProfilePreview suites green.

Paired with iOS Phase 3 PR (same registries, byte-identical). Contract: iOS `planning/2026-08-22-phase3-registry-contract.md`.

https://claude.ai/code/session_01CDcodSBGGkT2H1MpTqbmRs