### PR TITLE
refactor(validation): derive player-details attribute/service schema from registries

### DIFF
--- a/tests/unit/utils/validation/playerDetailsSchema.registry.spec.ts
+++ b/tests/unit/utils/validation/playerDetailsSchema.registry.spec.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { playerDetailsSchema } from "~/utils/validation/schemas";
+import { ALL_ATTRIBUTE_DEFS } from "~/utils/attributes/canonical";
+import { ALL_SERVICE_DEFS } from "~/utils/services/canonical";
+
+/**
+ * Drift guard: `playerDetailsSchema` strips unknown keys on save (safeParse, no
+ * passthrough), so any registry-backed attribute/service missing from the schema
+ * is silently dropped when the athlete saves it. These tests fail the moment a
+ * registry gains a key the schema doesn't validate — the exact failure mode this
+ * refactor exists to prevent.
+ */
+describe("playerDetailsSchema ↔ registry parity", () => {
+  const shapeKeys = new Set(Object.keys(playerDetailsSchema.shape));
+
+  it("validates every athlete-attribute registry key", () => {
+    const missing = ALL_ATTRIBUTE_DEFS.map((d) => d.key).filter(
+      (k) => !shapeKeys.has(k),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("validates every recruiting-service registry key", () => {
+    const missing = ALL_SERVICE_DEFS.map((d) => d.key).filter(
+      (k) => !shapeKeys.has(k),
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("accepts each attribute's registry option tokens and rejects unknown ones", () => {
+    for (const def of ALL_ATTRIBUTE_DEFS) {
+      for (const token of def.options) {
+        const result = playerDetailsSchema.safeParse({
+          graduation_year: 2027,
+          [def.key]: token,
+        });
+        expect(result.success, `${def.key}=${token} should be valid`).toBe(true);
+      }
+      const bad = playerDetailsSchema.safeParse({
+        graduation_year: 2027,
+        [def.key]: "__not_a_real_token__",
+      });
+      expect(bad.success, `${def.key} should reject a bogus token`).toBe(false);
+    }
+  });
+
+  it("accepts a value for every id-kind service key", () => {
+    for (const def of ALL_SERVICE_DEFS.filter((d) => d.valueKind === "id")) {
+      const result = playerDetailsSchema.safeParse({
+        graduation_year: 2027,
+        [def.key]: "12345",
+      });
+      expect(result.success, `${def.key} should accept an id`).toBe(true);
+    }
+  });
+
+  it("accepts a URL for every url-kind service key", () => {
+    for (const def of ALL_SERVICE_DEFS.filter((d) => d.valueKind === "url")) {
+      const result = playerDetailsSchema.safeParse({
+        graduation_year: 2027,
+        [def.key]: "https://example.com/profile/123",
+      });
+      expect(result.success, `${def.key} should accept a URL`).toBe(true);
+    }
+  });
+});

--- a/utils/services/canonical.ts
+++ b/utils/services/canonical.ts
@@ -37,6 +37,9 @@ export interface ServiceDef {
   /** "Get your profile" sign-up destination. */
   signupUrl: string;
   placeholder: string;
+  /** Max stored length for an `id`-kind value (drives the validation schema).
+   *  Defaults to 50; PBR ids run longer. Ignored for `url`-kind services. */
+  maxLength?: number;
 }
 
 /** Context for `serviceProfileUrl`; a bare string is treated as `{ value }`. */
@@ -131,6 +134,7 @@ const PREP_BASEBALL: ServiceDef = {
   linkKind: "prepBaseball",
   signupUrl: "https://www.prepbaseballreport.com/",
   placeholder: "ID Number",
+  maxLength: 100,
 };
 
 // ── Services v2 ──────────────────────────────────────────────────────────

--- a/utils/validation/schemas.ts
+++ b/utils/validation/schemas.ts
@@ -24,6 +24,8 @@ import {
   strongPasswordSchema,
   weakPasswordSchema,
 } from "./validators";
+import { ALL_ATTRIBUTE_DEFS } from "~/utils/attributes/canonical";
+import { ALL_SERVICE_DEFS } from "~/utils/services/canonical";
 
 // ============================================================================
 // AUTHENTICATION SCHEMAS
@@ -291,27 +293,35 @@ export const offerSchema = z
 // PLAYER DETAILS SCHEMAS
 // ============================================================================
 
+// Per-sport athlete attributes + recruiting services are derived from their
+// registries (single source of truth) rather than hand-listed, so a new registry
+// entry can never be silently stripped on save. See the drift-guard tests in
+// tests/unit/utils/validation/playerDetailsSchema.registry.spec.ts.
+const playerAttributeShapes = Object.fromEntries(
+  ALL_ATTRIBUTE_DEFS.map((def) => [
+    def.key,
+    z
+      .enum(def.options as [string, ...string[]])
+      .nullable()
+      .optional(),
+  ]),
+);
+
+const playerServiceShapes = Object.fromEntries(
+  ALL_SERVICE_DEFS.map((def) => [
+    def.key,
+    def.valueKind === "url"
+      ? urlSchema.nullable().optional()
+      : sanitizedTextSchema(def.maxLength ?? 50),
+  ]),
+);
+
 export const playerDetailsSchema = z.object({
   graduation_year: graduationYearSchema,
   positions: z.array(z.string()).default([]),
   gender: z.enum(["male", "female", "other", "prefer_not_to_say"]).nullable().optional(),
   // Per-sport athlete attributes (registry: utils/attributes/canonical.ts).
-  bats: z.enum(["L", "R", "S"]).nullable().optional(),
-  throws: z.enum(["L", "R"]).nullable().optional(),
-  shooting_hand: z.enum(["L", "R"]).nullable().optional(),
-  dominant_foot: z.enum(["L", "R", "Both"]).nullable().optional(),
-  hitting_hand: z.enum(["L", "R"]).nullable().optional(),
-  racket_hand: z.enum(["L", "R"]).nullable().optional(),
-  backhand_style: z.enum(["one", "two"]).nullable().optional(),
-  golf_handedness: z.enum(["L", "R"]).nullable().optional(),
-  dominant_hand: z.enum(["L", "R"]).nullable().optional(),
-  shoots: z.enum(["L", "R"]).nullable().optional(),
-  catches: z.enum(["L", "R"]).nullable().optional(),
-  wp_dominant_hand: z.enum(["L", "R"]).nullable().optional(),
-  rowing_side: z.enum(["port", "starboard", "both", "cox"]).nullable().optional(),
-  rowing_discipline: z.enum(["sweep", "scull", "both"]).nullable().optional(),
-  throwing_hand: z.enum(["L", "R"]).nullable().optional(),
-  kicking_foot: z.enum(["L", "R"]).nullable().optional(),
+  ...playerAttributeShapes,
   height_inches: heightSchema,
   weight_lbs: weightSchema,
   gpa: gpaSchema,
@@ -326,24 +336,12 @@ export const playerDetailsSchema = z.object({
   tiktok_handle: tiktokHandleSchema,
   facebook_handle: facebookHandleSchema,
   share_contact_with_coaches: z.boolean().default(false),
+  // NCAA Eligibility Center id + generic showcase id — NOT registry-backed
+  // recruiting services, so they stay hand-listed.
   ncaa_id: sanitizedTextSchema(50),
-  // Recruiting services (registry: utils/services/canonical.ts).
-  ncsa_id: sanitizedTextSchema(50),
-  hudl_url: urlSchema.nullable().optional(),
-  perfect_game_id: sanitizedTextSchema(50),
-  prep_baseball_id: sanitizedTextSchema(100),
-  // Recruiting services v2 — free-text ids and full profile URLs.
-  athletic_net_id: sanitizedTextSchema(50),
-  milesplit_url: urlSchema.nullable().optional(),
-  swimcloud_id: sanitizedTextSchema(50),
-  utr_id: sanitizedTextSchema(50),
-  tennis_recruiting_id: sanitizedTextSchema(50),
-  elite_prospects_id: sanitizedTextSchema(50),
-  sportsrecruits_id: sanitizedTextSchema(50),
-  concept2_id: sanitizedTextSchema(50),
-  on3_url: urlSchema.nullable().optional(),
-  sports247_url: urlSchema.nullable().optional(),
   showcase_id: sanitizedTextSchema(50),
+  // Recruiting services (registry: utils/services/canonical.ts).
+  ...playerServiceShapes,
 });
 
 // ============================================================================


### PR DESCRIPTION
## What

`playerDetailsSchema` hand-listed **16 per-sport attribute keys** and **14 recruiting-service keys** that already live in `utils/attributes/canonical.ts` and `utils/services/canonical.ts`.

The schema strips unknown keys on save (`safeParse`, no `.passthrough()`), so a registry entry missing here was **silently dropped when the athlete saved it** — a latent web/iOS parity bug with no error and no failing test.

## Change

Derive both blocks from the registries so they can't drift:
- `playerAttributeShapes` — `z.enum(def.options)` per `ALL_ATTRIBUTE_DEFS`
- `playerServiceShapes` — `urlSchema` (url-kind) / `sanitizedTextSchema` (id-kind) per `ALL_SERVICE_DEFS`; added optional `ServiceDef.maxLength` (`prep_baseball_id` = 100, else 50)

`ncaa_id` and `showcase_id` are not registry-backed services → stay hand-listed. **Derived shapes are byte-identical to the prior hand-listed ones.**

## Drift guard

New tests assert every registry key is validated and each attribute's enum accepts exactly its registry option tokens. Add a registry field, forget the schema → **red test** instead of silent strip on save.

## Scope notes

- `utils/services/canonical.ts` sport-list constants left as-is — reviewer flagged them, but they're single-use named groupings, not duplication. `ALL_SPORTS`-derives-from-vocab is a separate, smaller cleanup.
- **iOS:** none — web server-validation only. iOS already reads its registries directly; this makes web match that registry-is-truth model.

## Testing

- type-check + lint clean
- **7899 unit** pass — incl. 5 new drift-guard tests + 144 existing schema tests, all green (derivation proven byte-compatible)
- e2e: schema-relevant player-details paths pass (API-exists, auth-required, autosave-persist). Two unrelated failures in a local unseeded run — one cold-compile flake (passed on retry), one position-button test that requires `global-setup` to seed `primary_sport=Baseball` (skipped locally; CI seeds and passes it). Neither touches attribute/service validation.

https://claude.ai/code/session_01FgqZNX32XLT6KDudKmsQ9L