### PR TITLE
refactor(coaches): trim metrics panel rows duplicated by CoachStatsGrid

### DIFF
--- a/components/Coach/CoachMetricsPanel.vue
+++ b/components/Coach/CoachMetricsPanel.vue
@@ -71,7 +71,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import type { CoachMetrics, CoachComparison } from "~/composables/useCoachAnalytics";
-import { formatType } from "~/utils/interactionFormatters";
 
 const props = defineProps<{
   metrics: CoachMetrics;
@@ -79,8 +78,9 @@ const props = defineProps<{
   insights: string[];
 }>();
 
+// Total interactions, days-since-contact, and preferred method already live in
+// CoachStatsGrid above — the panel only carries the non-duplicated analytics.
 const rows = computed(() => [
-  { label: "Total interactions", value: String(props.metrics.totalInteractions) },
   {
     label: "Sent / received",
     value: `${props.metrics.outboundCount} / ${props.metrics.inboundCount}`,
@@ -93,13 +93,5 @@ const rows = computed(() => [
         ? `${props.metrics.averageResponseTime}h`
         : "—",
   },
-  {
-    label: "Days since contact",
-    value:
-      props.metrics.daysSinceContact >= 0
-        ? String(props.metrics.daysSinceContact)
-        : "N/A",
-  },
-  { label: "Preferred method", value: formatType(props.metrics.preferredMethod) },
 ]);
 </script>

--- a/tests/unit/components/Coach/CoachMetricsPanel.spec.ts
+++ b/tests/unit/components/Coach/CoachMetricsPanel.spec.ts
@@ -35,9 +35,12 @@ describe("CoachMetricsPanel", () => {
       props: { metrics: metrics(), comparison: null, insights: [] },
     });
     const text = wrapper.text();
-    expect(text).toContain("Total interactions");
+    // Total / days-since / preferred live in CoachStatsGrid; the panel carries
+    // the non-duplicated analytics only.
+    expect(text).toContain("Sent / received");
     expect(text).toContain("Response rate");
     expect(text).toContain("50%");
+    expect(text).not.toContain("Total interactions");
   });
 
   it("shows the ranking line only with 2+ coaches", () => {


### PR DESCRIPTION
Total interactions, days-since-contact, and preferred method already render in CoachStatsGrid on the coach detail page. Drop them from CoachMetricsPanel so it carries only the non-duplicated analytics (sent/received, response rate, avg response time) alongside the ranking line and insights.

Test updated to assert the panel no longer duplicates "Total interactions". 5/5 pass; type-check clean.

https://claude.ai/code/session_01FgqZNX32XLT6KDudKmsQ9L