### PR TITLE
chore: neutralize baseball copy + rebrand to The Recruiting Compass (Phase 5)

### DIFF
--- a/components/Dashboard/EventsSummary.vue
+++ b/components/Dashboard/EventsSummary.vue
@@ -141,7 +141,7 @@ const getEventEmoji = (type: string) => {
     camp: "⛺",
     official_visit: "🏟️",
     unofficial_visit: "🏫",
-    game: "⚾",
+    game: "🏟️",
   };
   return emojiMap[type] || "📅";
 };

--- a/components/Dashboard/InteractionStats.vue
+++ b/components/Dashboard/InteractionStats.vue
@@ -184,7 +184,7 @@ const getTypeEmoji = (type: string): string => {
     phone_call: "☎️",
     in_person_visit: "👥",
     virtual_meeting: "💻",
-    camp: "⚾",
+    camp: "⛺",
     showcase: "🎯",
     tweet: "𝕏",
     dm: "💭",

--- a/components/Dashboard/RecruitingCalendar.vue
+++ b/components/Dashboard/RecruitingCalendar.vue
@@ -158,7 +158,7 @@ const getKeyDates = () => {
       name: "Junior Fall Showcase Season",
       description: "Peak recruiting exposure events",
       date: new Date(year - 2, 8, 1), // September, junior year
-      emoji: "⚾",
+      emoji: "🎯",
     },
     {
       id: "early-signing",

--- a/components/Dashboard/UpcomingDeadlines.vue
+++ b/components/Dashboard/UpcomingDeadlines.vue
@@ -162,7 +162,7 @@ const getOfferTypeLabel = (type: string): string => {
 const getEventTypeLabel = (type: string): string => {
   const labels: Record<string, string> = {
     showcase: "🎯 Showcase",
-    camp: "⚾ Camp",
+    camp: "⛺ Camp",
     official_visit: "🏫 Official Visit",
     unofficial_visit: "🏫 Unofficial Visit",
     game: "🎮 Game",

--- a/components/Interaction/InteractionForm.vue
+++ b/components/Interaction/InteractionForm.vue
@@ -68,7 +68,7 @@ const typeOptions = computed(() => [
   { value: "phone_call", label: "☎️ Phone Call" },
   { value: "in_person_visit", label: "👥 In-Person Visit" },
   { value: "virtual_meeting", label: "💻 Virtual Meeting" },
-  { value: "camp", label: "⚾ Camp" },
+  { value: "camp", label: "⛺ Camp" },
   { value: "showcase", label: "🎯 Showcase" },
   { value: "tweet", label: "X (Twitter)" },
   { value: "dm", label: "💭 DM" },

--- a/components/TemplateEditor.vue
+++ b/components/TemplateEditor.vue
@@ -56,7 +56,7 @@
         <input
           v-model="formData.subject"
           type="text"
-          placeholder="e.g., Baseball Recruitment Inquiry - {{playerName}}"
+          placeholder="e.g., Recruiting Inquiry - {{playerName}}"
           class="w-full px-4 py-2 rounded-lg border border-slate-300 text-slate-900 bg-white"
         />
         <p class="text-xs mt-1 text-slate-600">
@@ -242,10 +242,10 @@ const preview = computed(() => {
     schoolName: "Ohio State University",
     highSchool: "Lincoln High School",
     gradYear: "2025",
-    position: "Shortstop",
+    position: "Captain",
     division: "D1",
     eventName: "Area Code Games",
-    schoolTwitter: "OhioStateBB",
+    schoolTwitter: "OhioStateAthletics",
     todayDate: new Date().toLocaleDateString("en-US", {
       month: "long",
       day: "numeric",

--- a/composables/useEvents.ts
+++ b/composables/useEvents.ts
@@ -20,7 +20,7 @@ type _EventUpdate = Database["public"]["Tables"]["events"]["Update"];
  * Manages recruiting events and performance opportunities
  *
  * Event types:
- * - camp: College baseball camp
+ * - camp: College athletic camp
  * - showcase: Prospect showcase/tournament
  * - official_visit: Official campus visit (OV)
  * - unofficial_visit: Unofficial campus visit

--- a/composables/useGeocoding.ts
+++ b/composables/useGeocoding.ts
@@ -35,7 +35,7 @@ export const useGeocoding = () => {
         `https://nominatim.openstreetmap.org/search?q=${encodedAddress}&format=json&limit=1`,
         {
           headers: {
-            "User-Agent": "BaseballRecruitingTracker/1.0",
+            "User-Agent": "TheRecruitingCompass/1.0",
           },
         },
       );
@@ -84,7 +84,7 @@ export const useGeocoding = () => {
         `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json`,
         {
           headers: {
-            "User-Agent": "BaseballRecruitingTracker/1.0",
+            "User-Agent": "TheRecruitingCompass/1.0",
           },
         },
       );

--- a/docs/marketing/BLOG_POST_TEMPLATES.md
+++ b/docs/marketing/BLOG_POST_TEMPLATES.md
@@ -217,9 +217,9 @@ For each school, find:
 Resources:
 
 - Perfect Game rankings
-- College Baseball websites
+- College athletics websites
 - Coaching staff social media
-- Baseball America
+- College sports media outlets
 
 Write down 5-7 schools.
 
@@ -337,10 +337,10 @@ Start with this framework. Build your list. And then attack it with focus and in
 
 ---
 
-### POST 3: 5 Mistakes Parents Make in College Baseball Recruiting (And How to Avoid Them)
+### POST 3: 5 Mistakes Parents Make in College Recruiting (And How to Avoid Them)
 
 **Headline:**
-5 Critical Mistakes Parents Make in College Baseball Recruiting (And How to Avoid Them)
+5 Critical Mistakes Parents Make in College Recruiting (And How to Avoid Them)
 
 **Subheading:**
 Learn from common recruiting pitfalls so you can support your student-athlete effectively without sabotaging their opportunities.
@@ -352,7 +352,7 @@ Learn from common recruiting pitfalls so you can support your student-athlete ef
 
 **Body:**
 
-If your son or daughter is a baseball player, you know how intense the recruiting process can be. As a parent, you want to help. But navigating recruiting waters can be tricky—there are plenty of ways to inadvertently hurt your student's chances.
+If your son or daughter is a student-athlete, you know how intense the recruiting process can be. As a parent, you want to help. But navigating recruiting waters can be tricky—there are plenty of ways to inadvertently hurt your student's chances.
 
 I've worked with hundreds of families going through recruiting. I've seen the good, the bad, and the ugly. Here are the five most common mistakes parents make—and how to avoid them.
 

--- a/docs/marketing/EMAIL_TEMPLATES.md
+++ b/docs/marketing/EMAIL_TEMPLATES.md
@@ -683,7 +683,7 @@ While your recruiting journey is complete, you might want to:
 
 **You've got this!**
 
-Welcome to the next chapter of your baseball journey. We can't wait to see what you accomplish in college.
+Welcome to the next chapter of your athletic journey. We can't wait to see what you accomplish in college.
 
 ---
 

--- a/docs/marketing/FEATURE_HIGHLIGHTS.md
+++ b/docs/marketing/FEATURE_HIGHLIGHTS.md
@@ -114,7 +114,7 @@ Get a fit score (1-10 scale) for every school based on your academic, athletic, 
 
 ### Feature Overview (2-3 Sentences)
 
-With 1,000+ colleges offering baseball, how do you know which ones are actually a good fit? Recruiting Compass analyzes your academics, athleticism, location preferences, and goals to give each school a fit score. No more guessing—understand exactly why a school is (or isn't) right for you.
+With thousands of colleges offering athletic programs, how do you know which ones are actually a good fit? Recruiting Compass analyzes your academics, athleticism, location preferences, and goals to give each school a fit score. No more guessing—understand exactly why a school is (or isn't) right for you.
 
 ### Key Benefits
 

--- a/docs/marketing/LANDING_PAGE_COPY.md
+++ b/docs/marketing/LANDING_PAGE_COPY.md
@@ -24,7 +24,7 @@ The all-in-one platform for student-athletes and families to organize schools, t
 
 Stop tracking recruiting in spreadsheets. Stop missing follow-ups. Stop second-guessing your decisions.
 
-Recruiting Compass brings clarity to the college baseball recruiting process. From managing your target schools to logging every coach interaction, we help you stay organized and make smarter decisions about your future.
+Recruiting Compass brings clarity to the college recruiting process. From managing your target schools to logging every coach interaction, we help you stay organized and make smarter decisions about your future.
 
 **Perfect for:**
 
@@ -203,7 +203,7 @@ Stay engaged and informed:
 
 **"We recommend it to all our families"**
 
-> _"So many families don't have a system for recruiting. We love that Recruiting Compass is free and easy to use." — Coach Wilson, High School Baseball_
+> _"So many families don't have a system for recruiting. We love that Recruiting Compass is free and easy to use." — Coach Wilson, High School Athletics_
 
 ### Numbers (Optional - if data exists)
 
@@ -377,7 +377,7 @@ Sign up for free and start tracking your recruiting journey today. No credit car
 
 ### Color Palette (Suggestions)
 
-- **Primary**: Sport-related (baseball blue #003087, grass green #2E7D32)
+- **Primary**: Sport-related (compass blue #003087, grass green #2E7D32)
 - **Accent**: Energy/growth (orange #FF8C00 for CTAs)
 - **Neutral**: Light gray backgrounds (#F5F5F5), dark text (#333)
 

--- a/docs/marketing/PRESS_KIT.md
+++ b/docs/marketing/PRESS_KIT.md
@@ -67,14 +67,14 @@ Recruiting Compass brings everything together in one intuitive platform:
 
 **Market Size:**
 
-- 300,000+ student-athletes in college baseball annually
+- 300,000+ student-athletes in college athletics annually
 - 4 million+ high school student-athletes across all sports
 - Every student-athlete goes through recruiting
 - Parent involvement is critical
 
 **Target Audience:**
 
-- High school student-athletes (baseball initially, expandable)
+- High school student-athletes (all sports)
 - Parents helping guide the recruiting process
 - Coaches looking for better tools
 
@@ -146,7 +146,7 @@ Chris is passionate about [your passions] and believes that better tools and org
 
 **Market Context:**
 
-- 300,000+ baseball student-athletes annually
+- 300,000+ college student-athletes annually
 - 4 million+ high school student-athletes (all sports)
 - Target demographic: 14-18 year-olds + parents
 - Peak recruiting season: Sophomore-Junior year
@@ -211,11 +211,11 @@ Chris is passionate about [your passions] and believes that better tools and org
 ```
 FOR IMMEDIATE RELEASE
 
-Recruiting Compass Launches Free Platform to Simplify College Baseball Recruiting
+Recruiting Compass Launches Free Platform to Simplify College Recruiting
 
 New platform brings clarity to chaotic recruiting process for student-athletes and families
 
-[Your City], [Date] – Recruiting Compass today announced the launch of its free platform designed to organize the entire college baseball recruiting journey. The platform solves a critical gap in the market: bringing together school management, coach interaction tracking, recruiting timeline, and family collaboration in one place.
+[Your City], [Date] – Recruiting Compass today announced the launch of its free platform designed to organize the entire college recruiting journey. The platform solves a critical gap in the market: bringing together school management, coach interaction tracking, recruiting timeline, and family collaboration in one place.
 
 The platform launches with four core features:
 • School list management with fit scores
@@ -410,7 +410,7 @@ Location: [Your city, state]
 
 ### Sports/Athletic Angles
 
-- "Baseball recruiting getting organized with new platform"
+- "Recruiting getting organized with new platform"
 - "How technology is changing college recruiting"
 - "Player development and recruitment: The next frontier"
 

--- a/docs/marketing/SOCIAL_MEDIA_CONTENT.md
+++ b/docs/marketing/SOCIAL_MEDIA_CONTENT.md
@@ -44,7 +44,7 @@ coaches reaching out without context.
 We built a better way. Sign up free today.
 
 recruitingcompass.com
-#BaseballRecruiting #CollegeAthletics
+#CollegeRecruiting #CollegeAthletics
 ```
 
 **Post 1B (Afternoon)**
@@ -227,7 +227,7 @@ Coaches care about:
 Recruiting Compass helps you demonstrate all three.
 
 recruitingcompass.com
-#BaseballRecruiting
+#CollegeRecruiting
 ```
 
 ### Day 5 - CTA & Momentum
@@ -277,7 +277,7 @@ You'll thank yourself later.
 
 ↓ Start free (no credit card)
 recruitingcompass.com
-#BaseballRecruiting
+#CollegeRecruiting
 ```
 
 ---
@@ -290,7 +290,7 @@ recruitingcompass.com
 
 ```
 Caption:
-Your recruiting headquarters is here. 🎓⚾
+Your recruiting headquarters is here. 🎓🏅
 
 Tired of juggling spreadsheets, email threads, and text chains?
 Meet Recruiting Compass—the free platform that organizes your
@@ -306,7 +306,7 @@ Everything you need in one place.
 
 Link in bio to sign up free (no credit card required)
 
-#RecruitingCompass #CollegeBaseball #Recruiting101
+#RecruitingCompass #CollegeSports #Recruiting101
 ```
 
 **Day 3 Post**
@@ -417,7 +417,7 @@ Stop wondering what to do. Get coached through it.
 ```
 Introducing Recruiting Compass: Bringing Clarity to College Recruiting
 
-The college baseball recruiting process is unnecessarily complex.
+The college recruiting process is unnecessarily complex.
 Student-athletes and families navigate:
 
 • Managing 15-20+ potential schools
@@ -453,14 +453,14 @@ Join us. Free to start, no credit card required.
 - #RecruitingCompass
 - #CollegeRecruiting
 - #CollegeAthletics
-- #BaseballRecruiting
+- #CollegeRecruiting
 
 ### Secondary Hashtags (Mix and match)
 
 - #StudentAthlete
 - #Recruiting101
-- #CollegeBaseball
-- #D1Baseball
+- #CollegeSports
+- #D1Athletics
 - #AthleteLife
 - #RecruitingTips
 - #CollegeFootball (if expanding)
@@ -521,16 +521,16 @@ Join us. Free to start, no credit card required.
 
 ### Accounts to Follow/Mention
 
-- @ABCA (American Baseball Coaches Association)
+- @NCAA (college athletics governing body)
 - @Perfect_Game (recruiting service)
-- @BaseballAmerica (media)
-- College baseball programs (where you recruit)
-- High school baseball programs
+- College recruiting media outlets
+- College athletic programs (where you recruit)
+- High school athletic programs
 
 ### Collaboration Opportunities
 
-- Partner with baseball Twitter influencers
-- Feature in baseball news websites
+- Partner with recruiting Twitter influencers
+- Feature in recruiting news websites
 - Guest post on recruiting blogs
 - Sponsorships of recruiting events
 
@@ -608,7 +608,7 @@ Thanks for your patience.
 
 ### Student-Athlete Stories
 
-- Journey to college baseball
+- Journey to college athletics
 - Recruiting lessons learned
 - How Recruiting Compass helped
 - Advice for younger players

--- a/pages/reports/timeline.vue
+++ b/pages/reports/timeline.vue
@@ -552,7 +552,7 @@ const formatEventType = (type: string) => {
 const getEventEmoji = (type: string) => {
   const emojis: Record<string, string> = {
     showcase: "🎯",
-    camp: "⚾",
+    camp: "⛺",
     official_visit: "✈️",
     unofficial_visit: "🚗",
     game: "🏟️",
@@ -582,7 +582,7 @@ const getInteractionEmoji = (type: string) => {
     text: "💬",
     in_person_visit: "👥",
     virtual_meeting: "💻",
-    camp: "⚾",
+    camp: "⛺",
     showcase: "🎯",
     tweet: "𝕏",
     dm: "💭",

--- a/pages/settings/school-preferences.vue
+++ b/pages/settings/school-preferences.vue
@@ -533,7 +533,7 @@ const TEMPLATES = [
     id: "d1_power",
     name: "D1 Power Conference",
     icon: "🏆",
-    description: "Focus on top-tier D1 programs with competitive baseball",
+    description: "Focus on top-tier D1 programs with competitive athletics",
     preferences: [
       {
         category: "program",

--- a/tests/unit/utils/reportExport.spec.ts
+++ b/tests/unit/utils/reportExport.spec.ts
@@ -33,7 +33,7 @@ describe("reportExport", () => {
         "2024-01-31",
       );
 
-      expect(report.title).toBe("Baseball Recruiting Report");
+      expect(report.title).toBe("The Recruiting Compass Report");
       expect(report.dateRange.from).toBe("2024-01-01");
       expect(report.dateRange.to).toBe("2024-01-31");
       expect(report.schools).toBeDefined();

--- a/utils/geocoding.ts
+++ b/utils/geocoding.ts
@@ -34,7 +34,7 @@ export const geocodeAddress = async (
       `https://nominatim.openstreetmap.org/search?q=${encodedAddress}&format=json&limit=1`,
       {
         headers: {
-          "User-Agent": "BaseballRecruitingTracker/1.0",
+          "User-Agent": "TheRecruitingCompass/1.0",
         },
       },
     );
@@ -79,7 +79,7 @@ export const reverseGeocode = async (
       `https://nominatim.openstreetmap.org/reverse?lat=${lat}&lon=${lng}&format=json`,
       {
         headers: {
-          "User-Agent": "BaseballRecruitingTracker/1.0",
+          "User-Agent": "TheRecruitingCompass/1.0",
         },
       },
     );

--- a/utils/ncaaDatabase.ts
+++ b/utils/ncaaDatabase.ts
@@ -1,5 +1,5 @@
 /**
- * NCAA baseball schools database
+ * NCAA schools database
  * Comprehensive list of 600+ NCAA Division I, II, III schools
  * Data extracted from data/ncaaSchools.json
  */
@@ -14,7 +14,7 @@ export interface SchoolInfo {
 }
 
 /**
- * Comprehensive database of NCAA baseball schools by division
+ * Comprehensive database of NCAA schools by division
  * Organized by division for efficient lookups
  */
 export const DIVISION_SCHOOLS: Record<NcaaDivision, SchoolInfo[]> =

--- a/utils/ncaaRecruitingCalendar.ts
+++ b/utils/ncaaRecruitingCalendar.ts
@@ -1,6 +1,6 @@
 /**
  * NCAA Recruiting Calendar utility for managing dead periods, recruiting windows, and important milestones
- * Reference: NCAA Division I Baseball Recruiting Rules
+ * Reference: NCAA Division I Recruiting Rules
  * 2026-2027 Calendar dates based on official NCAA guidelines and standardized testing calendars
  */
 
@@ -24,7 +24,7 @@ export interface Milestone {
 }
 
 /**
- * NCAA Division I Baseball Recruiting Calendar for 2026
+ * NCAA Division I Recruiting Calendar for 2026
  * Dead periods = No recruiting contact allowed
  * Quiet periods = Limited contact, no in-person visits
  * Contact/Evaluation = Normal recruiting allowed

--- a/utils/parentReassurance.ts
+++ b/utils/parentReassurance.ts
@@ -29,7 +29,7 @@ const REASSURANCE_MESSAGES: ReassuranceMessage[] = [
     id: "junior-late-bloomers",
     title: "Late Bloomers Are Very Common",
     message:
-      "Baseball players develop at different rates. Many elite players weren't heavily recruited until late junior or even senior year. Your athlete still has plenty of time.",
+      "Athletes develop at different rates. Many elite players weren't heavily recruited until late junior or even senior year. Your athlete still has plenty of time.",
     phases: ["junior"],
     icon: "🌱",
   },
@@ -53,7 +53,7 @@ const REASSURANCE_MESSAGES: ReassuranceMessage[] = [
     id: "senior-walkon-path",
     title: "Walk-On is a Legitimate Path",
     message:
-      "Walk-ons become key contributors and future pros. It's a valid way to play college baseball, even at top programs. Don't view it as a fallback.",
+      "Walk-ons become key contributors and future pros. It's a valid way to play in college, even at top programs. Don't view it as a fallback.",
     phases: ["senior"],
     icon: "🚪",
   },

--- a/utils/parentWorries.ts
+++ b/utils/parentWorries.ts
@@ -108,16 +108,16 @@ const PARENT_WORRIES: ParentWorry[] = [
   {
     id: "all-late-bloomers",
     question:
-      "Are late bloomers common in baseball recruiting? My athlete just started improving.",
+      "Are late bloomers common in recruiting? My athlete just started improving.",
     answer:
-      "Very common. Baseball development varies greatly by individual. Some athletes peak junior/senior year. Coaches know this and continue evaluating. Improvement is what matters. Don't lose hope if your athlete is still developing.",
+      "Very common. Athletic development varies greatly by individual. Some athletes peak junior/senior year. Coaches know this and continue evaluating. Improvement is what matters. Don't lose hope if your athlete is still developing.",
     phases: ["freshman", "sophomore", "junior"],
     category: "timeline",
   },
   {
     id: "all-grades-matter",
     question:
-      "How important are grades in recruiting? My athlete focuses more on baseball.",
+      "How important are grades in recruiting? My athlete focuses more on their sport.",
     answer:
       "Grades matter significantly. Most college programs require minimum GPA, and good grades keep options open at selective schools. Recruiting is about both athleticism AND academics. Strong grades make your athlete more attractive overall.",
     phases: ["freshman", "sophomore", "junior", "senior"],
@@ -128,7 +128,7 @@ const PARENT_WORRIES: ParentWorry[] = [
     question:
       "What does walk-on mean? Is it a legitimate way to play in college?",
     answer:
-      "Walk-ons are students who try out for the team without a scholarship offer. It's completely legitimate. Many walk-ons eventually earn scholarships or become key contributors. Walk-on can lead to college baseball, even D1. Consider it a viable option.",
+      "Walk-ons are students who try out for the team without a scholarship offer. It's completely legitimate. Many walk-ons eventually earn scholarships or become key contributors. Walk-on can lead to a college roster spot, even D1. Consider it a viable option.",
     phases: ["junior", "senior"],
     category: "recruiting",
   },

--- a/utils/phaseCalculation.ts
+++ b/utils/phaseCalculation.ts
@@ -84,7 +84,7 @@ export const PHASE_INFO: Record<
     label: "Committed",
     grade: 12,
     theme: "Post-Commitment",
-    description: "Signed and ready for college baseball",
+    description: "Signed and ready for college",
   },
 };
 

--- a/utils/printExport.ts
+++ b/utils/printExport.ts
@@ -117,7 +117,7 @@ export const printContent = (title: string, htmlContent: string) => {
         ${htmlContent}
       </div>
       <footer>
-        <p>Baseball Recruiting Compass • Confidential</p>
+        <p>The Recruiting Compass • Confidential</p>
       </footer>
     </body>
     </html>

--- a/utils/reportExport.ts
+++ b/utils/reportExport.ts
@@ -114,7 +114,7 @@ export const generateReportData = (
   });
 
   return {
-    title: "Baseball Recruiting Report",
+    title: "The Recruiting Compass Report",
     dateRange: { from, to },
     schools: {
       total: schools.length,


### PR DESCRIPTION
## Phase 5 (final) of the baseball-deprecation effort — web

Copy/cosmetic only, no logic changes. type-check 0, lint 0.

- **Brand → "The Recruiting Compass"**: print footer, export report title. **User-Agent → `TheRecruitingCompass/1.0`** (geocoding).
- **Prose** sport-neutral: `parentReassurance`, `parentWorries`, `phaseCalculation`.
- **⚾ event-type emojis** → neutral (camp ⛺, game 🏟️, showcase 🎯), matching each file's existing markers.
- **TemplateEditor** placeholder/sample, `ncaaRecruitingCalendar`/`ncaaDatabase`/`useEvents` comments, `school-preferences` preset copy.
- **Marketing docs** (`docs/marketing/*`): hashtags (#CollegeRecruiting…), handles, metric examples, "baseball blue"→"compass blue", copy widened to college-athletics.

Residual "baseball" all intentional (registries, gated Prep Baseball Report, internal keys, the Baseball sport-enum value, SVG field-art comments, tests/planning).

**Follow-up (data, not copy):** `BASEBALL_SIGNING_PERIODS_2026` in `ncaaRecruitingCalendar.ts` is baseball-specific signing-date data — per-sport recruiting calendars are a later concern, out of this copy pass.

_(Pushed --no-verify: pre-push lint hook crashes with Abort trap 6; ran type-check + lint directly, both clean.)_

Completes the 5-phase effort on web.

https://claude.ai/code/session_01CDcodSBGGkT2H1MpTqbmRs