### PR TITLE
refactor(performance): extract trend calc + edit modal, drop dead add-form

### DIFF
--- a/components/Performance/EditMetricModal.vue
+++ b/components/Performance/EditMetricModal.vue
@@ -1,0 +1,170 @@
+<template>
+  <div
+    v-if="show && metric"
+    class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+  >
+    <div
+      class="bg-white rounded-lg shadow-lg max-w-2xl w-full max-h-screen overflow-y-auto"
+    >
+      <div
+        class="sticky top-0 bg-white border-b border-gray-200 p-6 flex items-center justify-between"
+      >
+        <h2 class="text-2xl font-bold text-gray-900">
+          Edit Performance Metric
+        </h2>
+        <button
+          @click="emit('close')"
+          aria-label="Close edit metric"
+          class="text-gray-600 hover:text-gray-900"
+        >
+          <UIcon name="i-heroicons-x-mark-solid" class="w-6 h-6" />
+        </button>
+      </div>
+
+      <form @submit.prevent="emit('save')" class="p-6 space-y-6">
+        <!-- Metric Type -->
+        <div>
+          <label
+            for="editMetricType"
+            class="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Metric Type <span class="text-red-600">*</span>
+          </label>
+          <select
+            id="editMetricType"
+            v-model="metric.metric_type"
+            required
+            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          >
+            <option value="">Select Metric</option>
+            <option
+              v-for="opt in metricTypeOptions"
+              :key="opt.value"
+              :value="opt.value"
+            >
+              {{ opt.label }}
+            </option>
+          </select>
+        </div>
+
+        <!-- Value -->
+        <div>
+          <label
+            for="editValue"
+            class="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Value <span class="text-red-600">*</span>
+          </label>
+          <input
+            id="editValue"
+            v-model.number="metric.value"
+            type="number"
+            required
+            step="0.01"
+            placeholder="0.00"
+            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+        </div>
+
+        <!-- Recorded Date -->
+        <div>
+          <label
+            for="editRecordedDate"
+            class="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Date <span class="text-red-600">*</span>
+          </label>
+          <input
+            id="editRecordedDate"
+            v-model="metric.recorded_date"
+            type="date"
+            required
+            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+        </div>
+
+        <!-- Unit -->
+        <div>
+          <label
+            for="editUnit"
+            class="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Unit
+          </label>
+          <input
+            id="editUnit"
+            v-model="metric.unit"
+            type="text"
+            placeholder="e.g., mph, sec, avg"
+            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+        </div>
+
+        <!-- Verified Checkbox -->
+        <div class="flex items-center">
+          <input
+            v-model="metric.verified"
+            type="checkbox"
+            class="w-4 h-4 rounded-sm"
+          />
+          <label class="ml-2 text-sm text-gray-700"
+            >Verified by third party</label
+          >
+        </div>
+
+        <!-- Notes -->
+        <div>
+          <label
+            for="editNotes"
+            class="block text-sm font-medium text-gray-700 mb-1"
+          >
+            Notes
+          </label>
+          <textarea
+            id="editNotes"
+            v-model="metric.notes"
+            rows="3"
+            placeholder="Additional context or observations..."
+            class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          ></textarea>
+        </div>
+
+        <!-- Buttons -->
+        <div class="flex gap-4 justify-end">
+          <button
+            type="button"
+            @click="emit('close')"
+            class="px-6 py-2 bg-gray-200 text-gray-900 font-semibold rounded-lg hover:bg-gray-300 transition"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            :disabled="isUpdating"
+            class="px-6 py-2 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition disabled:opacity-50"
+          >
+            {{ isUpdating ? "Saving..." : "Save Changes" }}
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { PerformanceMetric } from "~/types/models";
+
+defineProps<{
+  show: boolean;
+  metricTypeOptions: { value: string; label: string }[];
+  isUpdating: boolean;
+}>();
+
+const emit = defineEmits<{ save: []; close: [] }>();
+
+// The editing metric is bound two-way so the form mutates the parent's draft copy
+// (the parent already clones the row before opening, so this is a scratch object).
+const metric = defineModel<PerformanceMetric | null>("metric", {
+  required: true,
+});
+</script>

--- a/pages/performance/index.vue
+++ b/pages/performance/index.vue
@@ -273,155 +273,14 @@
         </div>
 
         <!-- Edit Metric Modal -->
-        <div
-          v-if="showEditForm && editingMetric"
-          class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
-        >
-          <div
-            class="bg-white rounded-lg shadow-lg max-w-2xl w-full max-h-screen overflow-y-auto"
-          >
-            <div
-              class="sticky top-0 bg-white border-b border-gray-200 p-6 flex items-center justify-between"
-            >
-              <h2 class="text-2xl font-bold text-gray-900">
-                Edit Performance Metric
-              </h2>
-              <button
-                @click="showEditForm = false"
-                class="text-gray-600 hover:text-gray-900"
-              >
-                <UIcon name="i-heroicons-x-mark-solid" class="w-6 h-6" />
-              </button>
-            </div>
-
-            <form @submit.prevent="handleUpdateMetric" class="p-6 space-y-6">
-              <!-- Metric Type -->
-              <div>
-                <label
-                  for="editMetricType"
-                  class="block text-sm font-medium text-gray-700 mb-1"
-                >
-                  Metric Type <span class="text-red-600">*</span>
-                </label>
-                <select
-                  id="editMetricType"
-                  v-model="editingMetric.metric_type"
-                  required
-                  class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                >
-                  <option value="">Select Metric</option>
-                  <option
-                    v-for="opt in metricTypeOptions"
-                    :key="opt.value"
-                    :value="opt.value"
-                  >
-                    {{ opt.label }}
-                  </option>
-                </select>
-              </div>
-
-              <!-- Value -->
-              <div>
-                <label
-                  for="editValue"
-                  class="block text-sm font-medium text-gray-700 mb-1"
-                >
-                  Value <span class="text-red-600">*</span>
-                </label>
-                <input
-                  id="editValue"
-                  v-model.number="editingMetric.value"
-                  type="number"
-                  required
-                  step="0.01"
-                  placeholder="0.00"
-                  class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                />
-              </div>
-
-              <!-- Recorded Date -->
-              <div>
-                <label
-                  for="editRecordedDate"
-                  class="block text-sm font-medium text-gray-700 mb-1"
-                >
-                  Date <span class="text-red-600">*</span>
-                </label>
-                <input
-                  id="editRecordedDate"
-                  v-model="editingMetric.recorded_date"
-                  type="date"
-                  required
-                  class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                />
-              </div>
-
-              <!-- Unit -->
-              <div>
-                <label
-                  for="editUnit"
-                  class="block text-sm font-medium text-gray-700 mb-1"
-                >
-                  Unit
-                </label>
-                <input
-                  id="editUnit"
-                  v-model="editingMetric.unit"
-                  type="text"
-                  placeholder="e.g., mph, sec, avg"
-                  class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                />
-              </div>
-
-              <!-- Verified Checkbox -->
-              <div class="flex items-center">
-                <input
-                  v-model="editingMetric.verified"
-                  type="checkbox"
-                  class="w-4 h-4 rounded-sm"
-                />
-                <label class="ml-2 text-sm text-gray-700"
-                  >Verified by third party</label
-                >
-              </div>
-
-              <!-- Notes -->
-              <div>
-                <label
-                  for="editNotes"
-                  class="block text-sm font-medium text-gray-700 mb-1"
-                >
-                  Notes
-                </label>
-                <textarea
-                  id="editNotes"
-                  v-model="editingMetric.notes"
-                  rows="3"
-                  placeholder="Additional context or observations..."
-                  class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                />
-              </div>
-
-              <!-- Buttons -->
-              <div class="flex gap-4 justify-end">
-                <button
-                  type="button"
-                  @click="showEditForm = false"
-                  class="px-6 py-2 bg-gray-200 text-gray-900 font-semibold rounded-lg hover:bg-gray-300 transition"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  :disabled="isUpdating"
-                  class="px-6 py-2 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 transition disabled:opacity-50"
-                >
-                  {{ isUpdating ? "Saving..." : "Save Changes" }}
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
+        <PerformanceEditMetricModal
+          v-model:metric="editingMetric"
+          :show="showEditForm"
+          :metric-type-options="metricTypeOptions"
+          :is-updating="isUpdating"
+          @save="handleUpdateMetric"
+          @close="showEditForm = false"
+        />
       </div>
 
       <!-- Export Modal -->
@@ -456,12 +315,13 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, reactive, computed, defineAsyncComponent } from "vue";
+import { ref, onMounted, computed, defineAsyncComponent } from "vue";
 import { formatMetricValue } from "~/utils/metricFormat";
 import {
   metricTypesForSport,
   getMetricDef,
 } from "~/utils/metrics/canonical";
+import { computeMetricTrends } from "~/utils/metricTrends";
 import { usePerformance } from "~/composables/usePerformance";
 import { usePreferenceManager } from "~/composables/usePreferenceManager";
 import { useAppToast } from "~/composables/useAppToast";
@@ -504,10 +364,8 @@ definePageMeta({
 
 const {
   metrics,
-  latestMetrics,
   loading,
   fetchMetrics,
-  createMetric,
   deleteMetric: deleteMetricAPI,
   updateMetric,
   setPrimaryMetric,
@@ -516,7 +374,6 @@ const {
 const { showToast } = useAppToast();
 const { playerPrefs, getPlayerDetails } = usePreferenceManager();
 
-const showAddForm = ref(false);
 const showEditForm = ref(false);
 const showExportModal = ref(false);
 const showLogMetricModal = ref(false);
@@ -524,15 +381,6 @@ const isUpdating = ref(false);
 const editingMetric = ref<PerformanceMetric | null>(null);
 const selectedMetricType = ref("");
 const primarySport = ref<string | null>(null);
-
-const newMetric = reactive({
-  metric_type: "",
-  value: null as number | null,
-  recorded_date: new Date().toISOString().split("T")[0],
-  unit: "",
-  notes: "",
-  verified: false,
-});
 
 const sortedMetrics = computed(() => {
   return [...metrics.value].sort(
@@ -555,63 +403,7 @@ const latestMetricsByType = computed(() => {
   return result;
 });
 
-const metricTrends = computed(() => {
-  const typeGroups: Record<string, PerformanceMetric[]> = {};
-
-  // Group metrics by type
-  metrics.value.forEach((m) => {
-    if (!typeGroups[m.metric_type]) {
-      typeGroups[m.metric_type] = [];
-    }
-    typeGroups[m.metric_type].push(m);
-  });
-
-  // Calculate trends for each type
-  return Object.entries(typeGroups)
-    .filter(([_, records]) => records.length >= 2)
-    .map(([type, records]) => {
-      const sorted = [...records].sort(
-        (a, b) =>
-          new Date(a.recorded_date).getTime() -
-          new Date(b.recorded_date).getTime(),
-      );
-      const values = sorted.map((m) => m.value).slice(-10); // Last 10 records
-      const min = Math.min(...values);
-      const max = Math.max(...values);
-      const avg = values.reduce((a, b) => a + b, 0) / values.length;
-
-      // Determine trend (comparing first 3 to last 3)
-      const first3 = values.slice(0, 3);
-      const last3 = values.slice(-3);
-      const firstAvg = first3.reduce((a, b) => a + b, 0) / first3.length;
-      const lastAvg = last3.reduce((a, b) => a + b, 0) / last3.length;
-
-      // Direction ("lower is better") comes from the metric registry, per sport.
-      const lowerIsBetter = getMetricDef(type).lowerIsBetter;
-      let trend: "improving" | "declining" | "stable";
-
-      if (lowerIsBetter) {
-        if (lastAvg < firstAvg * 0.99) trend = "improving";
-        else if (lastAvg > firstAvg * 1.01) trend = "declining";
-        else trend = "stable";
-      } else {
-        if (lastAvg > firstAvg * 1.01) trend = "improving";
-        else if (lastAvg < firstAvg * 0.99) trend = "declining";
-        else trend = "stable";
-      }
-
-      return {
-        type,
-        values,
-        min: parseFloat(min.toFixed(2)),
-        max: parseFloat(max.toFixed(2)),
-        average: avg,
-        unit: sorted[0].unit || "unit",
-        count: values.length,
-        trend,
-      };
-    });
-});
+const metricTrends = computed(() => computeMetricTrends(metrics.value));
 
 const availableMetricTypes = computed(() => {
   const types = new Set(metrics.value.map((m) => m.metric_type));
@@ -719,33 +511,6 @@ const formatDate = (dateStr: string): string => {
     day: "numeric",
     year: "numeric",
   });
-};
-
-const handleAddMetric = async () => {
-  try {
-    await createMetric({
-      // metric_type is a registry key (any of 17 sports), not a baseball union.
-      metric_type: newMetric.metric_type,
-      value: newMetric.value!,
-      recorded_date: newMetric.recorded_date,
-      unit: newMetric.unit || "unit",
-      notes: newMetric.notes || null,
-      verified: newMetric.verified,
-    });
-
-    // Reset form
-    newMetric.metric_type = "";
-    newMetric.value = null;
-    newMetric.recorded_date = new Date().toISOString().split("T")[0];
-    newMetric.unit = "";
-    newMetric.notes = "";
-    newMetric.verified = false;
-    showAddForm.value = false;
-
-    await fetchMetrics();
-  } catch (err) {
-    logger.error("Failed to log metric", err);
-  }
 };
 
 const handleMetricCreated = async () => {

--- a/tests/unit/components/Performance/EditMetricModal.spec.ts
+++ b/tests/unit/components/Performance/EditMetricModal.spec.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import EditMetricModal from "~/components/Performance/EditMetricModal.vue";
+import type { PerformanceMetric } from "~/types/models";
+
+const baseMetric = {
+  id: "m1",
+  metric_type: "velo",
+  value: 88,
+  recorded_date: "2026-01-05",
+  unit: "mph",
+  verified: false,
+  notes: "",
+} as PerformanceMetric;
+
+const options = [
+  { value: "velo", label: "Velocity (mph)" },
+  { value: "sprint", label: "60-yard (sec)" },
+];
+
+const stubs = { UIcon: true };
+
+function mountModal(overrides: Record<string, unknown> = {}) {
+  return mount(EditMetricModal, {
+    props: {
+      show: true,
+      metric: { ...baseMetric },
+      metricTypeOptions: options,
+      isUpdating: false,
+      ...overrides,
+    },
+    global: { stubs },
+  });
+}
+
+describe("EditMetricModal", () => {
+  it("renders nothing when show is false", () => {
+    const wrapper = mountModal({ show: false });
+    expect(wrapper.find("form").exists()).toBe(false);
+  });
+
+  it("renders nothing when metric is null", () => {
+    const wrapper = mountModal({ metric: null });
+    expect(wrapper.find("form").exists()).toBe(false);
+  });
+
+  it("populates fields from the bound metric", () => {
+    const wrapper = mountModal();
+    expect(
+      (wrapper.find("#editValue").element as HTMLInputElement).value,
+    ).toBe("88");
+    expect(
+      (wrapper.find("#editMetricType").element as HTMLSelectElement).value,
+    ).toBe("velo");
+    expect(
+      (wrapper.find("#editUnit").element as HTMLInputElement).value,
+    ).toBe("mph");
+  });
+
+  it("lists every metric-type option", () => {
+    const wrapper = mountModal();
+    const optionTexts = wrapper
+      .findAll("#editMetricType option")
+      .map((o) => o.text());
+    expect(optionTexts).toContain("Velocity (mph)");
+    expect(optionTexts).toContain("60-yard (sec)");
+  });
+
+  it("emits save on form submit", async () => {
+    const wrapper = mountModal();
+    await wrapper.find("form").trigger("submit");
+    expect(wrapper.emitted("save")).toHaveLength(1);
+  });
+
+  it("emits close on Cancel", async () => {
+    const wrapper = mountModal();
+    await wrapper
+      .findAll("button")
+      .find((b) => b.text() === "Cancel")!
+      .trigger("click");
+    expect(wrapper.emitted("close")).toHaveLength(1);
+  });
+
+  it("edits mutate the bound metric object in place (shared draft)", async () => {
+    // The parent clones the row before opening, so the modal edits that draft
+    // object directly — the value reflects without a full model reassignment.
+    const draft = { ...baseMetric };
+    const wrapper = mount(EditMetricModal, {
+      props: {
+        show: true,
+        metric: draft,
+        metricTypeOptions: options,
+        isUpdating: false,
+      },
+      global: { stubs },
+    });
+    await wrapper.find("#editValue").setValue("92");
+    expect(draft.value).toBe(92);
+  });
+
+  it("disables the save button while updating", () => {
+    const wrapper = mountModal({ isUpdating: true });
+    const save = wrapper
+      .findAll("button")
+      .find((b) => b.text() === "Saving...");
+    expect(save?.attributes("disabled")).toBeDefined();
+  });
+});

--- a/tests/unit/utils/metricTrends.spec.ts
+++ b/tests/unit/utils/metricTrends.spec.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from "vitest";
+import { computeMetricTrends } from "~/utils/metricTrends";
+import type { PerformanceMetric } from "~/types/models";
+
+// Isolate the trend algorithm from registry data: any type starting with "low_"
+// is lower-is-better, everything else higher-is-better.
+vi.mock("~/utils/metrics/canonical", () => ({
+  getMetricDef: (type: string) => ({
+    key: type,
+    lowerIsBetter: type.startsWith("low_"),
+  }),
+}));
+
+let idSeq = 0;
+const metric = (
+  type: string,
+  value: number,
+  recorded_date: string,
+  unit = "mph",
+): PerformanceMetric =>
+  ({
+    id: `m${idSeq++}`,
+    metric_type: type,
+    value,
+    recorded_date,
+    unit,
+  }) as PerformanceMetric;
+
+// Ascending dates so chronological order is unambiguous.
+const day = (n: number) => `2026-01-${String(n).padStart(2, "0")}`;
+
+describe("computeMetricTrends", () => {
+  it("returns [] for no metrics", () => {
+    expect(computeMetricTrends([])).toEqual([]);
+  });
+
+  it("omits a type with only one record", () => {
+    expect(computeMetricTrends([metric("velo", 80, day(1))])).toEqual([]);
+  });
+
+  // Direction compares mean(first 3) to mean(last 3). With <= 3 records those
+  // windows fully overlap → always "stable" (documented quirk of the shipped
+  // algorithm; distinguishing direction needs > 3 records). See explicit test
+  // below. The direction tests therefore use 6 records.
+  it("marks a rising higher-is-better metric as improving", () => {
+    const trend = computeMetricTrends([
+      metric("velo", 80, day(1)),
+      metric("velo", 82, day(2)),
+      metric("velo", 84, day(3)),
+      metric("velo", 90, day(4)),
+      metric("velo", 93, day(5)),
+      metric("velo", 96, day(6)),
+    ])[0];
+    expect(trend.type).toBe("velo");
+    expect(trend.trend).toBe("improving");
+  });
+
+  it("marks a falling higher-is-better metric as declining", () => {
+    const trend = computeMetricTrends([
+      metric("velo", 96, day(1)),
+      metric("velo", 93, day(2)),
+      metric("velo", 90, day(3)),
+      metric("velo", 84, day(4)),
+      metric("velo", 82, day(5)),
+      metric("velo", 80, day(6)),
+    ])[0];
+    expect(trend.trend).toBe("declining");
+  });
+
+  it("inverts direction for a lower-is-better metric (falling time improves)", () => {
+    const trend = computeMetricTrends([
+      metric("low_sprint", 7.5, day(1)),
+      metric("low_sprint", 7.4, day(2)),
+      metric("low_sprint", 7.3, day(3)),
+      metric("low_sprint", 7.0, day(4)),
+      metric("low_sprint", 6.9, day(5)),
+      metric("low_sprint", 6.8, day(6)),
+    ])[0];
+    expect(trend.trend).toBe("improving");
+  });
+
+  it("treats within-1% movement as stable", () => {
+    const trend = computeMetricTrends([
+      metric("velo", 100, day(1)),
+      metric("velo", 100.1, day(2)),
+      metric("velo", 100.2, day(3)),
+      metric("velo", 100.3, day(4)),
+      metric("velo", 100.4, day(5)),
+      metric("velo", 100.5, day(6)),
+    ])[0];
+    expect(trend.trend).toBe("stable");
+  });
+
+  it("reports stable for <= 3 records regardless of movement (shipped quirk)", () => {
+    // first3 and last3 windows fully overlap at 3 records → no direction.
+    const trend = computeMetricTrends([
+      metric("velo", 80, day(1)),
+      metric("velo", 90, day(2)),
+      metric("velo", 100, day(3)),
+    ])[0];
+    expect(trend.trend).toBe("stable");
+  });
+
+  it("caps values at the last 10 records, chronologically", () => {
+    const metrics: PerformanceMetric[] = [];
+    for (let i = 1; i <= 12; i++) metrics.push(metric("velo", i, day(i)));
+    const trend = computeMetricTrends(metrics)[0];
+    expect(trend.values).toHaveLength(10);
+    expect(trend.values[0]).toBe(3); // records 3..12 kept (last 10)
+    expect(trend.values.at(-1)).toBe(12);
+    expect(trend.count).toBe(10);
+  });
+
+  it("sorts unordered input chronologically before deriving", () => {
+    const trend = computeMetricTrends([
+      metric("velo", 96, day(6)),
+      metric("velo", 80, day(1)),
+      metric("velo", 90, day(4)),
+      metric("velo", 84, day(3)),
+      metric("velo", 93, day(5)),
+      metric("velo", 82, day(2)),
+    ])[0];
+    expect(trend.values).toEqual([80, 82, 84, 90, 93, 96]);
+    expect(trend.trend).toBe("improving");
+  });
+
+  it("rounds min/max to 2 decimals and carries the first record's unit", () => {
+    const trend = computeMetricTrends([
+      metric("velo", 80.123, day(1), "mph"),
+      metric("velo", 90.987, day(2), "mph"),
+    ])[0];
+    expect(trend.min).toBe(80.12);
+    expect(trend.max).toBe(90.99);
+    expect(trend.unit).toBe("mph");
+  });
+
+  it("derives independent trends for multiple types", () => {
+    const trends = computeMetricTrends([
+      metric("velo", 80, day(1)),
+      metric("velo", 82, day(2)),
+      metric("velo", 84, day(3)),
+      metric("velo", 90, day(4)),
+      metric("velo", 93, day(5)),
+      metric("velo", 96, day(6)),
+      metric("low_sprint", 7.5, day(1)),
+      metric("low_sprint", 7.4, day(2)),
+      metric("low_sprint", 7.3, day(3)),
+      metric("low_sprint", 7.0, day(4)),
+      metric("low_sprint", 6.9, day(5)),
+      metric("low_sprint", 6.8, day(6)),
+    ]);
+    expect(trends).toHaveLength(2);
+    expect(trends.every((t) => t.trend === "improving")).toBe(true);
+  });
+});

--- a/utils/metricTrends.ts
+++ b/utils/metricTrends.ts
@@ -1,0 +1,83 @@
+/**
+ * Pure metric-trend derivation, extracted from pages/performance/index.vue so the
+ * improving/declining/stable logic is unit-testable in isolation.
+ *
+ * A metric type qualifies once it has >= 2 records. Trend direction compares the
+ * mean of the first 3 records to the mean of the last 3 (chronological), with a
+ * ±1% dead-band → "stable". Whether higher or lower is better comes from the
+ * metric registry per sport (`getMetricDef(type).lowerIsBetter`).
+ */
+
+import { getMetricDef } from "~/utils/metrics/canonical";
+import type { PerformanceMetric } from "~/types/models";
+
+export type MetricTrendDirection = "improving" | "declining" | "stable";
+
+export interface MetricTrend {
+  type: string;
+  /** Chronological values, capped to the last 10 records. */
+  values: number[];
+  min: number;
+  max: number;
+  average: number;
+  unit: string;
+  count: number;
+  trend: MetricTrendDirection;
+}
+
+const mean = (nums: number[]): number =>
+  nums.reduce((a, b) => a + b, 0) / nums.length;
+
+/**
+ * Group metrics by type and derive a trend per type with >= 2 records. Types
+ * with a single record are omitted (no trend to show).
+ */
+export function computeMetricTrends(
+  metrics: readonly PerformanceMetric[],
+): MetricTrend[] {
+  const typeGroups: Record<string, PerformanceMetric[]> = {};
+  for (const m of metrics) {
+    (typeGroups[m.metric_type] ??= []).push(m);
+  }
+
+  return Object.entries(typeGroups)
+    .filter(([, records]) => records.length >= 2)
+    .map(([type, records]) => {
+      const sorted = [...records].sort(
+        (a, b) =>
+          new Date(a.recorded_date).getTime() -
+          new Date(b.recorded_date).getTime(),
+      );
+      const values = sorted.map((m) => m.value).slice(-10); // last 10 records
+      const min = Math.min(...values);
+      const max = Math.max(...values);
+      const average = mean(values);
+
+      const firstAvg = mean(values.slice(0, 3));
+      const lastAvg = mean(values.slice(-3));
+
+      // Direction ("lower is better") comes from the metric registry, per sport.
+      const lowerIsBetter = getMetricDef(type).lowerIsBetter;
+      let trend: MetricTrendDirection;
+      if (lowerIsBetter) {
+        if (lastAvg < firstAvg * 0.99) trend = "improving";
+        else if (lastAvg > firstAvg * 1.01) trend = "declining";
+        else trend = "stable";
+      } else {
+        if (lastAvg > firstAvg * 1.01) trend = "improving";
+        else if (lastAvg < firstAvg * 0.99) trend = "declining";
+        else trend = "stable";
+      }
+
+      return {
+        type,
+        values,
+        min: parseFloat(min.toFixed(2)),
+        max: parseFloat(max.toFixed(2)),
+        average,
+        unit: sorted[0].unit || "unit",
+        count: values.length,
+        trend,
+      };
+    });
+}


### PR DESCRIPTION
## What

`pages/performance/index.vue` was **847 lines** mixing view, an inline edit modal, a 56-line trend algorithm, and dead code.

- **`utils/metricTrends.ts`** — pure `computeMetricTrends(metrics): MetricTrend[]`, extracted verbatim. The improving/declining/stable logic was untestable inside a `computed`; now has **11 unit tests**.
- **`components/Performance/EditMetricModal.vue`** — the ~150-line inline edit modal → component (`v-model:metric` + `save`/`close`). **8 contract tests.**
- **Dead code removed:** `showAddForm`, `newMetric`, `handleAddMetric` (no add-form in template — logging goes through `PerformanceLogMetricModal`), plus unused `latestMetrics` / `createMetric` destructures.

**Page 847 → 612 lines.**

## Notable find

TDD on the extracted algorithm surfaced a **pre-existing quirk**: trend direction compares mean(first 3) vs mean(last 3), so a metric with **≤ 3 records always reads "stable"** regardless of movement (the windows overlap). This is the shipped behavior — captured in a named test, **not changed**. Worth a product decision later (needs >3 records to show a direction).

## Behavior / parity

Behavior-preserving: identical trend output, edit flow, delete/primary/export paths. **iOS unaffected** — pure web extraction, same algorithm.

## Testing

- type-check + lint + `audit:tokens` clean (chart hex `audit-ignore`s untouched)
- **7913 unit** pass — 19 new (11 trends + 8 modal)
- Live smoke: `/performance` renders (H1, Log Metric button, **zero console errors**) via authed direct-nav. (The nav-more-dropdown e2e flaked on the known teleport-dropdown issue before reaching the page — unrelated.)

https://claude.ai/code/session_01FgqZNX32XLT6KDudKmsQ9L