### PR TITLE
fix(seed): self-heal demo/test account passwords on re-seed + reset script

### DIFF
--- a/scripts/reset-demo-passwords.ts
+++ b/scripts/reset-demo-passwords.ts
@@ -1,0 +1,60 @@
+/**
+ * Reset the shared demo-account passwords to a known value.
+ *
+ * The demo families (player1/player2/parent1/parent2 @compassdemo.app) live on
+ * the same Supabase project the local dev server points at, so a drifted
+ * password (e.g. after a password-reset test) breaks every manual verification.
+ * `createOneOffTestUser` now self-heals on re-seed, but this is the surgical
+ * path: it resets ONLY the four passwords and touches no family data.
+ *
+ * Requires Node 22+ (native WebSocket) and SUPABASE_SERVICE_ROLE_KEY +
+ * NUXT_PUBLIC_SUPABASE_URL in .env / .env.local.
+ *
+ *   npx tsx scripts/reset-demo-passwords.ts
+ */
+import { config } from "dotenv";
+import { resolve } from "path";
+import { getSupabaseAdmin } from "../tests/e2e/seed/helpers/supabase-admin";
+
+config({ path: resolve(process.cwd(), ".env") });
+config({ path: resolve(process.cwd(), ".env.local") }); // .env.local overrides
+
+const SHARED_PASSWORD = "DemoPass123!";
+const DEMO_EMAILS = [
+  "player1@compassdemo.app",
+  "parent1@compassdemo.app",
+  "player2@compassdemo.app",
+  "parent2@compassdemo.app",
+];
+
+async function main(): Promise<void> {
+  const supabase = getSupabaseAdmin();
+  console.log(`Resetting demo passwords → ${process.env.NUXT_PUBLIC_SUPABASE_URL}`);
+
+  const { data, error } = await supabase.auth.admin.listUsers({
+    page: 1,
+    perPage: 1000,
+  });
+  if (error) throw new Error(`listUsers failed: ${error.message}`);
+
+  for (const email of DEMO_EMAILS) {
+    const user = data.users.find((u) => u.email === email);
+    if (!user) {
+      console.warn(`⚠️  ${email} not found — skipping`);
+      continue;
+    }
+    const { error: updErr } = await supabase.auth.admin.updateUserById(user.id, {
+      password: SHARED_PASSWORD,
+      email_confirm: true,
+    });
+    if (updErr) throw new Error(`update ${email} failed: ${updErr.message}`);
+    console.log(`   ✅ ${email}`);
+  }
+
+  console.log(`\n✅ Done. Shared password for all demo accounts: ${SHARED_PASSWORD}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/e2e/seed/helpers/supabase-admin.ts
+++ b/tests/e2e/seed/helpers/supabase-admin.ts
@@ -541,7 +541,28 @@ export async function createOneOffTestUser(opts: {
         perPage: 1000,
       });
       const existing = list?.users?.find((u) => u.email === opts.email);
-      if (existing) return existing;
+      if (existing) {
+        // Self-heal: reset the password + keep the email confirmed and metadata
+        // so a re-seed restores known credentials even if they drifted (e.g. a
+        // password-reset test changed a shared demo account). Without this the
+        // account silently keeps whatever password it last had and logins fail.
+        const { data: updated } = await supabase.auth.admin.updateUserById(
+          existing.id,
+          {
+            password: opts.password,
+            email_confirm: true,
+            user_metadata: {
+              ...existing.user_metadata,
+              display_name: opts.displayName,
+              first_name: firstName,
+              last_name: lastName,
+              full_name: opts.displayName,
+              role,
+            },
+          },
+        );
+        return updated?.user ?? existing;
+      }
     }
     throw new Error(`createOneOffTestUser failed: ${error.message}`);
   }


### PR DESCRIPTION
## Problem
Demo families (player*/parent*@compassdemo.app) live on the same Supabase project the local dev server points at. A drifted password silently breaks every manual verification — `admin.createUser` no-ops when the account already exists, so `createOneOffTestUser` returned the account untouched and the old password stuck (logins 400'd, hit while verifying #433).

## Fix
- **`createOneOffTestUser` self-heals** — on "already registered", reset the password + re-confirm email + refresh metadata via `updateUserById`, so a re-seed restores known credentials.
- **`scripts/reset-demo-passwords.ts`** — surgical path resetting ONLY the four demo passwords to `DemoPass123!`, no family-data churn.

## Verified live
Ran the reset against the project; all four demo accounts now sign in with `DemoPass123!` (checked via `signInWithPassword`).

https://claude.ai/code/session_01FgqZNX32XLT6KDudKmsQ9L