### PR TITLE
feat: sport-aware NCAA recruiting calendar (gender field + 13-calendar dataset + resolver + rewire)

### DIFF
--- a/components/Settings/PlayerDetailsBasicsTab.vue
+++ b/components/Settings/PlayerDetailsBasicsTab.vue
@@ -16,7 +16,7 @@
           :target-user-id="activeAthleteId ?? undefined"
         />
         <div class="flex-1 space-y-5 w-full">
-          <div class="grid grid-cols-1 md:grid-cols-2 gap-5">
+          <div class="space-y-5">
             <div>
               <label
                 class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1 whitespace-nowrap"
@@ -72,7 +72,7 @@
                 @change="triggerSave"
                 class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-transparent transition disabled:opacity-50 appearance-none font-medium text-slate-700"
               >
-                <option :value="undefined">Prefer not to answer</option>
+                <option :value="undefined" disabled>Select…</option>
                 <option
                   v-for="opt in genderOptions"
                   :key="opt.value"

--- a/components/Settings/PlayerDetailsBasicsTab.vue
+++ b/components/Settings/PlayerDetailsBasicsTab.vue
@@ -64,7 +64,7 @@
               <label
                 class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1 whitespace-nowrap"
               >
-                Gender <span class="normal-case text-slate-400">(optional)</span>
+                Gender <span class="normal-case text-slate-400">(Optional)</span>
               </label>
               <select
                 v-model="form.gender"

--- a/components/Settings/PlayerDetailsBasicsTab.vue
+++ b/components/Settings/PlayerDetailsBasicsTab.vue
@@ -60,6 +60,28 @@
                 </option>
               </select>
             </div>
+            <div>
+              <label
+                class="block text-[10px] font-bold text-slate-400 uppercase tracking-widest mb-1.5 ml-1 whitespace-nowrap"
+              >
+                Gender <span class="normal-case text-slate-400">(optional)</span>
+              </label>
+              <select
+                v-model="form.gender"
+                :disabled="isParentRole"
+                @change="triggerSave"
+                class="w-full px-4 py-3 bg-slate-50 border border-slate-200 rounded-xl focus:ring-2 focus:ring-blue-500 focus:border-transparent transition disabled:opacity-50 appearance-none font-medium text-slate-700"
+              >
+                <option :value="undefined">Prefer not to answer</option>
+                <option
+                  v-for="opt in genderOptions"
+                  :key="opt.value"
+                  :value="opt.value"
+                >
+                  {{ opt.label }}
+                </option>
+              </select>
+            </div>
           </div>
         </div>
       </div>
@@ -281,6 +303,10 @@ defineProps<{
   campusSizeOptions: { value: "small" | "medium" | "large"; label: string }[];
   costSensitivityOptions: {
     value: "high" | "medium" | "low";
+    label: string;
+  }[];
+  genderOptions: {
+    value: "male" | "female" | "other" | "prefer_not_to_say";
     label: string;
   }[];
   triggerSave: () => void;

--- a/composables/usePlayerDetailsForm.ts
+++ b/composables/usePlayerDetailsForm.ts
@@ -51,6 +51,13 @@ export function usePlayerDetailsForm() {
     { value: "large" as const, label: "Large (25K+)" },
   ];
 
+  const GENDER_OPTIONS = [
+    { value: "male" as const, label: "Male" },
+    { value: "female" as const, label: "Female" },
+    { value: "other" as const, label: "Other" },
+    { value: "prefer_not_to_say" as const, label: "Prefer not to say" },
+  ];
+
   const COST_SENSITIVITY_OPTIONS = [
     { value: "high" as const, label: "High" },
     { value: "medium" as const, label: "Medium" },
@@ -62,6 +69,7 @@ export function usePlayerDetailsForm() {
 
   const form = ref<PlayerDetails>({
     graduation_year: undefined,
+    gender: undefined,
     club_team: "",
     positions: [],
     bats: undefined,
@@ -435,6 +443,7 @@ export function usePlayerDetailsForm() {
     THROWS_OPTIONS,
     CAMPUS_SIZE_OPTIONS,
     COST_SENSITIVITY_OPTIONS,
+    GENDER_OPTIONS,
     homeState,
     load,
   };

--- a/pages/onboarding/index.vue
+++ b/pages/onboarding/index.vue
@@ -100,6 +100,27 @@
             </p>
           </div>
 
+          <!-- Gender -->
+          <div>
+            <label
+              for="onboarding-gender"
+              class="block text-sm font-medium text-slate-700 mb-2"
+            >
+              Gender (Optional)
+            </label>
+            <select
+              id="onboarding-gender"
+              v-model="onboardingData.gender"
+              class="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            >
+              <option :value="undefined">Select gender</option>
+              <option value="male">Male</option>
+              <option value="female">Female</option>
+              <option value="other">Other</option>
+              <option value="prefer_not_to_say">Prefer not to say</option>
+            </select>
+          </div>
+
           <!-- Position -->
           <div v-if="onboardingData.primary_sport">
             <label
@@ -378,6 +399,7 @@ import { useAppToast } from "~/composables/useAppToast";
 import { createClientLogger } from "~/utils/logger";
 import { getCanonicalPositions } from "~/utils/positions/canonical";
 import { getGraduationYearOptions } from "~/utils/graduationYears";
+import type { PlayerDetails } from "~/types/models";
 
 const logger = createClientLogger("Onboarding");
 
@@ -553,6 +575,7 @@ const nextScreen = async () => {
           primary_sport: onboardingData.value.primary_sport as string,
           primary_position: onboardingPosition,
           positions: onboardingPosition ? [onboardingPosition] : [],
+          gender: onboardingData.value.gender as PlayerDetails["gender"],
         });
       }
 
@@ -662,6 +685,7 @@ const prefillFromCanonical = () => {
     seedIfEmpty("graduation_year", details.graduation_year);
     seedIfEmpty("primary_sport", details.primary_sport);
     seedIfEmpty("primary_position", details.primary_position);
+    seedIfEmpty("gender", details.gender);
     seedIfEmpty("gpa", details.gpa);
     seedIfEmpty("sat_score", details.sat_score);
     seedIfEmpty("act_score", details.act_score);

--- a/pages/settings/player-details.vue
+++ b/pages/settings/player-details.vue
@@ -127,6 +127,7 @@
             :common-sports="commonSports"
             :campus-size-options="CAMPUS_SIZE_OPTIONS"
             :cost-sensitivity-options="COST_SENSITIVITY_OPTIONS"
+            :gender-options="GENDER_OPTIONS"
             :trigger-save="triggerSave"
             :social-inputs="socialInputs"
             :handle-social-blur="handleSocialBlur"
@@ -414,6 +415,7 @@ const {
   gradeLevels,
   CAMPUS_SIZE_OPTIONS,
   COST_SENSITIVITY_OPTIONS,
+  GENDER_OPTIONS,
   homeState,
   load,
 } = usePlayerDetailsForm();

--- a/server/api/family/player-details.post.ts
+++ b/server/api/family/player-details.post.ts
@@ -8,7 +8,8 @@ export default defineEventHandler(async (event) => {
   const user = await requireAuth(event);
   const body = await readBody(event);
 
-  const { playerName, playerDob, graduationYear, sport, position } = body;
+  const { playerName, playerDob, graduationYear, sport, position, gender } =
+    body;
 
   const supabase = useSupabaseAdmin();
 
@@ -37,6 +38,7 @@ export default defineEventHandler(async (event) => {
         graduationYear,
         sport,
         position,
+        ...(gender ? { gender } : {}),
       },
     })
     .eq("id", membership.family_unit_id);

--- a/server/utils/hydrateAthleteProfile.ts
+++ b/server/utils/hydrateAthleteProfile.ts
@@ -21,6 +21,7 @@ interface PendingPlayerDetails {
   graduationYear?: unknown;
   sport?: unknown;
   position?: unknown;
+  gender?: unknown;
 }
 
 interface HydrationLogger {
@@ -82,6 +83,7 @@ async function hydratePlayerPreferences(
       typeof pending.sport === "string" ? pending.sport : undefined,
     primary_position: position,
     positions: position ? [position] : undefined,
+    gender: typeof pending.gender === "string" ? pending.gender : undefined,
   };
 
   const merged = { ...existing };

--- a/tests/unit/utils/validation/schemas.extended.spec.ts
+++ b/tests/unit/utils/validation/schemas.extended.spec.ts
@@ -928,6 +928,30 @@ describe("playerDetailsSchema - Extended", () => {
     expect(() => playerDetailsSchema.parse(data)).not.toThrow();
   });
 
+  it("should accept all gender values", () => {
+    const genders = ["male", "female", "other", "prefer_not_to_say"];
+    genders.forEach((gender) => {
+      const data = { ...validPlayerDetails, gender };
+      expect(() => playerDetailsSchema.parse(data)).not.toThrow();
+    });
+  });
+
+  it("should accept null/absent gender", () => {
+    expect(() =>
+      playerDetailsSchema.parse({ ...validPlayerDetails, gender: null }),
+    ).not.toThrow();
+    const { gender: _gender, ...withoutGender } = {
+      ...validPlayerDetails,
+      gender: "male",
+    };
+    expect(() => playerDetailsSchema.parse(withoutGender)).not.toThrow();
+  });
+
+  it("should reject unknown gender", () => {
+    const data = { ...validPlayerDetails, gender: "M" };
+    expect(() => playerDetailsSchema.parse(data)).toThrow();
+  });
+
   it("should validate height range", () => {
     const data = { ...validPlayerDetails, height_inches: 50 };
     expect(() => playerDetailsSchema.parse(data)).not.toThrow();

--- a/tests/unit/validation/schemas.test.ts
+++ b/tests/unit/validation/schemas.test.ts
@@ -308,19 +308,6 @@ describe("playerDetailsSchema", () => {
     };
     await expect(playerDetailsSchema.parseAsync(data)).rejects.toThrow();
   });
-
-  it("accepts valid gender values", () => {
-    for (const g of ["male", "female", "other", "prefer_not_to_say"]) {
-      expect(playerDetailsSchema.safeParse({ gender: g }).success).toBe(true);
-    }
-  });
-  it("accepts null/absent gender", () => {
-    expect(playerDetailsSchema.safeParse({ gender: null }).success).toBe(true);
-    expect(playerDetailsSchema.safeParse({}).success).toBe(true);
-  });
-  it("rejects unknown gender", () => {
-    expect(playerDetailsSchema.safeParse({ gender: "M" }).success).toBe(false);
-  });
 });
 
 describe("eventSchema", () => {

--- a/tests/unit/validation/schemas.test.ts
+++ b/tests/unit/validation/schemas.test.ts
@@ -308,6 +308,19 @@ describe("playerDetailsSchema", () => {
     };
     await expect(playerDetailsSchema.parseAsync(data)).rejects.toThrow();
   });
+
+  it("accepts valid gender values", () => {
+    for (const g of ["male", "female", "other", "prefer_not_to_say"]) {
+      expect(playerDetailsSchema.safeParse({ gender: g }).success).toBe(true);
+    }
+  });
+  it("accepts null/absent gender", () => {
+    expect(playerDetailsSchema.safeParse({ gender: null }).success).toBe(true);
+    expect(playerDetailsSchema.safeParse({}).success).toBe(true);
+  });
+  it("rejects unknown gender", () => {
+    expect(playerDetailsSchema.safeParse({ gender: "M" }).success).toBe(false);
+  });
 });
 
 describe("eventSchema", () => {

--- a/types/models.ts
+++ b/types/models.ts
@@ -366,6 +366,7 @@ export interface PlayerDetails {
   nces_school_id?: string; // NCES school identifier; null if free-text entry was used
   club_team?: string;
   positions?: string[];
+  gender?: "male" | "female" | "other" | "prefer_not_to_say";
   // Per-sport athlete attributes (registry: utils/attributes/canonical.ts).
   // Flat keys in user_preferences.data; each shown only for its sport(s).
   bats?: "L" | "R" | "S";

--- a/utils/preferenceValidation.ts
+++ b/utils/preferenceValidation.ts
@@ -108,6 +108,10 @@ export function validatePlayerDetails(data: unknown): PlayerDetails | null {
     high_school: toString(obj.high_school),
     club_team: toString(obj.club_team),
     positions: normalizePositionsForSport(sport, toStringArray(obj.positions)),
+    gender: toOption<"male" | "female" | "other" | "prefer_not_to_say">(
+      obj.gender,
+      ["male", "female", "other", "prefer_not_to_say"],
+    ),
     bats: toOption<"L" | "R" | "S">(obj.bats, ["L", "R", "S"]),
     throws: toOption<"L" | "R">(obj.throws, ["L", "R"]),
     height_inches: toNumber(obj.height_inches),

--- a/utils/validation/schemas.ts
+++ b/utils/validation/schemas.ts
@@ -294,6 +294,7 @@ export const offerSchema = z
 export const playerDetailsSchema = z.object({
   graduation_year: graduationYearSchema,
   positions: z.array(z.string()).default([]),
+  gender: z.enum(["male", "female", "other", "prefer_not_to_say"]).nullable().optional(),
   // Per-sport athlete attributes (registry: utils/attributes/canonical.ts).
   bats: z.enum(["L", "R", "S"]).nullable().optional(),
   throws: z.enum(["L", "R"]).nullable().optional(),


### PR DESCRIPTION
## Sport-aware NCAA Recruiting Calendar (Phases 1–3, web)

Replaces the baseball-only hard-coded recruiting calendar with a sport-, gender-, and division-aware system so the app is usable by all HS athletes. **iOS calendar = Phase 4 (separate); gender field already has an iOS PR (#52).**

**Spec:** `planning/2026-08-23-sport-recruiting-calendar-design.md` · **Plans:** `…-phase1-gender-field-plan.md`, `…-phase2-3-data-resolver-rewire-plan.md` (iOS repo).

### Phase 1 — Gender field
Optional `gender` (`male|female|other|prefer_not_to_say`) in the `player_details` JSON blob (no DB migration): type + Zod + runtime guard, Basics-tab selector (stacked Essential Info), optional onboarding + parent pre-fill (staged + hydrated on invite-accept). One decline option; disabled "Select…" placeholder.

### Phase 2 — Calendar data + resolver
`utils/recruitingCalendar/`: **21 NCAA calendar keys** (12 base + 9 `OTHER_*` per-sport sub-calendars for Soccer/Swim/Ice Hockey/Rowing/Field Hockey/Wrestling), transcribed from the official NCAA 2026-27 D1 PDFs via a render→vision pipeline, every window carrying `source` (PDF URL) + `verifiedOn` + `confidence`. 5-type taxonomy (`dead|quiet|contact|evaluation|recruiting_shutdown`). Resolver maps all 17 app sports → the right calendar incl. gender-split, Football FBS/FCS, Golf, Other-bundle, null-gender→men's default.

### Phase 3 — Rewire consumers
Retires the `BASEBALL_` constant. Server **ruleEngine** now gates timeline-task generation on the athlete's **real sport** dead periods (sourced from prefs at both RuleContext sites) — regression-tested: non-baseball athletes no longer suppressed by baseball dates. Dashboard + timeline are sport-aware. The `RecruitingCalendar` widget (rewritten from dead fake-baseball code to real data) is **mounted on the dashboard + timeline** with Men's/Women's + FBS/FCS toggles, an L6a compliance disclaimer (links the official NCAA PDF), and an L6b staleness banner. SEASON constants + a CODEOWNERS gate on the calendar data.

### Accuracy safeguards (§8.1)
Source-anchored data + CI integrity/plausibility tests (dead periods in sane month ranges), confidence tags, CODEOWNERS review gate, runtime disclaimer + PDF link + staleness banner. NCAA dates could not be independently second-sourced for the just-released 2026-27 cycle → most are single-authoritative-source (MEDIUM), anchors HIGH; disclaimer is load-bearing.

### Tests
~250 module tests + regression sweeps green; type-check clean throughout. Executed via subagent-driven development: per-task review + a whole-branch opus review; the one real bug found (banner showed the enclosing period over a nested dead carve-out) was fixed + re-reviewed.

### Known / deferred (non-blocking)
- Not device/browser-verified (unit + type-check green only).
- Timeline widget defaults division D1 (no division signal on that page).
- Pre-existing `division:"DI"` milestone-typo + 2 pre-existing LogMetricModal test failures left untouched (separate bugs).
- Refresh job (quarterly NCAA-cycle checker) = Phase 5.

https://claude.ai/code/session_01AWiAGdNsWYRjvHQo9hRv43