### PR TITLE
test: fix stale LogMetricModal picker order + drop dead coach e2e helpers

### DIFF
--- a/tests/e2e/fixtures/coaches.fixture.ts
+++ b/tests/e2e/fixtures/coaches.fixture.ts
@@ -249,7 +249,6 @@ export const coachSelectors = {
   instagramAction: 'button[aria-label*="instagram"], a[href*="instagram.com"]',
 
   // Communication/History
-  communicationsTab: 'button:has-text("Messages"), a[href*="/communications"]',
   logInteractionButton: 'button:has-text("Log Interaction")',
   interactionList: '[data-testid="interaction-list"]',
   interactionItem: '[data-testid="interaction-item"]',
@@ -429,14 +428,6 @@ export const coachHelpers = {
    */
   async clickTextAction(page) {
     await page.click(coachSelectors.textAction);
-  },
-
-  /**
-   * Navigate to coach communications page
-   */
-  async navigateToCommunications(page) {
-    await page.click(coachSelectors.communicationsTab);
-    await page.waitForURL(/\/communications/);
   },
 
   /**

--- a/tests/e2e/pages/CoachesPage.ts
+++ b/tests/e2e/pages/CoachesPage.ts
@@ -23,14 +23,6 @@ export class CoachesPage extends BasePage {
     await this.page.waitForLoadState("domcontentloaded");
   }
 
-  async goToCoachCommunications(
-    _schoolId: string | undefined,
-    coachId: string,
-  ) {
-    await super.goto(`/coaches/${coachId}/communications`);
-    await this.page.waitForLoadState("domcontentloaded");
-  }
-
   // CRUD Operations
   async clickAddCoach() {
     // Look for add coach button or navigate to add coach page
@@ -293,24 +285,6 @@ export class CoachesPage extends BasePage {
         instagramButton.click(),
       ]);
       await popup.close();
-    }
-  }
-
-  // Communication and History
-  async navigateToCommunications() {
-    const commButton = await this.page
-      .locator('button:has-text("Messages"), a[href*="/communications"]')
-      .first();
-    await commButton.click();
-    await this.waitForURL(/\/communications/);
-  }
-
-  async viewCoachAnalytics() {
-    const analyticsTab = await this.page
-      .locator('[data-testid="analytics-tab"], button:has-text("Analytics")')
-      .first();
-    if (await analyticsTab.isVisible()) {
-      await analyticsTab.click();
     }
   }
 

--- a/tests/unit/components/Performance/LogMetricModal.spec.ts
+++ b/tests/unit/components/Performance/LogMetricModal.spec.ts
@@ -122,24 +122,38 @@ describe("LogMetricModal - Form Fields", () => {
     const options = wrapper.find("#metricType").findAll("option");
     expect(options).toHaveLength(13); // 11 baseball types + "other" + empty option
 
-    // Verify registry-backed labels (no unit repeated in the label)
-    expect(options[0].text()).toBe("Select Metric");
-    expect(options[1].text()).toBe("Fastball Velocity");
-    expect(options[2].text()).toBe("Exit Velocity");
-    expect(options[3].text()).toBe("Batting Average");
-    expect(options[4].text()).toBe("60-Yard Dash");
-    expect(options[5].text()).toBe("Pop Time");
-    expect(options[6].text()).toBe("ERA");
-    expect(options[12].text()).toBe("Other Metric");
-
-    // Verify registry-ordered values
-    expect(options[1].element.value).toBe("velocity");
-    expect(options[2].element.value).toBe("exit_velo");
-    expect(options[3].element.value).toBe("batting_avg");
-    expect(options[4].element.value).toBe("sixty_time");
-    expect(options[5].element.value).toBe("pop_time");
-    expect(options[6].element.value).toBe("era");
-    expect(options[12].element.value).toBe("other");
+    // Grouped picker order (Hitting → Pitching → Fielding → Speed → Other),
+    // registry-backed labels (no unit repeated in the label).
+    expect(options.map((o) => o.text())).toEqual([
+      "Select Metric",
+      "Exit Velocity",
+      "Batting Average",
+      "On-Base Percentage",
+      "Slugging Percentage",
+      "Fastball Velocity",
+      "ERA",
+      "WHIP",
+      "Strikeouts",
+      "Pop Time",
+      "Fielding Percentage",
+      "60-Yard Dash",
+      "Other Metric",
+    ]);
+    expect(options.map((o) => o.element.value)).toEqual([
+      "",
+      "exit_velo",
+      "batting_avg",
+      "on_base_pct",
+      "slugging_pct",
+      "velocity",
+      "era",
+      "whip",
+      "strikeouts",
+      "pop_time",
+      "fielding_pct",
+      "sixty_time",
+      "other",
+    ]);
   });
 
   it("filters the metric-type list to the athlete's primary sport", () => {
@@ -159,11 +173,11 @@ describe("LogMetricModal - Form Fields", () => {
     expect(values).toEqual([
       "",
       "points_per_game",
-      "rebounds_per_game",
-      "assists_per_game",
       "field_goal_pct",
       "three_point_pct",
       "free_throw_pct",
+      "assists_per_game",
+      "rebounds_per_game",
       "steals_per_game",
       "blocks_per_game",
       "vertical_jump",


### PR DESCRIPTION
## Summary

Greens `develop`, which is currently red on `LogMetricModal.spec.ts`, and removes e2e helpers left dangling by the coach-detail consolidation (#433).

- **LogMetricModal picker order** — the spec asserted the old flat metric-type order, but the log picker groups metrics per sport (commit e002bfa2). Updated the Baseball and Basketball expectations to the grouped order actually rendered (Hitting→Pitching→Fielding→Speed for Baseball; Scoring→Playmaking→Defense for Basketball). Was failing on `develop` and on every open PR's CI.
- **Dead e2e helpers** — removed `CoachesPage.goToCoachCommunications` / `navigateToCommunications` / `viewCoachAnalytics` and the `coaches.fixture` `navigateToCommunications` + `communicationsTab` selector, all of which pointed at the now-deleted coach `/analytics` and `/communications` routes. No spec referenced them.

## Verification
`LogMetricModal.spec.ts` 25/25 pass; type-check clean; no residual references to the deleted routes.

This is the follow-up commit that landed on the #433 branch just after it merged, so it needs its own PR.

https://claude.ai/code/session_01FgqZNX32XLT6KDudKmsQ9L