### PR TITLE
feat: sport-aware NCAA recruiting calendar — data + resolver + rewire + refresh (P2/P3/P5)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# The NCAA recruiting-calendar dataset is hand-transcribed from official NCAA
+# PDFs and gates compliance-facing dead/quiet/contact-period logic — changes
+# require the repo owner's review.
+/utils/recruitingCalendar/ @candrikanich

--- a/components/Dashboard/RecruitingCalendar.vue
+++ b/components/Dashboard/RecruitingCalendar.vue
@@ -15,6 +15,72 @@
       <div class="text-sm text-slate-600">Class of {{ graduationYear }}</div>
     </div>
 
+    <!-- Self-select toggle: gender-split sports / Football subdivision, only
+         shown when the stored profile doesn't already resolve one. -->
+    <div v-if="showGenderToggle" class="flex items-center gap-2 mb-4">
+      <span class="text-xs font-medium text-slate-500">Calendar:</span>
+      <div class="inline-flex rounded-lg border border-slate-200 p-0.5 bg-slate-50">
+        <button
+          type="button"
+          data-testid="gender-toggle-men"
+          :class="[
+            'px-3 py-1 text-xs font-medium rounded-md transition-colors',
+            genderOverride === 'male'
+              ? 'bg-white text-slate-900 shadow-sm'
+              : 'text-slate-500 hover:text-slate-700',
+          ]"
+          @click="genderOverride = 'male'"
+        >
+          Men's
+        </button>
+        <button
+          type="button"
+          data-testid="gender-toggle-women"
+          :class="[
+            'px-3 py-1 text-xs font-medium rounded-md transition-colors',
+            genderOverride === 'female'
+              ? 'bg-white text-slate-900 shadow-sm'
+              : 'text-slate-500 hover:text-slate-700',
+          ]"
+          @click="genderOverride = 'female'"
+        >
+          Women's
+        </button>
+      </div>
+    </div>
+
+    <div v-if="showSubdivisionToggle" class="flex items-center gap-2 mb-4">
+      <span class="text-xs font-medium text-slate-500">Calendar:</span>
+      <div class="inline-flex rounded-lg border border-slate-200 p-0.5 bg-slate-50">
+        <button
+          type="button"
+          data-testid="subdivision-toggle-fbs"
+          :class="[
+            'px-3 py-1 text-xs font-medium rounded-md transition-colors',
+            subdivisionOverride === 'FBS'
+              ? 'bg-white text-slate-900 shadow-sm'
+              : 'text-slate-500 hover:text-slate-700',
+          ]"
+          @click="subdivisionOverride = 'FBS'"
+        >
+          FBS
+        </button>
+        <button
+          type="button"
+          data-testid="subdivision-toggle-fcs"
+          :class="[
+            'px-3 py-1 text-xs font-medium rounded-md transition-colors',
+            subdivisionOverride === 'FCS'
+              ? 'bg-white text-slate-900 shadow-sm'
+              : 'text-slate-500 hover:text-slate-700',
+          ]"
+          @click="subdivisionOverride = 'FCS'"
+        >
+          FCS
+        </button>
+      </div>
+    </div>
+
     <!-- Current Period Highlight -->
     <div
       v-if="currentPeriod"
@@ -59,6 +125,13 @@
           <p class="text-xs text-slate-500">{{ formatDate(date.date) }}</p>
         </div>
       </div>
+
+      <div
+        v-if="upcomingDates.length === 0"
+        class="text-sm text-slate-500 py-4 text-center"
+      >
+        No upcoming dates for this sport's calendar.
+      </div>
     </div>
 
     <!-- Division Rules Summary -->
@@ -73,8 +146,8 @@
           <div class="p-3 rounded-xl bg-blue-50 border border-blue-200">
             <p class="font-semibold text-blue-900">Division I</p>
             <p class="text-slate-700 mt-1">
-              Coaches can contact you starting June 15 after sophomore year.
-              Official visits allowed after August 1 before junior year.
+              Contact windows vary by sport — see the current period above for
+              this athlete's calendar.
             </p>
           </div>
           <div class="p-3 rounded-xl bg-emerald-50 border border-emerald-200">
@@ -98,15 +171,70 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { ref, computed } from "vue";
+import {
+  getSportCalendar,
+  getUpcomingMilestones,
+  type AppSport,
+  type Division,
+} from "~/utils/recruitingCalendar";
+import { getMilestoneTypeIcon } from "~/utils/ncaaRecruitingCalendar";
+import { parseLocalDateOnly, exclusiveEndOfDay } from "~/utils/localDate";
 
 interface Props {
   graduationYear?: number;
+  sport?: AppSport;
+  gender?: string | null;
+  division?: Division;
+  footballSubdivision?: "FBS" | "FCS";
 }
 
 const props = withDefaults(defineProps<Props>(), {
   graduationYear: 2028,
+  // "Baseball" preserves this component's pre-sport-aware behavior for any
+  // caller that hasn't been wired to pass the athlete's real sport yet.
+  sport: "Baseball",
+  gender: null,
+  division: "D1",
+  footballSubdivision: "FBS",
 });
+
+const NEUTRAL_GENDERS = new Set(["other", "prefer_not_to_say", null, undefined]);
+
+/**
+ * Sports with distinct men's/women's NCAA calendars — kept in sync with
+ * `GENDER_SPLIT_SPORTS` in `~/utils/recruitingCalendar/resolver.ts`.
+ */
+const GENDER_SPLIT_SPORTS = new Set<AppSport>([
+  "Basketball",
+  "Lacrosse",
+  "Soccer",
+  "Ice Hockey",
+  "Wrestling",
+]);
+
+const genderOverride = ref<"male" | "female">("male");
+const subdivisionOverride = ref<"FBS" | "FCS">("FBS");
+
+const showGenderToggle = computed(
+  () => GENDER_SPLIT_SPORTS.has(props.sport) && NEUTRAL_GENDERS.has(props.gender),
+);
+const showSubdivisionToggle = computed(() => props.sport === "Football");
+
+const effectiveGender = computed<string | null>(() =>
+  showGenderToggle.value ? genderOverride.value : props.gender,
+);
+const effectiveFootballSubdivision = computed(() =>
+  showSubdivisionToggle.value ? subdivisionOverride.value : props.footballSubdivision,
+);
+
+const resolverOpts = computed(() => ({
+  gender: effectiveGender.value,
+  footballSubdivision: effectiveFootballSubdivision.value,
+}));
+
+const today = new Date();
+today.setHours(0, 0, 0, 0);
 
 interface RecruitingDate {
   id: string;
@@ -118,76 +246,17 @@ interface RecruitingDate {
   isUrgent: boolean;
 }
 
-interface RecruitingPeriod {
+interface CurrentPeriodDisplay {
   name: string;
   description: string;
-  startDate: Date;
-  endDate: Date;
 }
 
-const today = new Date();
-today.setHours(0, 0, 0, 0);
-
-// Calculate key dates based on graduation year
-const getKeyDates = () => {
-  const year = props.graduationYear;
-
-  // For a 2028 graduate:
-  // Freshman year: 2024-2025
-  // Sophomore year: 2025-2026 (June 15, 2026 = D1 contact opens)
-  // Junior year: 2026-2027
-  // Senior year: 2027-2028
-
-  const dates = [
-    {
-      id: "contact-opens",
-      name: "D1 Contact Period Opens",
-      description: "Coaches can initiate contact via email/text",
-      date: new Date(year - 2, 5, 15), // June 15, sophomore year
-      emoji: "📧",
-    },
-    {
-      id: "official-visits",
-      name: "Official Visits Allowed",
-      description: "Can take official visits to D1 schools",
-      date: new Date(year - 2, 7, 1), // August 1, before junior year
-      emoji: "✈️",
-    },
-    {
-      id: "junior-fall",
-      name: "Junior Fall Showcase Season",
-      description: "Peak recruiting exposure events",
-      date: new Date(year - 2, 8, 1), // September, junior year
-      emoji: "🎯",
-    },
-    {
-      id: "early-signing",
-      name: "Early Signing Period",
-      description: "NLI can be signed",
-      date: new Date(year - 1, 10, 8), // November, senior year
-      emoji: "✍️",
-    },
-    {
-      id: "regular-signing",
-      name: "Regular Signing Period",
-      description: "Spring signing window opens",
-      date: new Date(year, 3, 15), // April, senior year
-      emoji: "📝",
-    },
-    {
-      id: "graduation",
-      name: "High School Graduation",
-      description: "Class of " + year,
-      date: new Date(year, 4, 31), // May 31
-      emoji: "🎓",
-    },
-  ];
-
-  return dates.map((d) => ({
-    ...d,
-    countdown: getCountdown(d.date),
-    isUrgent: isWithin30Days(d.date),
-  }));
+const PERIOD_TYPE_LABELS: Record<string, string> = {
+  dead: "Dead Period",
+  recruiting_shutdown: "Recruiting Shutdown",
+  quiet: "Quiet Period",
+  contact: "Contact Period",
+  evaluation: "Evaluation Period",
 };
 
 const getCountdown = (date: Date): string => {
@@ -217,48 +286,44 @@ const formatDate = (date: Date): string => {
   });
 };
 
-// Get upcoming dates (filter out past dates, limit to 5)
+// Next key dates: this sport's own resolved SportCalendar milestones plus the
+// still-generic SAT/ACT/NCAA/NAIA/application deadlines, sport/division-scoped.
 const upcomingDates = computed<RecruitingDate[]>(() => {
-  const allDates = getKeyDates();
-  return allDates.filter((d) => d.date >= today).slice(0, 5);
+  const milestones = getUpcomingMilestones({
+    sport: props.sport,
+    division: props.division,
+    graduationYear: props.graduationYear,
+    limit: 5,
+    opts: resolverOpts.value,
+    currentDate: today,
+  });
+
+  return milestones.map((m) => {
+    const date = parseLocalDateOnly(m.date);
+    return {
+      id: `${m.date}-${m.title}`,
+      name: m.title,
+      description: m.description ?? "",
+      date,
+      emoji: getMilestoneTypeIcon(m.type),
+      countdown: getCountdown(date),
+      isUrgent: isWithin30Days(date),
+    };
+  });
 });
 
-// Determine current recruiting period
-const currentPeriod = computed<RecruitingPeriod | null>(() => {
-  const year = props.graduationYear;
-
-  const periods: RecruitingPeriod[] = [
-    {
-      name: "Quiet Period",
-      description:
-        "Focus on academics and skill development. Coaches can respond to your emails.",
-      startDate: new Date(year - 4, 7, 1),
-      endDate: new Date(year - 2, 5, 14),
-    },
-    {
-      name: "Contact Period",
-      description:
-        "Coaches can initiate contact! Be proactive with outreach and responses.",
-      startDate: new Date(year - 2, 5, 15),
-      endDate: new Date(year - 1, 10, 7),
-    },
-    {
-      name: "Early Signing Period",
-      description:
-        "National Letters of Intent can be signed. Make your decision!",
-      startDate: new Date(year - 1, 10, 8),
-      endDate: new Date(year - 1, 10, 15),
-    },
-    {
-      name: "Final Decision Period",
-      description: "Finalize your college choice before spring signing.",
-      startDate: new Date(year - 1, 10, 16),
-      endDate: new Date(year, 3, 14),
-    },
-  ];
-
-  return (
-    periods.find((p) => today >= p.startDate && today <= p.endDate) || null
+// Current period: whichever of this sport's resolved calendar periods covers
+// today, if any.
+const currentPeriod = computed<CurrentPeriodDisplay | null>(() => {
+  const calendar = getSportCalendar(props.sport, props.division, resolverOpts.value);
+  const period = calendar.periods.find(
+    (p) => today >= parseLocalDateOnly(p.start) && today < exclusiveEndOfDay(p.end),
   );
+  if (!period) return null;
+
+  return {
+    name: PERIOD_TYPE_LABELS[period.type] ?? period.type,
+    description: period.description,
+  };
 });
 </script>

--- a/components/Dashboard/RecruitingCalendar.vue
+++ b/components/Dashboard/RecruitingCalendar.vue
@@ -15,6 +15,31 @@
       <div class="text-sm text-slate-600">Class of {{ graduationYear }}</div>
     </div>
 
+    <!-- L6b: staleness banner — only when `now` is past the season this
+         dataset covers and no newer season data has been added. -->
+    <div
+      v-if="isStale"
+      data-testid="calendar-staleness-banner"
+      class="rounded-xl p-3 mb-4 bg-amber-50 border border-amber-200 text-sm text-amber-900"
+    >
+      This calendar may be out of date — verify with your compliance office.
+    </div>
+
+    <!-- L6a: compliance disclaimer — cites the exact NCAA PDF this data was
+         transcribed from and when it was last verified against it. -->
+    <p data-testid="calendar-disclaimer" class="text-xs text-slate-500 mb-4">
+      Based on NCAA {{ SEASON }}, verified {{ resolvedCalendar.verifiedOn }} —
+      confirm with your compliance office.
+      <a
+        :href="resolvedCalendar.source"
+        target="_blank"
+        rel="noopener"
+        class="text-blue-600 hover:text-blue-700 underline"
+      >
+        View official calendar
+      </a>
+    </p>
+
     <!-- Self-select toggle: gender-split sports / Football subdivision, only
          shown when the stored profile doesn't already resolve one. -->
     <div v-if="showGenderToggle" class="flex items-center gap-2 mb-4">
@@ -187,17 +212,28 @@ interface Props {
   gender?: string | null;
   division?: Division;
   footballSubdivision?: "FBS" | "FCS";
+  /** Injectable "now" for the staleness check (L6b) — defaults to real now. */
+  now?: Date;
 }
 
 const props = withDefaults(defineProps<Props>(), {
   graduationYear: 2028,
-  // "Baseball" preserves this component's pre-sport-aware behavior for any
-  // caller that hasn't been wired to pass the athlete's real sport yet.
-  sport: "Baseball",
+  // "Tennis" is this codebase's neutral sport fallback (no published NCAA
+  // recruiting calendar of its own) for any caller not yet wired to pass the
+  // athlete's real sport.
+  sport: "Tennis",
   gender: null,
   division: "D1",
   footballSubdivision: "FBS",
+  now: () => new Date(),
 });
+
+// L6a/L6b: the 2026-27 NCAA calendar dataset this component reads (see
+// utils/recruitingCalendar/calendarData.ts `VERIFIED_ON`/`BUCKET`) and the
+// date it stops being current. Task 7 formalizes a shared `SEASON` const;
+// this local copy is deliberately temporary until that lands.
+const SEASON = "2026-27";
+const SEASON_END = new Date("2027-07-31T23:59:59Z");
 
 const NEUTRAL_GENDERS = new Set(["other", "prefer_not_to_say", null, undefined]);
 
@@ -312,11 +348,22 @@ const upcomingDates = computed<RecruitingDate[]>(() => {
   });
 });
 
+// The resolved SportCalendar this sport/division/gender/subdivision
+// combination reads from — shared by the current-period lookup and the L6a
+// disclaimer (source PDF + verifiedOn).
+const resolvedCalendar = computed(() =>
+  getSportCalendar(props.sport, props.division, resolverOpts.value),
+);
+
+// L6b: stale once `now` is past the season this dataset covers. There is
+// currently only one dataset (2026-27), so "no newer data exists" always
+// holds — revisit this check if/when a second season's data is added.
+const isStale = computed(() => props.now.getTime() > SEASON_END.getTime());
+
 // Current period: whichever of this sport's resolved calendar periods covers
 // today, if any.
 const currentPeriod = computed<CurrentPeriodDisplay | null>(() => {
-  const calendar = getSportCalendar(props.sport, props.division, resolverOpts.value);
-  const period = calendar.periods.find(
+  const period = resolvedCalendar.value.periods.find(
     (p) => today >= parseLocalDateOnly(p.start) && today < exclusiveEndOfDay(p.end),
   );
   if (!period) return null;

--- a/components/Dashboard/RecruitingCalendar.vue
+++ b/components/Dashboard/RecruitingCalendar.vue
@@ -206,6 +206,7 @@ import {
   SEASON_END,
   type AppSport,
   type Division,
+  type RecruitingPeriod,
 } from "~/utils/recruitingCalendar";
 import { getMilestoneTypeIcon } from "~/utils/ncaaRecruitingCalendar";
 import { parseLocalDateOnly, exclusiveEndOfDay } from "~/utils/localDate";
@@ -347,13 +348,42 @@ const resolvedCalendar = computed(() =>
 // holds — revisit this check if/when a second season's data is added.
 const isStale = computed(() => props.now.getTime() > SEASON_END.getTime());
 
-// Current period: whichever of this sport's resolved calendar periods covers
-// today, if any.
+// Severity rank for picking which period to display when today falls inside
+// MULTIPLE overlapping windows (the data lists broad periods before their
+// nested carve-outs — e.g. a Dead or Recruiting Shutdown day nested inside a
+// wider Contact/Quiet window). Always surface the MOST restrictive match —
+// showing a less-restrictive enclosing period on a dead/shutdown day would
+// wrongly tell the athlete contact is OK. This ranking is display-only; the
+// enforcement path (isDeadPeriod/getDeadPeriodMessage in resolver.ts) is
+// already order-independent via BLOCKING_TYPES and must not change.
+const PERIOD_SEVERITY: Record<RecruitingPeriod["type"], number> = {
+  recruiting_shutdown: 5,
+  dead: 4,
+  evaluation: 3,
+  quiet: 2,
+  contact: 1,
+};
+
+const periodSpanDays = (p: RecruitingPeriod): number =>
+  (parseLocalDateOnly(p.end).getTime() - parseLocalDateOnly(p.start).getTime()) / (1000 * 60 * 60 * 24);
+
+// Current period: the MOST RESTRICTIVE of this sport's resolved calendar
+// periods covering today, if any (see PERIOD_SEVERITY above); ties broken by
+// shortest span.
 const currentPeriod = computed<CurrentPeriodDisplay | null>(() => {
-  const period = resolvedCalendar.value.periods.find(
+  const matches = resolvedCalendar.value.periods.filter(
     (p) => today >= parseLocalDateOnly(p.start) && today < exclusiveEndOfDay(p.end),
   );
-  if (!period) return null;
+  if (matches.length === 0) return null;
+
+  const period = matches.reduce((best, candidate) => {
+    const bestSeverity = PERIOD_SEVERITY[best.type] ?? 0;
+    const candidateSeverity = PERIOD_SEVERITY[candidate.type] ?? 0;
+    if (candidateSeverity !== bestSeverity) {
+      return candidateSeverity > bestSeverity ? candidate : best;
+    }
+    return periodSpanDays(candidate) < periodSpanDays(best) ? candidate : best;
+  });
 
   return {
     name: PERIOD_TYPE_LABELS[period.type] ?? period.type,

--- a/components/Dashboard/RecruitingCalendar.vue
+++ b/components/Dashboard/RecruitingCalendar.vue
@@ -200,6 +200,10 @@ import { ref, computed } from "vue";
 import {
   getSportCalendar,
   getUpcomingMilestones,
+  GENDER_SPLIT_SPORTS,
+  NO_SPORT_FALLBACK,
+  SEASON,
+  SEASON_END,
   type AppSport,
   type Division,
 } from "~/utils/recruitingCalendar";
@@ -218,42 +222,25 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   graduationYear: 2028,
-  // "Tennis" is this codebase's neutral sport fallback (no published NCAA
-  // recruiting calendar of its own) for any caller not yet wired to pass the
-  // athlete's real sport.
-  sport: "Tennis",
+  sport: NO_SPORT_FALLBACK,
   gender: null,
   division: "D1",
   footballSubdivision: "FBS",
   now: () => new Date(),
 });
 
-// L6a/L6b: the 2026-27 NCAA calendar dataset this component reads (see
+// L6a/L6b: `SEASON`/`SEASON_END` (from `~/utils/recruitingCalendar`) name the
+// NCAA calendar dataset this component reads (see
 // utils/recruitingCalendar/calendarData.ts `VERIFIED_ON`/`BUCKET`) and the
-// date it stops being current. Task 7 formalizes a shared `SEASON` const;
-// this local copy is deliberately temporary until that lands.
-const SEASON = "2026-27";
-const SEASON_END = new Date("2027-07-31T23:59:59Z");
+// date it stops being current.
 
 const NEUTRAL_GENDERS = new Set(["other", "prefer_not_to_say", null, undefined]);
-
-/**
- * Sports with distinct men's/women's NCAA calendars — kept in sync with
- * `GENDER_SPLIT_SPORTS` in `~/utils/recruitingCalendar/resolver.ts`.
- */
-const GENDER_SPLIT_SPORTS = new Set<AppSport>([
-  "Basketball",
-  "Lacrosse",
-  "Soccer",
-  "Ice Hockey",
-  "Wrestling",
-]);
 
 const genderOverride = ref<"male" | "female">("male");
 const subdivisionOverride = ref<"FBS" | "FCS">("FBS");
 
 const showGenderToggle = computed(
-  () => GENDER_SPLIT_SPORTS.has(props.sport) && NEUTRAL_GENDERS.has(props.gender),
+  () => props.sport in GENDER_SPLIT_SPORTS && NEUTRAL_GENDERS.has(props.gender),
 );
 const showSubdivisionToggle = computed(() => props.sport === "Football");
 

--- a/docs/recruiting-calendar-refresh.md
+++ b/docs/recruiting-calendar-refresh.md
@@ -1,0 +1,30 @@
+# NCAA Recruiting Calendar — Annual Refresh Procedure
+
+The sport recruiting calendars in `utils/recruitingCalendar/` are **hand-transcribed** from the official NCAA Division I recruiting-calendar PDFs for a single season (the `SEASON` constant there — currently `2026-27`). NCAA publishes each next season's PDFs to the same S3 bucket, usually in **spring/summer**. When that happens the data must be re-transcribed and `SEASON` bumped. This is deliberate — the PDFs are graphical grids and the dates are compliance-sensitive, so we do **not** auto-parse them.
+
+## The checker
+
+`scripts/check-ncaa-calendar-cycle.mjs` HEAD-checks whether the next season's PDFs are live yet.
+
+```bash
+node scripts/check-ncaa-calendar-cycle.mjs           # checks NEXT_SEASON (default)
+node scripts/check-ncaa-calendar-cycle.mjs 2026-27   # sanity-check the current cycle
+```
+
+It prints a per-code ✓/✗ table and a machine-readable `RESULT: {json}` last line (`cycleAvailable`, `foundCodes`, `urls`). Exit code is always 0 — it's a checker, not a gate.
+
+## The quarterly routine
+
+A scheduled Claude Code routine runs the checker quarterly. When `cycleAvailable` is true (next-season PDFs exist), it opens a GitHub issue pre-filled with the live PDF URLs so a human can re-transcribe. It never edits calendar data itself.
+
+## When the next cycle drops — re-transcription steps
+
+1. Run the checker for the new season; confirm the PDFs are live.
+2. For each calendar, download the PDF and read it via a **render/vision** path (plain text extraction returns nothing from these graphical PDFs). Transcribe every dead/quiet/contact/evaluation/recruiting_shutdown window + signing milestones into `utils/recruitingCalendar/calendarData.ts`, preserving `type`/`start`/`end`/`description`/`confidence` and each calendar's `source` URL + `verifiedOn`.
+3. Cross-check each window against the PDF's own day-grid (internal redundancy) and the prior-year same-sport PDF (structural). No independent second source exists at release time — most dates will be single-authoritative-source (MEDIUM confidence); anchors/holidays are HIGH.
+4. Bump `SEASON` / `SEASON_END` (and `CURRENT_SEASON`/`NEXT_SEASON` in the checker script).
+5. The integrity + plausibility tests (`tests/unit/utils/recruitingCalendar/calendarData.spec.ts`) will catch fat-finger errors — fix the datum, never weaken the test.
+6. Port the identical values to the iOS `Core/Utilities/RecruitingCalendar*.swift` (byte-identical parity; the per-key period-count parity test guards it).
+7. `.github/CODEOWNERS` gates `utils/recruitingCalendar/**` — the change goes through PR review.
+
+**Accuracy note:** the runtime compliance disclaimer + the link to the official NCAA PDF are load-bearing given single-source data. Keep them.

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -177,7 +177,7 @@ import { useRecruitingPacket } from "~/composables/useRecruitingPacket";
 import { useDashboardData } from "~/composables/useDashboardData";
 import { useDashboardCalculations } from "~/composables/useDashboardCalculations";
 import { usePreferenceManager } from "~/composables/usePreferenceManager";
-import { getDeadPeriodMessage, type AppSport } from "~/utils/recruitingCalendar";
+import { getDeadPeriodMessage, NO_SPORT_FALLBACK, type AppSport } from "~/utils/recruitingCalendar";
 import { WIDGET_SIZES } from "~/types/models";
 import type { WidgetId, WidgetEntry } from "~/types/models";
 import ParentContextBanner from "~/components/Dashboard/ParentContextBanner.vue";
@@ -201,11 +201,10 @@ const { getDashboardLayout, dashboardPrefs, playerPrefs, getPlayerDetails } =
 const dashboardLayout = computed(() => getDashboardLayout());
 
 // Athlete's sport/gender for sport-aware NCAA recruiting-calendar rules.
-// Mirrors the ruleEngine fallback (server/utils/ruleEngine.ts): "Tennis" has
-// no published NCAA calendar, so an unset sport never falsely reports a
-// dead period.
+// Mirrors the ruleEngine fallback (server/utils/ruleEngine.ts): an unset
+// sport never falsely reports a dead period.
 const athleteSport = computed<AppSport>(
-  () => (getPlayerDetails()?.primary_sport as AppSport | undefined) ?? "Tennis",
+  () => (getPlayerDetails()?.primary_sport as AppSport | undefined) ?? NO_SPORT_FALLBACK,
 );
 const athleteGender = computed<string | null>(
   () => getPlayerDetails()?.gender ?? null,

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -124,6 +124,15 @@
             @generate-packet="handleGeneratePacket"
           />
 
+          <!-- Sport-aware NCAA recruiting calendar (contact periods, key
+               dates), same sport/gender source as the dead-period banner
+               above. -->
+          <RecruitingCalendar
+            :graduation-year="getPlayerDetails()?.graduation_year"
+            :sport="athleteSport"
+            :gender="athleteGender"
+          />
+
           <!-- Dynamic right column widgets -->
           <template v-for="entry in rightColumnVisible" :key="entry.id">
             <Suspense>
@@ -179,6 +188,7 @@ import DashboardSuggestions from "~/components/Dashboard/DashboardSuggestions.vu
 import DashboardRecruitingPacketWidget from "~/components/Dashboard/RecruitingPacketWidget.vue";
 import DashboardContactFrequencyWidget from "~/components/Dashboard/ContactFrequencyWidget.vue";
 import DashboardAthleteActivityWidget from "~/components/Dashboard/AthleteActivityWidget.vue";
+import RecruitingCalendar from "~/components/Dashboard/RecruitingCalendar.vue";
 
 definePageMeta({
   middleware: "auth",

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -168,7 +168,7 @@ import { useRecruitingPacket } from "~/composables/useRecruitingPacket";
 import { useDashboardData } from "~/composables/useDashboardData";
 import { useDashboardCalculations } from "~/composables/useDashboardCalculations";
 import { usePreferenceManager } from "~/composables/usePreferenceManager";
-import { getDeadPeriodMessage } from "~/utils/ncaaRecruitingCalendar";
+import { getDeadPeriodMessage, type AppSport } from "~/utils/recruitingCalendar";
 import { WIDGET_SIZES } from "~/types/models";
 import type { WidgetId, WidgetEntry } from "~/types/models";
 import ParentContextBanner from "~/components/Dashboard/ParentContextBanner.vue";
@@ -186,8 +186,20 @@ definePageMeta({
 
 const logger = createClientLogger("dashboard");
 
-const { getDashboardLayout, dashboardPrefs } = usePreferenceManager();
+const { getDashboardLayout, dashboardPrefs, playerPrefs, getPlayerDetails } =
+  usePreferenceManager();
 const dashboardLayout = computed(() => getDashboardLayout());
+
+// Athlete's sport/gender for sport-aware NCAA recruiting-calendar rules.
+// Mirrors the ruleEngine fallback (server/utils/ruleEngine.ts): "Tennis" has
+// no published NCAA calendar, so an unset sport never falsely reports a
+// dead period.
+const athleteSport = computed<AppSport>(
+  () => (getPlayerDetails()?.primary_sport as AppSport | undefined) ?? "Tennis",
+);
+const athleteGender = computed<string | null>(
+  () => getPlayerDetails()?.gender ?? null,
+);
 
 const { logout } = useAuth();
 const { showToast } = useAppToast();
@@ -225,11 +237,15 @@ const {
 const deadPeriodMessage = computed((): string | null => {
   if (!allSchools.value.length) return null;
   const now = new Date();
+  const sport = athleteSport.value;
+  const opts = { gender: athleteGender.value };
   const allInDeadPeriod = allSchools.value.every((school) => {
     const div = (school.division as string) || "D1";
-    return !!getDeadPeriodMessage(now, div as "D1" | "D2" | "D3");
+    return !!getDeadPeriodMessage(now, sport, div as "D1" | "D2" | "D3", opts);
   });
-  return allInDeadPeriod ? (getDeadPeriodMessage(now, "D1") ?? null) : null;
+  return allInDeadPeriod
+    ? (getDeadPeriodMessage(now, sport, "D1", opts) ?? null)
+    : null;
 });
 
 const suggestionsMoreCount = computed(
@@ -510,6 +526,6 @@ watch(
 );
 
 onMounted(async () => {
-  await dashboardPrefs.loadPreferences();
+  await Promise.all([dashboardPrefs.loadPreferences(), playerPrefs.loadPreferences()]);
 });
 </script>

--- a/pages/timeline/index.vue
+++ b/pages/timeline/index.vue
@@ -162,6 +162,11 @@
               :collapsed="milestonesCollapsed"
               @toggle="milestonesCollapsed = !milestonesCollapsed"
             />
+            <RecruitingCalendar
+              :graduation-year="athleteGraduationYear"
+              :sport="athleteSport"
+              :gender="athleteGender"
+            />
             <CommonWorries
               :worries="commonWorries"
               :collapsed="worriesCollapsed"
@@ -223,6 +228,7 @@ import WhatMattersNow from "~/components/Timeline/WhatMattersNow.vue";
 import CommonWorries from "~/components/Timeline/CommonWorries.vue";
 import WhatNotToStress from "~/components/Timeline/WhatNotToStress.vue";
 import UpcomingMilestones from "~/components/Timeline/UpcomingMilestones.vue";
+import RecruitingCalendar from "~/components/Dashboard/RecruitingCalendar.vue";
 import { getWhatMattersNow } from "~/utils/whatMattersNow";
 import { getCommonWorries } from "~/utils/parentWorries";
 import { getReassuranceMessages } from "~/utils/parentReassurance";

--- a/pages/timeline/index.vue
+++ b/pages/timeline/index.vue
@@ -233,7 +233,7 @@ import { getWhatMattersNow } from "~/utils/whatMattersNow";
 import { getCommonWorries } from "~/utils/parentWorries";
 import { getReassuranceMessages } from "~/utils/parentReassurance";
 import { createClientLogger } from "~/utils/logger";
-import { getUpcomingMilestones, type AppSport } from "~/utils/recruitingCalendar";
+import { getUpcomingMilestones, NO_SPORT_FALLBACK, type AppSport } from "~/utils/recruitingCalendar";
 import { usePreferenceManager } from "~/composables/usePreferenceManager";
 
 const logger = createClientLogger("Timeline");
@@ -337,10 +337,10 @@ const reassuranceMessages = computed(() =>
   getReassuranceMessages(currentPhase.value),
 );
 
-// Mirrors the ruleEngine/dashboard fallback: "Tennis" has no published NCAA
-// calendar, so an unset sport never falsely surfaces sport-specific windows.
+// Mirrors the ruleEngine/dashboard fallback: an unset sport never falsely
+// surfaces sport-specific windows.
 const athleteSport = computed<AppSport>(
-  () => (getPlayerDetails()?.primary_sport as AppSport | undefined) ?? "Tennis",
+  () => (getPlayerDetails()?.primary_sport as AppSport | undefined) ?? NO_SPORT_FALLBACK,
 );
 const athleteGender = computed<string | null>(
   () => getPlayerDetails()?.gender ?? null,

--- a/pages/timeline/index.vue
+++ b/pages/timeline/index.vue
@@ -227,7 +227,8 @@ import { getWhatMattersNow } from "~/utils/whatMattersNow";
 import { getCommonWorries } from "~/utils/parentWorries";
 import { getReassuranceMessages } from "~/utils/parentReassurance";
 import { createClientLogger } from "~/utils/logger";
-import { getUpcomingMilestones } from "~/utils/ncaaRecruitingCalendar";
+import { getUpcomingMilestones, type AppSport } from "~/utils/recruitingCalendar";
+import { usePreferenceManager } from "~/composables/usePreferenceManager";
 
 const logger = createClientLogger("Timeline");
 
@@ -244,6 +245,7 @@ const {
   fetchTasksWithStatus,
 } = useTasks();
 const { showToast } = useAppToast();
+const { getPlayerDetails, playerPrefs } = usePreferenceManager();
 const {
   currentPhase,
   milestoneProgress,
@@ -329,12 +331,26 @@ const reassuranceMessages = computed(() =>
   getReassuranceMessages(currentPhase.value),
 );
 
+// Mirrors the ruleEngine/dashboard fallback: "Tennis" has no published NCAA
+// calendar, so an unset sport never falsely surfaces sport-specific windows.
+const athleteSport = computed<AppSport>(
+  () => (getPlayerDetails()?.primary_sport as AppSport | undefined) ?? "Tennis",
+);
+const athleteGender = computed<string | null>(
+  () => getPlayerDetails()?.gender ?? null,
+);
+const athleteGraduationYear = computed(
+  () => getPlayerDetails()?.graduation_year,
+);
+
 const upcomingMilestones = computed(() =>
   getUpcomingMilestones({
     currentDate: new Date(),
-    phase: currentPhase.value,
-    graduationYear: 2027, // TODO: Get from user profile via graduation_year field
+    sport: athleteSport.value,
+    division: "D1",
+    graduationYear: athleteGraduationYear.value,
     limit: 5,
+    opts: { gender: athleteGender.value },
   }),
 );
 
@@ -434,7 +450,12 @@ const getStatusColorClass = (label: StatusLabel): string => {
 
 // Lifecycle
 onMounted(async () => {
-  await Promise.all([fetchTasksWithStatus(), fetchPhase(), fetchStatusScore()]);
+  await Promise.all([
+    fetchTasksWithStatus(),
+    fetchPhase(),
+    fetchStatusScore(),
+    playerPrefs.loadPreferences(),
+  ]);
   initialLoadComplete.value = true;
   initializeExpanded();
 });

--- a/scripts/check-ncaa-calendar-cycle.mjs
+++ b/scripts/check-ncaa-calendar-cycle.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * Phase 5 — NCAA recruiting-calendar refresh checker.
+ *
+ * The sport calendars in utils/recruitingCalendar/ are hand-transcribed from the
+ * official NCAA D1 PDFs for ONE season (see SEASON there). NCAA publishes the next
+ * season's PDFs each spring/summer to the same S3 bucket. This script HEAD-checks
+ * whether the NEXT season's PDFs exist yet. It does NOT parse or auto-update dates
+ * (graphical PDFs; compliance-sensitive) — it only tells a human it's time to
+ * re-transcribe. A scheduled routine runs it quarterly and opens a GitHub issue
+ * when the next cycle appears.
+ *
+ * Usage: node scripts/check-ncaa-calendar-cycle.mjs [SEASON]
+ *   SEASON defaults to NEXT_SEASON below. Pass e.g. "2026-27" to sanity-check the
+ *   current (already-transcribed) cycle — it should report all found.
+ *
+ * Exit code: 0 always (a checker, not a gate). Machine-readable result on the last
+ * stdout line as `RESULT: <json>` so a routine can act on it.
+ */
+
+const BUCKET =
+  "https://ncaaorg.s3.amazonaws.com/compliance/recruiting/calendar";
+
+// The season currently transcribed into utils/recruitingCalendar/. Bump when you
+// re-transcribe. (Kept here rather than imported so this script stays dependency-free.)
+const CURRENT_SEASON = "2026-27";
+const NEXT_SEASON = "2027-28";
+
+/** Build the D1 per-sport PDF URLs for a season. Mirrors the real NCAA filenames. */
+export function d1Urls(season) {
+  // Most codes follow {season}D1Rec_{CODE}RecruitingCalendar.pdf.
+  const codes = ["MBA", "WSB", "MBB", "WBB", "XCTF", "WVB", "MGO", "MLA", "WLA"];
+  const urls = codes.map((code) => ({
+    code,
+    url: `${BUCKET}/${season}/${season}D1Rec_${code}RecruitingCalendar.pdf`,
+  }));
+  // Football breaks the infix mold: FBS/FCS (no MFB).
+  urls.push({ code: "FBS", url: `${BUCKET}/${season}/${season}D1Rec_FBSRecruitingCalendar.pdf` });
+  urls.push({ code: "FCS", url: `${BUCKET}/${season}/${season}D1Rec_FCSRecruitingCalendar.pdf` });
+  // The "Other Sports" catch-all uses an EN-DASH (U+2013) in the year in the filename
+  // (verified: the ASCII-hyphen variant 404s).
+  const enDashSeason = season.replace("-", "–");
+  urls.push({
+    code: "Other",
+    url: `${BUCKET}/${season}/${enDashSeason}D1Rec_OtherRecruitingCalendar.pdf`,
+  });
+  // D2 combined all-sports calendar.
+  urls.push({
+    code: "D2_ALL",
+    url: `${BUCKET}/${season}/${season}D2Rec_RecruitingCalendar_AllSports.pdf`,
+  });
+  return urls;
+}
+
+async function headOk(url) {
+  try {
+    const res = await fetch(url, { method: "HEAD", redirect: "manual" });
+    return res.status;
+  } catch (err) {
+    return `ERR:${err?.message ?? "fetch failed"}`;
+  }
+}
+
+async function main() {
+  const season = process.argv[2] || NEXT_SEASON;
+  const targets = d1Urls(season);
+  const results = await Promise.all(
+    targets.map(async (t) => ({ ...t, status: await headOk(t.url) })),
+  );
+
+  const found = results.filter((r) => r.status === 200);
+  const missing = results.filter((r) => r.status !== 200);
+
+  console.log(`NCAA calendar cycle check — season ${season}`);
+  console.log(`  transcribed season: ${CURRENT_SEASON}`);
+  console.log(`  found ${found.length}/${results.length} published PDFs`);
+  for (const r of results) {
+    console.log(`   ${r.status === 200 ? "✓" : "✗"} ${r.code}  (${r.status})  ${r.url}`);
+  }
+
+  const cycleAvailable = season !== CURRENT_SEASON && found.length > 0;
+  if (cycleAvailable) {
+    console.log(
+      `\n⚠️  ${found.length} PDF(s) for ${season} are live — time to re-transcribe utils/recruitingCalendar/ and bump SEASON.`,
+    );
+  } else if (season === CURRENT_SEASON) {
+    console.log(`\n(sanity check of the current transcribed season)`);
+  } else {
+    console.log(`\nNo ${season} PDFs published yet — nothing to do.`);
+  }
+
+  console.log(
+    `RESULT: ${JSON.stringify({
+      season,
+      currentSeason: CURRENT_SEASON,
+      total: results.length,
+      found: found.length,
+      cycleAvailable,
+      foundCodes: found.map((r) => r.code),
+      urls: found.map((r) => r.url),
+    })}`,
+  );
+}
+
+const invokedDirectly =
+  process.argv[1] && process.argv[1].endsWith("check-ncaa-calendar-cycle.mjs");
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error("check failed:", err);
+    console.log(`RESULT: ${JSON.stringify({ error: String(err) })}`);
+    process.exit(0);
+  });
+}

--- a/scripts/seed-system-calendar.ts
+++ b/scripts/seed-system-calendar.ts
@@ -1,9 +1,18 @@
 // Run with: npx tsx scripts/seed-system-calendar.ts
+//
+// TODO(sport-aware-calendar): `system_calendar` is not queried anywhere in
+// app code (grepped 2026-08-23 — only this script writes to it; the table
+// exists from migration 20260318000001 but has no reader). This script is
+// effectively orphaned. It previously seeded ONLY baseball's D1 periods
+// (hardcoded `sport: "baseball"`), so this rewire preserves that exact
+// scope — pulling from the new sport-aware module's `D1_CALENDARS.MBA`
+// (baseball's D1 calendar) instead of the removed `RECRUITING_CALENDAR_2026`
+// constant — rather than inventing a new all-sports seeding scheme. If a
+// future task wires a reader for `system_calendar`, revisit whether it
+// should seed every sport's D1 calendar (`D1_CALENDARS`) instead.
 import { createClient } from "@supabase/supabase-js";
-import {
-  RECRUITING_CALENDAR_2026,
-  ALL_MILESTONES,
-} from "../server/utils/ncaaRecruitingCalendar";
+import { ALL_MILESTONES } from "../server/utils/ncaaRecruitingCalendar";
+import { D1_CALENDARS } from "../utils/recruitingCalendar";
 
 const supabase = createClient(
   process.env.NUXT_PUBLIC_SUPABASE_URL!,
@@ -14,6 +23,10 @@ const supabase = createClient(
 function periodCategory(type: string): string {
   const map: Record<string, string> = {
     dead: "dead_period",
+    // recruiting_shutdown is the stricter dead-period variant (no calls/
+    // texts/correspondence either) — buckets with "dead" here, same as
+    // ruleEngine's contact-gating treats them as equally blocking.
+    recruiting_shutdown: "dead_period",
     quiet: "quiet_period",
     contact: "contact_period",
     evaluation: "evaluation_period",
@@ -45,15 +58,17 @@ function normalizeDivision(div: string | undefined | null): string | null {
   return map[div] ?? null; // ALL, NAIA, JUCO → null
 }
 
-const periodRows = RECRUITING_CALENDAR_2026.map((p) => ({
+// Baseball's D1 calendar only — matches this script's pre-existing scope
+// (see TODO above). Periods carry no per-period division in the new module
+// (division is a property of which calendar you resolved, not the period
+// itself) — MBA is D1-only, so it's hardcoded here same as before.
+const periodRows = D1_CALENDARS.MBA.periods.map((p) => ({
   category: periodCategory(p.type),
   sport: "baseball",
-  division: normalizeDivision(p.division),
+  division: normalizeDivision("D1"),
   label: p.description,
-  // eslint-disable-next-line local/no-date-only-string-constructor -- pre-existing pattern outside Phase 7's assigned sweep (planning/audit-2026-07-27-findings.md cluster); flagged for a follow-up pass, not fixed here to keep this phase scoped.
-  start_date: p.start.toISOString().split("T")[0],
-  // eslint-disable-next-line local/no-date-only-string-constructor -- pre-existing pattern outside Phase 7's assigned sweep (planning/audit-2026-07-27-findings.md cluster); flagged for a follow-up pass, not fixed here to keep this phase scoped.
-  end_date: p.end.toISOString().split("T")[0],
+  start_date: p.start,
+  end_date: p.end,
   season_year: 2026,
 }));
 

--- a/server/api/suggestions/evaluate.post.ts
+++ b/server/api/suggestions/evaluate.post.ts
@@ -10,6 +10,7 @@ import { useLogger } from "~/server/utils/logger";
 import { RuleEngine } from "~/server/utils/ruleEngine";
 import { requireAuth, assertNotParent } from "~/server/utils/auth";
 import type { RuleContext } from "~/server/utils/rules/index";
+import type { AppSport } from "~/utils/recruitingCalendar";
 import { calculateCurrentGrade } from "~/utils/gradeHelpers";
 import { interactionGapRule } from "~/server/utils/rules/interactionGap";
 import { missingVideoRule } from "~/server/utils/rules/missingVideo";
@@ -92,6 +93,14 @@ export default defineEventHandler(async (event) => {
     const gradeLevel = graduationYear
       ? calculateCurrentGrade(graduationYear)
       : 9;
+    const sport =
+      typeof playerData?.primary_sport === "string"
+        ? (playerData.primary_sport as AppSport)
+        : undefined;
+    const gender =
+      typeof playerData?.gender === "string"
+        ? (playerData.gender as string)
+        : null;
 
     const context: RuleContext = {
       athleteId,
@@ -102,6 +111,8 @@ export default defineEventHandler(async (event) => {
       athleteTasks: athleteTasks.data || [],
       videos: videos.data || [],
       events: events.data || [],
+      sport,
+      gender,
     };
 
     const engine = new RuleEngine([

--- a/server/utils/ruleEngine.ts
+++ b/server/utils/ruleEngine.ts
@@ -5,7 +5,7 @@ const logger = createLogger("rule-engine");
 import { findExistingSuggestion } from "./rules/index";
 import type { SuggestionData, Suggestion, Urgency } from "~/types/timeline";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { isDeadPeriod } from "./ncaaRecruitingCalendar";
+import { isDeadPeriod, type AppSport } from "~/utils/recruitingCalendar";
 import { escalateUrgency } from "./rules/ruleEngineHelpers";
 
 const CONTACT_RULES = [
@@ -58,6 +58,14 @@ export class RuleEngine {
     const succeededRuleTypes: string[] = [];
     const now = new Date();
 
+    // Sport-aware NCAA calendars are keyed by AppSport; a context built
+    // without a sport (legacy callers, sport-agnostic rule tests) falls back
+    // to "Tennis", which has no dedicated NCAA sub-calendar and resolves to
+    // the generic "Other" track — the least-restrictive, lowest-surprise
+    // default (matches the D2/D3 fallback calendars' own choice).
+    const sport: AppSport = context.sport ?? "Tennis";
+    const gender = context.gender;
+
     for (const rule of this.rules) {
       try {
         // Skip contact-related rules during NCAA dead periods
@@ -68,7 +76,7 @@ export class RuleEngine {
               const school = s as Record<string, unknown>;
               const division = ((school.division as string | null) || "D1") as
                 "D1" | "D2" | "D3";
-              return isDeadPeriod(now, division);
+              return isDeadPeriod(now, sport, division, { gender });
             },
           );
 

--- a/server/utils/ruleEngine.ts
+++ b/server/utils/ruleEngine.ts
@@ -5,7 +5,7 @@ const logger = createLogger("rule-engine");
 import { findExistingSuggestion } from "./rules/index";
 import type { SuggestionData, Suggestion, Urgency } from "~/types/timeline";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { isDeadPeriod, type AppSport } from "~/utils/recruitingCalendar";
+import { isDeadPeriod, NO_SPORT_FALLBACK, type AppSport } from "~/utils/recruitingCalendar";
 import { escalateUrgency } from "./rules/ruleEngineHelpers";
 
 const CONTACT_RULES = [
@@ -60,10 +60,8 @@ export class RuleEngine {
 
     // Sport-aware NCAA calendars are keyed by AppSport; a context built
     // without a sport (legacy callers, sport-agnostic rule tests) falls back
-    // to "Tennis", which has no dedicated NCAA sub-calendar and resolves to
-    // the generic "Other" track — the least-restrictive, lowest-surprise
-    // default (matches the D2/D3 fallback calendars' own choice).
-    const sport: AppSport = context.sport ?? "Tennis";
+    // to NO_SPORT_FALLBACK.
+    const sport: AppSport = context.sport ?? NO_SPORT_FALLBACK;
     const gender = context.gender;
 
     for (const rule of this.rules) {

--- a/server/utils/rules/index.ts
+++ b/server/utils/rules/index.ts
@@ -1,6 +1,7 @@
 import type { SuggestionData, Suggestion } from "~/types/timeline";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "~/types/database";
+import type { AppSport } from "~/utils/recruitingCalendar";
 
 export interface RuleContext {
   athleteId: string;
@@ -11,6 +12,15 @@ export interface RuleContext {
   athleteTasks: unknown[];
   videos: unknown[];
   events: unknown[];
+  /**
+   * The athlete's primary sport, used to resolve which NCAA recruiting
+   * calendar governs contact-period dead-period gating in the rule engine.
+   * Optional (falls back to the generic "Other" calendar in ruleEngine.ts)
+   * so existing sport-agnostic rule tests don't need updating.
+   */
+  sport?: AppSport;
+  /** Needed to resolve gender-split sport calendars (e.g. Basketball, Soccer). */
+  gender?: string | null;
 }
 
 export interface Rule {

--- a/server/utils/triggerSuggestionUpdate.ts
+++ b/server/utils/triggerSuggestionUpdate.ts
@@ -12,6 +12,7 @@ import { surfacePendingSuggestions } from "./suggestionStaggering";
 import { calculateCurrentGrade } from "~/utils/gradeHelpers";
 import { createLogger } from "~/server/utils/logger";
 import type { RuleContext } from "./rules/index";
+import type { AppSport } from "~/utils/recruitingCalendar";
 import { interactionGapRule } from "./rules/interactionGap";
 import { missingVideoRule } from "./rules/missingVideo";
 import { eventFollowUpRule } from "./rules/eventFollowUp";
@@ -114,6 +115,14 @@ export async function triggerSuggestionUpdate(
     const gradeLevel = graduationYear
       ? calculateCurrentGrade(graduationYear)
       : 9;
+    const sport =
+      typeof playerData?.primary_sport === "string"
+        ? (playerData.primary_sport as AppSport)
+        : undefined;
+    const gender =
+      typeof playerData?.gender === "string"
+        ? (playerData.gender as string)
+        : null;
 
     const context: RuleContext = {
       athleteId,
@@ -124,6 +133,8 @@ export async function triggerSuggestionUpdate(
       athleteTasks: athleteTasks.data || [],
       videos: videos.data || [],
       events: events.data || [],
+      sport,
+      gender,
     };
 
     // Initialize rule engine with all rules

--- a/tests/unit/components/Dashboard/RecruitingCalendar.spec.ts
+++ b/tests/unit/components/Dashboard/RecruitingCalendar.spec.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import RecruitingCalendar from "~/components/Dashboard/RecruitingCalendar.vue";
+
+describe("RecruitingCalendar Component", () => {
+  it("resolves a non-baseball sport's own calendar, not the baseball default", () => {
+    const baseball = mount(RecruitingCalendar, {
+      props: { graduationYear: 2028, sport: "Baseball" },
+    });
+    const softball = mount(RecruitingCalendar, {
+      props: { graduationYear: 2028, sport: "Softball" },
+    });
+
+    // Both render successfully off their own sport's calendar — the softball
+    // instance must not silently fall back to reading baseball's data.
+    expect(baseball.text()).toContain("Recruiting Calendar");
+    expect(softball.text()).toContain("Recruiting Calendar");
+  });
+
+  it("hides the gender toggle for a non-gender-split sport", () => {
+    const wrapper = mount(RecruitingCalendar, {
+      props: { graduationYear: 2028, sport: "Baseball" },
+    });
+    expect(wrapper.find("[data-testid='gender-toggle-men']").exists()).toBe(false);
+  });
+
+  it("hides the gender toggle for a gender-split sport when the stored gender is already known", () => {
+    const wrapper = mount(RecruitingCalendar, {
+      props: { graduationYear: 2028, sport: "Basketball", gender: "female" },
+    });
+    expect(wrapper.find("[data-testid='gender-toggle-men']").exists()).toBe(false);
+  });
+
+  it("shows a Men's/Women's toggle, defaulted to Men's, for a gender-split sport with null stored gender", () => {
+    const wrapper = mount(RecruitingCalendar, {
+      props: { graduationYear: 2028, sport: "Basketball", gender: null },
+    });
+
+    const menToggle = wrapper.find("[data-testid='gender-toggle-men']");
+    const womenToggle = wrapper.find("[data-testid='gender-toggle-women']");
+    expect(menToggle.exists()).toBe(true);
+    expect(womenToggle.exists()).toBe(true);
+    expect(menToggle.classes().join(" ")).toContain("bg-white");
+  });
+
+  it("shows the toggle for 'other'/'prefer_not_to_say' stored gender too", () => {
+    const other = mount(RecruitingCalendar, {
+      props: { graduationYear: 2028, sport: "Wrestling", gender: "other" },
+    });
+    const preferNot = mount(RecruitingCalendar, {
+      props: { graduationYear: 2028, sport: "Wrestling", gender: "prefer_not_to_say" },
+    });
+    expect(other.find("[data-testid='gender-toggle-men']").exists()).toBe(true);
+    expect(preferNot.find("[data-testid='gender-toggle-men']").exists()).toBe(true);
+  });
+
+  it("the toggle overrides the resolved gender when clicked to Women's", async () => {
+    const wrapper = mount(RecruitingCalendar, {
+      props: { graduationYear: 2028, sport: "Basketball", gender: null },
+    });
+
+    const beforeCurrentPeriodText = wrapper.text();
+
+    await wrapper.find("[data-testid='gender-toggle-women']").trigger("click");
+    await wrapper.vm.$nextTick();
+
+    expect(
+      wrapper.find("[data-testid='gender-toggle-women']").classes().join(" "),
+    ).toContain("bg-white");
+    expect(
+      wrapper.find("[data-testid='gender-toggle-men']").classes().join(" "),
+    ).not.toContain("bg-white");
+
+    // Rendering doesn't throw and the component re-resolves against the
+    // women's calendar (content may legitimately be identical to men's on
+    // some dates, so we only assert the toggle state actually flipped).
+    expect(wrapper.text()).toBeTruthy();
+    expect(beforeCurrentPeriodText).toBeTruthy();
+  });
+
+  it("shows an FBS/FCS toggle, defaulted to FBS, for Football", () => {
+    const wrapper = mount(RecruitingCalendar, {
+      props: { graduationYear: 2028, sport: "Football" },
+    });
+
+    const fbsToggle = wrapper.find("[data-testid='subdivision-toggle-fbs']");
+    const fcsToggle = wrapper.find("[data-testid='subdivision-toggle-fcs']");
+    expect(fbsToggle.exists()).toBe(true);
+    expect(fcsToggle.exists()).toBe(true);
+    expect(fbsToggle.classes().join(" ")).toContain("bg-white");
+  });
+
+  it("hides the FBS/FCS toggle for non-Football sports", () => {
+    const wrapper = mount(RecruitingCalendar, {
+      props: { graduationYear: 2028, sport: "Baseball" },
+    });
+    expect(wrapper.find("[data-testid='subdivision-toggle-fbs']").exists()).toBe(false);
+  });
+});

--- a/tests/unit/components/Dashboard/RecruitingCalendar.spec.ts
+++ b/tests/unit/components/Dashboard/RecruitingCalendar.spec.ts
@@ -96,4 +96,54 @@ describe("RecruitingCalendar Component", () => {
     });
     expect(wrapper.find("[data-testid='subdivision-toggle-fbs']").exists()).toBe(false);
   });
+
+  describe("L6a: compliance disclaimer", () => {
+    it("renders the disclaimer with the resolved calendar's verifiedOn date and a link to its source PDF", () => {
+      const wrapper = mount(RecruitingCalendar, {
+        props: { graduationYear: 2028, sport: "Baseball" },
+      });
+
+      const disclaimer = wrapper.find("[data-testid='calendar-disclaimer']");
+      expect(disclaimer.exists()).toBe(true);
+      expect(disclaimer.text()).toContain("Based on NCAA 2026-27");
+      expect(disclaimer.text()).toContain("confirm with your compliance office");
+      // Baseball's own resolved calendar's verifiedOn, not a hardcoded stub.
+      expect(disclaimer.text()).toContain("2026-08-23");
+
+      const link = disclaimer.find("a");
+      expect(link.exists()).toBe(true);
+      expect(link.attributes("href")).toBe(
+        "https://ncaaorg.s3.amazonaws.com/compliance/recruiting/calendar/2026-27/2026-27D1Rec_MBARecruitingCalendar.pdf",
+      );
+      expect(link.attributes("target")).toBe("_blank");
+      expect(link.attributes("rel")).toBe("noopener");
+    });
+  });
+
+  describe("L6b: staleness banner", () => {
+    it("does not render before the season end", () => {
+      const wrapper = mount(RecruitingCalendar, {
+        props: {
+          graduationYear: 2028,
+          sport: "Baseball",
+          now: new Date("2027-01-01"),
+        },
+      });
+      expect(wrapper.find("[data-testid='calendar-staleness-banner']").exists()).toBe(false);
+    });
+
+    it("renders once `now` is past the season end and no newer data exists", () => {
+      const wrapper = mount(RecruitingCalendar, {
+        props: {
+          graduationYear: 2028,
+          sport: "Baseball",
+          now: new Date("2027-08-01"),
+        },
+      });
+      const banner = wrapper.find("[data-testid='calendar-staleness-banner']");
+      expect(banner.exists()).toBe(true);
+      expect(banner.text()).toContain("may be out of date");
+      expect(banner.text()).toContain("verify with your compliance office");
+    });
+  });
 });

--- a/tests/unit/components/Dashboard/RecruitingCalendar.spec.ts
+++ b/tests/unit/components/Dashboard/RecruitingCalendar.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import RecruitingCalendar from "~/components/Dashboard/RecruitingCalendar.vue";
 
@@ -117,6 +117,40 @@ describe("RecruitingCalendar Component", () => {
       );
       expect(link.attributes("target")).toBe("_blank");
       expect(link.attributes("rel")).toBe("noopener");
+    });
+  });
+
+  describe("current-period banner: most-restrictive selection on nested/overlapping periods", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("on 2027-07-04, Baseball shows the nested Dead period, not the enclosing Contact period", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2027-07-04T12:00:00"));
+
+      const wrapper = mount(RecruitingCalendar, {
+        props: { graduationYear: 2028, sport: "Baseball" },
+      });
+
+      const currentPeriodText = wrapper.text();
+      expect(currentPeriodText).toContain("Current Period");
+      expect(currentPeriodText).toContain("Dead Period");
+      expect(currentPeriodText).not.toContain("Contact Period");
+    });
+
+    it("on 2026-11-25, Baseball shows the Recruiting Shutdown, not the enclosing Quiet period", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-11-25T12:00:00"));
+
+      const wrapper = mount(RecruitingCalendar, {
+        props: { graduationYear: 2028, sport: "Baseball" },
+      });
+
+      const currentPeriodText = wrapper.text();
+      expect(currentPeriodText).toContain("Current Period");
+      expect(currentPeriodText).toContain("Recruiting Shutdown");
+      expect(currentPeriodText).not.toContain("Quiet Period");
     });
   });
 

--- a/tests/unit/pages/dashboard.spec.ts
+++ b/tests/unit/pages/dashboard.spec.ts
@@ -23,6 +23,7 @@ import {
   createVeryLargeSchool,
 } from "~/tests/fixtures/schools.fixture";
 import { getCarnegieSize } from "~/utils/schoolSize";
+import { getDeadPeriodMessage, type AppSport } from "~/utils/recruitingCalendar";
 
 // Mock modules
 vi.mock("~/composables/useSupabase");
@@ -2362,6 +2363,111 @@ describe("Dashboard Page Logic", () => {
         ).length;
         expect(acceptedCount).toBe(1);
       });
+    });
+  });
+
+  describe("deadPeriodMessage computed property (sport-aware)", () => {
+    // Mirrors pages/dashboard.vue's deadPeriodMessage computed exactly,
+    // against the real sport-aware ~/utils/recruitingCalendar module.
+    const computeDeadPeriodMessage = (params: {
+      now: Date;
+      schools: Array<{ division?: string | null }>;
+      sport: AppSport;
+      gender: string | null;
+    }) => {
+      const { now, schools, sport, gender } = params;
+      if (!schools.length) return null;
+      const opts = { gender };
+      const allInDeadPeriod = schools.every((school) => {
+        const div = (school.division as string) || "D1";
+        return !!getDeadPeriodMessage(now, sport, div as "D1" | "D2" | "D3", opts);
+      });
+      return allInDeadPeriod
+        ? (getDeadPeriodMessage(now, sport, "D1", opts) ?? null)
+        : null;
+    };
+
+    it("returns null when there are no schools", () => {
+      expect(
+        computeDeadPeriodMessage({
+          now: new Date("2026-08-23"),
+          schools: [],
+          sport: "Baseball",
+          gender: null,
+        }),
+      ).toBeNull();
+    });
+
+    it("resolves the dead period using the athlete's real sport, not baseball", () => {
+      // Men's D1 basketball has a dead period Aug 1-19, 2026 (calendarData.ts);
+      // baseball's first 2026 dead period doesn't open until Nov 9.
+      const now = new Date(2026, 7, 10); // local Aug 10, 2026 — avoid UTC date-string offset drift
+      const baseballResult = computeDeadPeriodMessage({
+        now,
+        schools: [{ division: "D1" }],
+        sport: "Baseball",
+        gender: null,
+      });
+      const basketballResult = computeDeadPeriodMessage({
+        now,
+        schools: [{ division: "D1" }],
+        sport: "Basketball",
+        gender: "male",
+      });
+
+      expect(baseballResult).toBeNull();
+      expect(basketballResult).not.toBeNull();
+    });
+
+    it("passes gender through to the resolver for gender-split sports", () => {
+      // Aug 10, 2026 is a "Dead Period" for men's D1 basketball but a
+      // "Recruiting Shutdown" for women's — independently transcribed
+      // windows, so the gender opt must reach the resolver, not just the sport.
+      const now = new Date(2026, 7, 10); // local Aug 10, 2026 — avoid UTC date-string offset drift
+      const mensResult = computeDeadPeriodMessage({
+        now,
+        schools: [{ division: "D1" }],
+        sport: "Basketball",
+        gender: "male",
+      });
+      const womensResult = computeDeadPeriodMessage({
+        now,
+        schools: [{ division: "D1" }],
+        sport: "Basketball",
+        gender: "female",
+      });
+
+      expect(mensResult).toContain("Dead Period");
+      expect(womensResult).toContain("Recruiting Shutdown");
+      expect(mensResult).not.toEqual(womensResult);
+    });
+
+    it("falls back to a neutral sport with no calendar when primary_sport is unset — never a false-positive dead period", () => {
+      const now = new Date("2026-08-25");
+      const result = computeDeadPeriodMessage({
+        now,
+        schools: [{ division: "D1" }],
+        sport: "Tennis",
+        gender: null,
+      });
+      expect(result).toBeNull();
+    });
+
+    it("D2/D3 schools use their shared calendar regardless of sport", () => {
+      const now = new Date("2026-08-25");
+      const d3Baseball = computeDeadPeriodMessage({
+        now,
+        schools: [{ division: "D3" }],
+        sport: "Baseball",
+        gender: null,
+      });
+      const d3Basketball = computeDeadPeriodMessage({
+        now,
+        schools: [{ division: "D3" }],
+        sport: "Basketball",
+        gender: "male",
+      });
+      expect(d3Baseball).toEqual(d3Basketball);
     });
   });
 });

--- a/tests/unit/pages/timeline-index.spec.ts
+++ b/tests/unit/pages/timeline-index.spec.ts
@@ -51,6 +51,32 @@ vi.mock("~/composables/useStatusScore", () => ({
   }),
 }));
 
+const playerDetailsRef = ref<{
+  primary_sport?: string;
+  gender?: string | null;
+  graduation_year?: number;
+} | null>(null);
+const loadPlayerPreferencesMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("~/composables/usePreferenceManager", () => ({
+  usePreferenceManager: () => ({
+    getPlayerDetails: () => playerDetailsRef.value,
+    playerPrefs: { loadPreferences: loadPlayerPreferencesMock },
+  }),
+}));
+
+const getUpcomingMilestonesSpy = vi.fn();
+vi.mock("~/utils/recruitingCalendar", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/utils/recruitingCalendar")>();
+  return {
+    ...actual,
+    getUpcomingMilestones: (params: Parameters<typeof actual.getUpcomingMilestones>[0]) => {
+      getUpcomingMilestonesSpy(params);
+      return actual.getUpcomingMilestones(params);
+    },
+  };
+});
+
 import TimelineIndexPage from "~/pages/timeline/index.vue";
 
 describe("pages/timeline/index.vue", () => {
@@ -58,6 +84,9 @@ describe("pages/timeline/index.vue", () => {
     vi.clearAllMocks();
     fetchPhaseMock.mockResolvedValue(undefined);
     statusLabelRef.value = null;
+    playerDetailsRef.value = null;
+    loadPlayerPreferencesMock.mockResolvedValue(undefined);
+    getUpcomingMilestonesSpy.mockClear();
   });
 
   const mountPage = () =>
@@ -121,5 +150,42 @@ describe("pages/timeline/index.vue", () => {
     expect(wrapper.find("[data-testid='status-label-text']").text()).toBe(
       "At Risk",
     );
+  });
+
+  describe("sport-aware upcoming milestones", () => {
+    it("resolves milestones through the sport-aware resolver with the athlete's real sport/gender/graduation year — not the legacy baseball/D1-only helper", async () => {
+      playerDetailsRef.value = {
+        primary_sport: "Softball",
+        gender: "female",
+        graduation_year: 2027,
+      };
+      const wrapper = mountPage();
+      await wrapper.vm.$nextTick();
+
+      expect(getUpcomingMilestonesSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sport: "Softball",
+          division: "D1",
+          graduationYear: 2027,
+          opts: { gender: "female" },
+        }),
+      );
+    });
+
+    it("falls back to a neutral sport (no NCAA calendar) when the profile has no primary_sport", async () => {
+      playerDetailsRef.value = { graduation_year: 2027 };
+      const wrapper = mountPage();
+      await wrapper.vm.$nextTick();
+      const vm = wrapper.vm as any;
+
+      expect(vm.athleteSport).toBe("Tennis");
+    });
+
+    it("loads player preferences on mount so sport/gender are available", async () => {
+      mountPage();
+      await Promise.resolve();
+
+      expect(loadPlayerPreferencesMock).toHaveBeenCalled();
+    });
   });
 });

--- a/tests/unit/scripts/check-ncaa-calendar-cycle.spec.ts
+++ b/tests/unit/scripts/check-ncaa-calendar-cycle.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+// @ts-expect-error — plain .mjs script, no types
+import { d1Urls } from "../../../scripts/check-ncaa-calendar-cycle.mjs";
+
+describe("check-ncaa-calendar-cycle d1Urls", () => {
+  const urls = d1Urls("2027-28") as { code: string; url: string }[];
+  const byCode = Object.fromEntries(urls.map((u) => [u.code, u.url]));
+
+  it("builds all 13 calendar URLs for a season", () => {
+    expect(urls).toHaveLength(13);
+    for (const code of [
+      "MBA", "WSB", "MBB", "WBB", "XCTF", "WVB", "MGO", "MLA", "WLA",
+      "FBS", "FCS", "Other", "D2_ALL",
+    ]) {
+      expect(byCode[code], code).toBeTruthy();
+    }
+  });
+
+  it("uses the plain-hyphen filename for standard D1 codes", () => {
+    expect(byCode.MBA).toBe(
+      "https://ncaaorg.s3.amazonaws.com/compliance/recruiting/calendar/2027-28/2027-28D1Rec_MBARecruitingCalendar.pdf",
+    );
+  });
+
+  it("uses the FBS/FCS infix-less football filenames", () => {
+    expect(byCode.FBS).toContain("2027-28D1Rec_FBSRecruitingCalendar.pdf");
+    expect(byCode.FCS).toContain("2027-28D1Rec_FCSRecruitingCalendar.pdf");
+  });
+
+  it("uses the EN-DASH year in the Other-sports filename", () => {
+    expect(byCode.Other).toBe(
+      "https://ncaaorg.s3.amazonaws.com/compliance/recruiting/calendar/2027-28/2027–28D1Rec_OtherRecruitingCalendar.pdf",
+    );
+    // and NOT the ASCII-hyphen form (which 404s on NCAA's bucket)
+    expect(byCode.Other).not.toContain("2027-28D1Rec_Other");
+  });
+
+  it("uses the D2 combined all-sports filename", () => {
+    expect(byCode.D2_ALL).toContain("2027-28D2Rec_RecruitingCalendar_AllSports.pdf");
+  });
+});

--- a/tests/unit/server/ruleEngine.deadPeriod.spec.ts
+++ b/tests/unit/server/ruleEngine.deadPeriod.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * Regression test for the sport-agnostic dead-period bug: the rule engine
+ * used to gate contact rules off baseball's own dead-period dates for EVERY
+ * sport (it called `isDeadPeriod(now, division)` with no sport). A Tennis (or
+ * any non-baseball) athlete whose schools sat on a date that was dead for
+ * baseball had their contact suggestions silently suppressed for a sport
+ * whose actual NCAA calendar had no such dead window.
+ *
+ * Concrete dates (from utils/recruitingCalendar/calendarData.ts, D1 track):
+ * - Baseball (MBA): 2027-07-03..2027-07-05 is a "Dead period (July 4th)".
+ * - Tennis has no dedicated NCAA sub-calendar and resolves to the generic
+ *   "Other" track (OTHER), whose only dead period is 2026-11-09..2026-11-12
+ *   — nowhere near July 2027. So 2027-07-04 is a normal contact-eligible day
+ *   for a Tennis athlete.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { RuleEngine } from "~/server/utils/ruleEngine";
+import type { Rule, RuleContext } from "~/server/utils/rules/index";
+
+const JULY_FOURTH_DEAD_FOR_BASEBALL = new Date("2027-07-04T12:00:00Z");
+
+function buildContext(overrides: Partial<RuleContext>): RuleContext {
+  return {
+    athleteId: "athlete-123",
+    athlete: {},
+    schools: [{ id: "school-1", division: "D1" }],
+    interactions: [],
+    tasks: [],
+    athleteTasks: [],
+    videos: [],
+    events: [],
+    ...overrides,
+  };
+}
+
+function buildContactRule(id = "interaction-gap"): Rule {
+  return {
+    id,
+    name: "Interaction Gap",
+    description: "Contact rule under test",
+    evaluate: vi.fn().mockResolvedValue({
+      rule_type: id,
+      urgency: "medium",
+      message: "Contact reminder",
+      action_type: "log_interaction",
+    }),
+  };
+}
+
+describe("RuleEngine dead-period gating is sport-aware (not baseball-only)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("does NOT suppress contact rules for a non-baseball athlete on a date dead only for baseball", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(JULY_FOURTH_DEAD_FOR_BASEBALL);
+
+    const engine = new RuleEngine();
+    const contactRule = buildContactRule();
+    engine.addRule(contactRule);
+
+    const context = buildContext({ sport: "Tennis" });
+    const result = await engine.evaluateAll(context);
+
+    expect(contactRule.evaluate).toHaveBeenCalled();
+    expect(result).toHaveLength(1);
+  });
+
+  it("positive control: DOES suppress contact rules for a baseball athlete on the same date", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(JULY_FOURTH_DEAD_FOR_BASEBALL);
+
+    const engine = new RuleEngine();
+    const contactRule = buildContactRule();
+    engine.addRule(contactRule);
+
+    const context = buildContext({ sport: "Baseball" });
+    const result = await engine.evaluateAll(context);
+
+    expect(contactRule.evaluate).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
+
+  it("non-contact rules are never gated by dead periods, regardless of sport", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(JULY_FOURTH_DEAD_FOR_BASEBALL);
+
+    const engine = new RuleEngine();
+    const nonContactRule: Rule = {
+      id: "portfolio-health",
+      name: "Portfolio Health",
+      description: "Non-contact rule",
+      evaluate: vi.fn().mockResolvedValue({
+        rule_type: "portfolio-health",
+        urgency: "medium",
+        message: "Portfolio needs review",
+        action_type: "log_interaction",
+      }),
+    };
+    engine.addRule(nonContactRule);
+
+    const context = buildContext({ sport: "Baseball" });
+    const result = await engine.evaluateAll(context);
+
+    expect(nonContactRule.evaluate).toHaveBeenCalled();
+    expect(result).toHaveLength(1);
+  });
+});

--- a/tests/unit/server/utils/ruleEngine.generate.spec.ts
+++ b/tests/unit/server/utils/ruleEngine.generate.spec.ts
@@ -13,9 +13,15 @@ vi.mock("~/server/utils/rules/index", async () => {
   };
 });
 
-vi.mock("~/server/utils/ncaaRecruitingCalendar", () => ({
-  isDeadPeriod: vi.fn(() => false),
-}));
+vi.mock("~/utils/recruitingCalendar", async () => {
+  const actual = await vi.importActual<typeof import("~/utils/recruitingCalendar")>(
+    "~/utils/recruitingCalendar",
+  );
+  return {
+    ...actual,
+    isDeadPeriod: vi.fn(() => false),
+  };
+});
 
 vi.mock("~/server/utils/rules/ruleEngineHelpers", () => ({
   escalateUrgency: vi.fn((u: string) => (u === "low" ? "medium" : "high")),

--- a/tests/unit/utils/ncaaRecruitingCalendar.spec.ts
+++ b/tests/unit/utils/ncaaRecruitingCalendar.spec.ts
@@ -3,16 +3,15 @@ import {
   getUpcomingMilestones,
   getMilestonesByDateRange,
   getMilestoneTypeIcon,
-  isQuietPeriod,
-  isDeadPeriod,
-  getDeadPeriodMessage,
-  getNextDeadPeriod,
-  getRecruitingCalendar,
   SAT_TEST_DATES_2026,
   ACT_TEST_DATES_2026,
   COLLEGE_APPLICATION_DEADLINES_2026,
-  BASEBALL_SIGNING_PERIODS_2026,
 } from "~/utils/ncaaRecruitingCalendar";
+
+// Sport-aware isDeadPeriod/isQuietPeriod/getDeadPeriodMessage/getNextDeadPeriod
+// and the RECRUITING_CALENDAR_2026/BASEBALL_SIGNING_PERIODS_2026 data now live
+// in ~/utils/recruitingCalendar (see tests/unit/utils/recruitingCalendar/).
+// This file only covers the still-generic pieces that remain here.
 
 describe("ncaaRecruitingCalendar", () => {
   describe("milestone arrays exist", () => {
@@ -29,11 +28,6 @@ describe("ncaaRecruitingCalendar", () => {
     it("should have college application deadlines", () => {
       expect(COLLEGE_APPLICATION_DEADLINES_2026.length).toBeGreaterThan(0);
       expect(COLLEGE_APPLICATION_DEADLINES_2026[0].type).toBe("application");
-    });
-
-    it("should have baseball signing periods", () => {
-      expect(BASEBALL_SIGNING_PERIODS_2026.length).toBeGreaterThan(0);
-      expect(BASEBALL_SIGNING_PERIODS_2026[0].type).toBe("signing");
     });
   });
 
@@ -189,143 +183,6 @@ describe("ncaaRecruitingCalendar", () => {
 
     it("should return default calendar icon for unknown type", () => {
       expect(getMilestoneTypeIcon("unknown" as any)).toBe("📅");
-    });
-  });
-
-  describe("isQuietPeriod", () => {
-    it("returns true for a date inside the D1 quiet period (Sep 1-10 2026)", () => {
-      // The calendar has a quiet period Sep 1–10 2026 for D1
-      expect(isQuietPeriod(new Date("2026-09-05"), "D1")).toBe(true);
-    });
-
-    it("returns true on the start boundary of the quiet period", () => {
-      expect(isQuietPeriod(new Date("2026-09-01"), "D1")).toBe(true);
-    });
-
-    it("returns true on the end boundary of the quiet period", () => {
-      expect(isQuietPeriod(new Date("2026-09-10"), "D1")).toBe(true);
-    });
-
-    it("returns false for a date outside all quiet periods", () => {
-      // October is a normal contact period
-      expect(isQuietPeriod(new Date("2026-10-01"), "D1")).toBe(false);
-    });
-
-    it("returns false when division does not match", () => {
-      // The quiet period is only defined for D1; D2 has none in the calendar
-      expect(isQuietPeriod(new Date("2026-09-05"), "D2")).toBe(false);
-    });
-
-    it("defaults to D1 when no division argument is supplied", () => {
-      expect(isQuietPeriod(new Date("2026-09-05"))).toBe(true);
-    });
-  });
-
-  describe("getDeadPeriodMessage", () => {
-    it("returns a message string when the date is inside a dead period", () => {
-      // Thanksgiving dead period: Nov 22–29 2026
-      const result = getDeadPeriodMessage(new Date("2026-11-25"), "D1");
-      expect(result).not.toBeNull();
-      expect(typeof result).toBe("string");
-      expect(result).toContain("Dead period");
-      expect(result).toContain("Thanksgiving");
-    });
-
-    it("returns null when the date is outside all dead periods", () => {
-      // A normal day in October
-      expect(getDeadPeriodMessage(new Date("2026-10-15"), "D1")).toBeNull();
-    });
-
-    it("includes the period description in the message", () => {
-      // Winter break: Dec 20 2026 – Jan 3 2027
-      const result = getDeadPeriodMessage(new Date("2026-12-25"), "D1");
-      expect(result).toContain("Winter Break");
-    });
-
-    it("returns null for a division that has no matching dead period", () => {
-      // Dead periods are only D1 in the 2026 calendar
-      expect(getDeadPeriodMessage(new Date("2026-11-25"), "D2")).toBeNull();
-    });
-
-    it("defaults to D1 when no division is supplied", () => {
-      const result = getDeadPeriodMessage(new Date("2026-11-25"));
-      expect(result).not.toBeNull();
-    });
-  });
-
-  describe("getNextDeadPeriod", () => {
-    it("returns the soonest upcoming dead period from a given date", () => {
-      // Asking from Oct 1 2026, the next dead period is Thanksgiving (Nov 22)
-      const result = getNextDeadPeriod(new Date("2026-10-01"), "D1");
-      expect(result).not.toBeNull();
-      expect(result!.description).toBe("Thanksgiving Break");
-    });
-
-    it("returns the correct type and division on the result", () => {
-      const result = getNextDeadPeriod(new Date("2026-10-01"), "D1");
-      expect(result!.type).toBe("dead");
-      expect(result!.division).toBe("D1");
-    });
-
-    it("returns null when the given date is after all dead periods in the calendar", () => {
-      // After the last dead period (Spring Break ends Apr 10 2027)
-      const result = getNextDeadPeriod(new Date("2027-05-01"), "D1");
-      expect(result).toBeNull();
-    });
-
-    it("returns null for a division with no dead periods", () => {
-      expect(getNextDeadPeriod(new Date("2026-01-01"), "D2")).toBeNull();
-    });
-
-    it("includes the current date's dead period when the date is inside one", () => {
-      // Nov 22 is the start of Thanksgiving — querying from that date should return it
-      const result = getNextDeadPeriod(new Date("2026-11-22"), "D1");
-      expect(result).not.toBeNull();
-      expect(result!.description).toBe("Thanksgiving Break");
-    });
-  });
-
-  describe("getRecruitingCalendar", () => {
-    it("returns only D1 periods when called with 'D1'", () => {
-      const result = getRecruitingCalendar("D1");
-      expect(result.length).toBeGreaterThan(0);
-      result.forEach((period) => {
-        expect(period.division).toBe("D1");
-      });
-    });
-
-    it("returns an empty array for D2 (no D2 periods defined)", () => {
-      const result = getRecruitingCalendar("D2");
-      expect(result).toEqual([]);
-    });
-
-    it("returns an empty array for D3 (no D3 periods defined)", () => {
-      const result = getRecruitingCalendar("D3");
-      expect(result).toEqual([]);
-    });
-
-    it("defaults to D1 when no division argument is supplied", () => {
-      const withD1 = getRecruitingCalendar("D1");
-      const withDefault = getRecruitingCalendar();
-      expect(withDefault).toEqual(withD1);
-    });
-
-    it("includes both dead and quiet period types for D1", () => {
-      const result = getRecruitingCalendar("D1");
-      const types = result.map((p) => p.type);
-      expect(types).toContain("dead");
-      expect(types).toContain("quiet");
-    });
-
-    it("every returned period has start and end Date objects", () => {
-      const result = getRecruitingCalendar("D1");
-      result.forEach((period) => {
-        expect(period.start).toBeInstanceOf(Date);
-        expect(period.end).toBeInstanceOf(Date);
-        expect(period.start.getTime()).toBeLessThanOrEqual(
-          period.end.getTime(),
-        );
-      });
     });
   });
 

--- a/tests/unit/utils/recruitingCalendar/calendarData.spec.ts
+++ b/tests/unit/utils/recruitingCalendar/calendarData.spec.ts
@@ -83,20 +83,21 @@ describe("D2/D3 fallbacks", () => {
 });
 
 describe("Other sub-calendars (per-sport bundle expansion)", () => {
-  it("each new sub-key has more/different periods than the generic Other default", () => {
-    const subKeys = [
-      "OTHER_MSOCCER",
-      "OTHER_WSOCCER",
-      "OTHER_SWIM",
-      "OTHER_MICEHOCKEY",
-      "OTHER_WICEHOCKEY",
-      "OTHER_ROWING",
-      "OTHER_FIELDHOCKEY",
-      "OTHER_MWRESTLING",
-      "OTHER_WWRESTLING",
-    ] as const;
-    for (const k of subKeys) {
+  const SUB_KEYS = [
+    "OTHER_MSOCCER",
+    "OTHER_WSOCCER",
+    "OTHER_SWIM",
+    "OTHER_MICEHOCKEY",
+    "OTHER_WICEHOCKEY",
+    "OTHER_ROWING",
+    "OTHER_FIELDHOCKEY",
+    "OTHER_MWRESTLING",
+    "OTHER_WWRESTLING",
+  ] as const;
+  it("each new sub-key's periods differ from the generic Other default (not just a copy/fallback)", () => {
+    for (const k of SUB_KEYS) {
       expect(D1_CALENDARS[k].periods.length, k).toBeGreaterThan(0);
+      expect(D1_CALENDARS[k].periods, k).not.toEqual(D1_CALENDARS.Other.periods);
     }
   });
   it("soccer sub-calendars are gender-distinct", () => {

--- a/tests/unit/utils/recruitingCalendar/calendarData.spec.ts
+++ b/tests/unit/utils/recruitingCalendar/calendarData.spec.ts
@@ -21,6 +21,8 @@ const ALL_KEYS = [
   "OTHER_WICEHOCKEY",
   "OTHER_ROWING",
   "OTHER_FIELDHOCKEY",
+  "OTHER_MWRESTLING",
+  "OTHER_WWRESTLING",
 ] as const;
 const ISO = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -90,6 +92,8 @@ describe("Other sub-calendars (per-sport bundle expansion)", () => {
       "OTHER_WICEHOCKEY",
       "OTHER_ROWING",
       "OTHER_FIELDHOCKEY",
+      "OTHER_MWRESTLING",
+      "OTHER_WWRESTLING",
     ] as const;
     for (const k of subKeys) {
       expect(D1_CALENDARS[k].periods.length, k).toBeGreaterThan(0);
@@ -100,5 +104,8 @@ describe("Other sub-calendars (per-sport bundle expansion)", () => {
   });
   it("ice hockey sub-calendars are gender-distinct", () => {
     expect(D1_CALENDARS.OTHER_MICEHOCKEY.periods).not.toEqual(D1_CALENDARS.OTHER_WICEHOCKEY.periods);
+  });
+  it("wrestling sub-calendars are gender-distinct", () => {
+    expect(D1_CALENDARS.OTHER_MWRESTLING.periods).not.toEqual(D1_CALENDARS.OTHER_WWRESTLING.periods);
   });
 });

--- a/tests/unit/utils/recruitingCalendar/calendarData.spec.ts
+++ b/tests/unit/utils/recruitingCalendar/calendarData.spec.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { D1_CALENDARS, D2_ALL_SPORTS, D3_FALLBACK } from "~/utils/recruitingCalendar/calendarData";
+
+const ALL_KEYS = ["MBA", "WSB", "MBB", "WBB", "FBS", "FCS", "XCTF", "WVB", "MGO", "MLA", "WLA", "Other"] as const;
+const ISO = /^\d{4}-\d{2}-\d{2}$/;
+
+describe("calendarData integrity (L1)", () => {
+  it("has every D1 calendar with source + verifiedOn", () => {
+    for (const k of ALL_KEYS) {
+      const c = D1_CALENDARS[k];
+      expect(c, k).toBeTruthy();
+      expect(c.source, k).toMatch(/ncaaorg\.s3\.amazonaws\.com/);
+      expect(c.verifiedOn, k).toBe("2026-08-23");
+      expect(c.periods.length, k).toBeGreaterThan(0);
+    }
+  });
+  it("every period is well-formed and start<=end", () => {
+    for (const k of ALL_KEYS)
+      for (const p of D1_CALENDARS[k].periods) {
+        expect(p.start, `${k} ${p.description}`).toMatch(ISO);
+        expect(p.end).toMatch(ISO);
+        expect(p.start <= p.end, `${k} ${p.description}`).toBe(true);
+        expect(["dead", "quiet", "contact", "evaluation", "recruiting_shutdown"]).toContain(p.type);
+        expect(["HIGH", "MEDIUM", "LOW"]).toContain(p.confidence);
+      }
+  });
+});
+
+describe("plausibility (L3)", () => {
+  const month = (iso: string) => Number(iso.slice(5, 7));
+  it("dead/shutdown windows sit in plausible months (no summer-holiday-in-spring typos)", () => {
+    // Thanksgiving-ish shutdowns land in Nov; winter shutdowns in Dec/Jan; July-4 dead in Jul.
+    for (const k of ALL_KEYS)
+      for (const p of D1_CALENDARS[k].periods) {
+        if (/thanksgiving/i.test(p.description)) expect(month(p.start), `${k}`).toBe(11);
+        if (/winter|holiday/i.test(p.description) && p.type !== "contact")
+          expect([12, 1]).toContain(month(p.start));
+        if (/july 4|independence/i.test(p.description)) expect(month(p.start)).toBe(7);
+      }
+  });
+  it("no period spans more than ~10 months (catches a swapped start/end year)", () => {
+    for (const k of ALL_KEYS)
+      for (const p of D1_CALENDARS[k].periods) {
+        const days = (Date.parse(p.end) - Date.parse(p.start)) / 86400000;
+        expect(days, `${k} ${p.description}`).toBeLessThan(310);
+        expect(days).toBeGreaterThanOrEqual(0);
+      }
+  });
+});
+
+describe("D2/D3 fallbacks", () => {
+  it("D2_ALL_SPORTS + D3_FALLBACK are populated with source + verifiedOn", () => {
+    for (const c of [D2_ALL_SPORTS, D3_FALLBACK]) {
+      expect(c.periods.length).toBeGreaterThan(0);
+      expect(c.verifiedOn).toBe("2026-08-23");
+    }
+  });
+});

--- a/tests/unit/utils/recruitingCalendar/calendarData.spec.ts
+++ b/tests/unit/utils/recruitingCalendar/calendarData.spec.ts
@@ -1,7 +1,27 @@
 import { describe, it, expect } from "vitest";
 import { D1_CALENDARS, D2_ALL_SPORTS, D3_FALLBACK } from "~/utils/recruitingCalendar/calendarData";
 
-const ALL_KEYS = ["MBA", "WSB", "MBB", "WBB", "FBS", "FCS", "XCTF", "WVB", "MGO", "MLA", "WLA", "Other"] as const;
+const ALL_KEYS = [
+  "MBA",
+  "WSB",
+  "MBB",
+  "WBB",
+  "FBS",
+  "FCS",
+  "XCTF",
+  "WVB",
+  "MGO",
+  "MLA",
+  "WLA",
+  "Other",
+  "OTHER_MSOCCER",
+  "OTHER_WSOCCER",
+  "OTHER_SWIM",
+  "OTHER_MICEHOCKEY",
+  "OTHER_WICEHOCKEY",
+  "OTHER_ROWING",
+  "OTHER_FIELDHOCKEY",
+] as const;
 const ISO = /^\d{4}-\d{2}-\d{2}$/;
 
 describe("calendarData integrity (L1)", () => {
@@ -54,5 +74,31 @@ describe("D2/D3 fallbacks", () => {
       expect(c.periods.length).toBeGreaterThan(0);
       expect(c.verifiedOn).toBe("2026-08-23");
     }
+  });
+  it("D3_FALLBACK is the generic Other default, not a sub-calendar", () => {
+    expect(D3_FALLBACK).toBe(D1_CALENDARS.Other);
+  });
+});
+
+describe("Other sub-calendars (per-sport bundle expansion)", () => {
+  it("each new sub-key has more/different periods than the generic Other default", () => {
+    const subKeys = [
+      "OTHER_MSOCCER",
+      "OTHER_WSOCCER",
+      "OTHER_SWIM",
+      "OTHER_MICEHOCKEY",
+      "OTHER_WICEHOCKEY",
+      "OTHER_ROWING",
+      "OTHER_FIELDHOCKEY",
+    ] as const;
+    for (const k of subKeys) {
+      expect(D1_CALENDARS[k].periods.length, k).toBeGreaterThan(0);
+    }
+  });
+  it("soccer sub-calendars are gender-distinct", () => {
+    expect(D1_CALENDARS.OTHER_MSOCCER.periods).not.toEqual(D1_CALENDARS.OTHER_WSOCCER.periods);
+  });
+  it("ice hockey sub-calendars are gender-distinct", () => {
+    expect(D1_CALENDARS.OTHER_MICEHOCKEY.periods).not.toEqual(D1_CALENDARS.OTHER_WICEHOCKEY.periods);
   });
 });

--- a/tests/unit/utils/recruitingCalendar/queries.spec.ts
+++ b/tests/unit/utils/recruitingCalendar/queries.spec.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import {
+  getSportCalendar,
+  isDeadPeriod,
+  isQuietPeriod,
+  getDeadPeriodMessage,
+  getNextDeadPeriod,
+  getUpcomingMilestones,
+} from "~/utils/recruitingCalendar";
+
+describe("sport-aware queries", () => {
+  it("getSportCalendar returns the resolved sport's calendar (D1)", () => {
+    expect(getSportCalendar("Softball", "D1").source).toContain("WSB");
+    expect(getSportCalendar("Basketball", "D1", { gender: "female" }).source).toContain("WBB");
+  });
+
+  it("D2 → all-sports calendar regardless of sport", () => {
+    expect(getSportCalendar("Baseball", "D2")).toEqual(getSportCalendar("Soccer", "D2"));
+  });
+
+  it("D3 → fallback calendar regardless of sport", () => {
+    expect(getSportCalendar("Baseball", "D3")).toEqual(getSportCalendar("Volleyball", "D3"));
+  });
+
+  it("isDeadPeriod is sport-specific (regression: non-baseball ≠ baseball dates)", () => {
+    // MBA (Baseball, D1) has a HIGH-confidence "Dead Period (July 4th)" window
+    // 2027-07-03..2027-07-05 (calendarData.ts). Tennis resolves to "Other",
+    // whose only D1 period is the Nov 9-12 fall-signing dead period — it has
+    // no window anywhere near July 4th, so the two sports must disagree here.
+    const d = new Date("2027-07-04T12:00:00Z"); // July-4 dead for baseball
+    expect(isDeadPeriod(d, "Baseball", "D1")).toBe(true);
+    // a sport whose data has no July-4 dead window must return false
+    expect(isDeadPeriod(d, "Tennis", "D1")).toBe(false); // Tennis → Other
+  });
+
+  it("isQuietPeriod is sport-specific", () => {
+    // MBA quiet period 2026-08-17..2026-09-10 (calendarData.ts).
+    const d = new Date("2026-08-20T12:00:00Z");
+    expect(isQuietPeriod(d, "Baseball", "D1")).toBe(true);
+    expect(isQuietPeriod(d, "Tennis", "D1")).toBe(false);
+  });
+
+  it("getDeadPeriodMessage returns null outside any dead window", () => {
+    expect(getDeadPeriodMessage(new Date("2026-10-15T12:00:00Z"), "Softball", "D1")).toBeNull();
+  });
+
+  it("getDeadPeriodMessage returns a message inside a dead window", () => {
+    const msg = getDeadPeriodMessage(new Date("2027-07-04T12:00:00Z"), "Baseball", "D1");
+    expect(msg).not.toBeNull();
+    expect(msg).toContain("July 4th");
+  });
+
+  it("getNextDeadPeriod returns the next dead/shutdown period after the given date", () => {
+    const next = getNextDeadPeriod(new Date("2027-06-01T00:00:00Z"), "Baseball", "D1");
+    expect(next).not.toBeNull();
+    expect(next?.start).toBe("2027-06-19");
+  });
+
+  it("getNextDeadPeriod returns null when no future dead period exists", () => {
+    const next = getNextDeadPeriod(new Date("2028-01-01T00:00:00Z"), "Baseball", "D1");
+    expect(next).toBeNull();
+  });
+
+  it("getUpcomingMilestones merges the resolved sport calendar's milestones with generic ones", () => {
+    const milestones = getUpcomingMilestones({
+      sport: "Baseball",
+      division: "D1",
+      currentDate: new Date("2026-08-01T00:00:00Z"),
+      limit: 50,
+    });
+    // MBA-specific signing milestone
+    expect(milestones.some((m) => m.title.includes("Early Signing Period"))).toBe(true);
+    // Generic SAT test date milestone
+    expect(milestones.some((m) => m.title === "SAT Test Date")).toBe(true);
+    // Sorted ascending by date
+    const dates = milestones.map((m) => m.date);
+    expect([...dates].sort((a, b) => a.localeCompare(b))).toEqual(dates);
+  });
+
+  it("getUpcomingMilestones respects limit", () => {
+    const milestones = getUpcomingMilestones({
+      sport: "Baseball",
+      division: "D1",
+      currentDate: new Date("2026-08-01T00:00:00Z"),
+      limit: 2,
+    });
+    expect(milestones.length).toBeLessThanOrEqual(2);
+  });
+});

--- a/tests/unit/utils/recruitingCalendar/resolver.spec.ts
+++ b/tests/unit/utils/recruitingCalendar/resolver.spec.ts
@@ -25,7 +25,7 @@ describe("resolveCalendarKey", () => {
     expect(resolveCalendarKey("Football", { footballSubdivision: "FCS" })).toBe("FCS");
   });
   it("sports without any published NCAA calendar fall to the generic Other default", () => {
-    for (const s of ["Tennis", "Wrestling", "Water Polo"] as const) {
+    for (const s of ["Tennis", "Water Polo"] as const) {
       expect(resolveCalendarKey(s)).toBe("Other");
     }
   });
@@ -46,5 +46,12 @@ describe("resolveCalendarKey", () => {
     expect(resolveCalendarKey("Ice Hockey", { gender: "female" })).toBe("OTHER_WICEHOCKEY");
     expect(resolveCalendarKey("Ice Hockey", { gender: null })).toBe("OTHER_MICEHOCKEY");
     expect(resolveCalendarKey("Ice Hockey", { gender: "prefer_not_to_say" })).toBe("OTHER_MICEHOCKEY");
+  });
+  it("Wrestling: gender-split sub-keys, default men's", () => {
+    expect(resolveCalendarKey("Wrestling", { gender: "male" })).toBe("OTHER_MWRESTLING");
+    expect(resolveCalendarKey("Wrestling", { gender: "female" })).toBe("OTHER_WWRESTLING");
+    expect(resolveCalendarKey("Wrestling", { gender: null })).toBe("OTHER_MWRESTLING");
+    expect(resolveCalendarKey("Wrestling", { gender: "other" })).toBe("OTHER_MWRESTLING");
+    expect(resolveCalendarKey("Wrestling", { gender: "prefer_not_to_say" })).toBe("OTHER_MWRESTLING");
   });
 });

--- a/tests/unit/utils/recruitingCalendar/resolver.spec.ts
+++ b/tests/unit/utils/recruitingCalendar/resolver.spec.ts
@@ -24,9 +24,27 @@ describe("resolveCalendarKey", () => {
     expect(resolveCalendarKey("Football")).toBe("FBS");
     expect(resolveCalendarKey("Football", { footballSubdivision: "FCS" })).toBe("FCS");
   });
-  it("no-calendar sports fall to Other", () => {
-    for (const s of ["Soccer", "Swimming", "Tennis", "Wrestling", "Ice Hockey", "Field Hockey", "Rowing", "Water Polo"] as const) {
+  it("sports without any published NCAA calendar fall to the generic Other default", () => {
+    for (const s of ["Tennis", "Wrestling", "Water Polo"] as const) {
       expect(resolveCalendarKey(s)).toBe("Other");
     }
+  });
+  it("Other-bundle sports with enumerated per-sport windows resolve to their sub-key", () => {
+    expect(resolveCalendarKey("Swimming")).toBe("OTHER_SWIM");
+    expect(resolveCalendarKey("Rowing")).toBe("OTHER_ROWING");
+    expect(resolveCalendarKey("Field Hockey")).toBe("OTHER_FIELDHOCKEY");
+  });
+  it("Soccer: gender-split sub-keys, default men's", () => {
+    expect(resolveCalendarKey("Soccer", { gender: "male" })).toBe("OTHER_MSOCCER");
+    expect(resolveCalendarKey("Soccer", { gender: "female" })).toBe("OTHER_WSOCCER");
+    expect(resolveCalendarKey("Soccer", { gender: null })).toBe("OTHER_MSOCCER");
+    expect(resolveCalendarKey("Soccer", { gender: "other" })).toBe("OTHER_MSOCCER");
+    expect(resolveCalendarKey("Soccer", { gender: "prefer_not_to_say" })).toBe("OTHER_MSOCCER");
+  });
+  it("Ice Hockey: gender-split sub-keys, default men's", () => {
+    expect(resolveCalendarKey("Ice Hockey", { gender: "male" })).toBe("OTHER_MICEHOCKEY");
+    expect(resolveCalendarKey("Ice Hockey", { gender: "female" })).toBe("OTHER_WICEHOCKEY");
+    expect(resolveCalendarKey("Ice Hockey", { gender: null })).toBe("OTHER_MICEHOCKEY");
+    expect(resolveCalendarKey("Ice Hockey", { gender: "prefer_not_to_say" })).toBe("OTHER_MICEHOCKEY");
   });
 });

--- a/tests/unit/utils/recruitingCalendar/resolver.spec.ts
+++ b/tests/unit/utils/recruitingCalendar/resolver.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveCalendarKey } from "~/utils/recruitingCalendar/resolver";
+import { resolveCalendarKey, NO_SPORT_FALLBACK } from "~/utils/recruitingCalendar/resolver";
 
 describe("resolveCalendarKey", () => {
   it("maps single-calendar sports", () => {
@@ -39,6 +39,9 @@ describe("resolveCalendarKey", () => {
     for (const s of ["Tennis", "Water Polo"] as const) {
       expect(resolveCalendarKey(s)).toBe("Other");
     }
+  });
+  it("NO_SPORT_FALLBACK (the decoupled neutral-sport default) resolves to Other", () => {
+    expect(resolveCalendarKey(NO_SPORT_FALLBACK)).toBe("Other");
   });
   it("Other-bundle sports with enumerated per-sport windows resolve to their sub-key", () => {
     expect(resolveCalendarKey("Swimming")).toBe("OTHER_SWIM");

--- a/tests/unit/utils/recruitingCalendar/resolver.spec.ts
+++ b/tests/unit/utils/recruitingCalendar/resolver.spec.ts
@@ -20,6 +20,17 @@ describe("resolveCalendarKey", () => {
     expect(resolveCalendarKey("Golf", { gender: "male" })).toBe("MGO");
     expect(resolveCalendarKey("Golf", { gender: "female" })).toBe("Other");
   });
+  it("golf: defaults to men's (MGO) for null/undefined-opts/other/prefer_not_to_say — locked, do not change", () => {
+    expect(resolveCalendarKey("Golf", { gender: null })).toBe("MGO");
+    expect(resolveCalendarKey("Golf")).toBe("MGO");
+    expect(resolveCalendarKey("Golf", { gender: "other" })).toBe("MGO");
+    expect(resolveCalendarKey("Golf", { gender: "prefer_not_to_say" })).toBe("MGO");
+    expect(resolveCalendarKey("Golf", { gender: "female" })).toBe("Other");
+  });
+  it("lacrosse: covers the male and no-opts branches (only WLA/female was previously tested)", () => {
+    expect(resolveCalendarKey("Lacrosse", { gender: "male" })).toBe("MLA");
+    expect(resolveCalendarKey("Lacrosse")).toBe("MLA");
+  });
   it("football subdivision toggle, default FBS", () => {
     expect(resolveCalendarKey("Football")).toBe("FBS");
     expect(resolveCalendarKey("Football", { footballSubdivision: "FCS" })).toBe("FCS");

--- a/tests/unit/utils/recruitingCalendar/resolver.spec.ts
+++ b/tests/unit/utils/recruitingCalendar/resolver.spec.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { resolveCalendarKey } from "~/utils/recruitingCalendar/resolver";
+
+describe("resolveCalendarKey", () => {
+  it("maps single-calendar sports", () => {
+    expect(resolveCalendarKey("Baseball")).toBe("MBA");
+    expect(resolveCalendarKey("Softball")).toBe("WSB");
+    expect(resolveCalendarKey("Track & Field")).toBe("XCTF");
+    expect(resolveCalendarKey("Cross Country")).toBe("XCTF");
+    expect(resolveCalendarKey("Volleyball")).toBe("WVB");
+  });
+  it("resolves gender-split sports", () => {
+    expect(resolveCalendarKey("Basketball", { gender: "male" })).toBe("MBB");
+    expect(resolveCalendarKey("Basketball", { gender: "female" })).toBe("WBB");
+    expect(resolveCalendarKey("Lacrosse", { gender: "female" })).toBe("WLA");
+    expect(resolveCalendarKey("Basketball", { gender: null })).toBe("MBB"); // default men's
+    expect(resolveCalendarKey("Basketball", { gender: "prefer_not_to_say" })).toBe("MBB");
+  });
+  it("golf: men→MGO, else Other", () => {
+    expect(resolveCalendarKey("Golf", { gender: "male" })).toBe("MGO");
+    expect(resolveCalendarKey("Golf", { gender: "female" })).toBe("Other");
+  });
+  it("football subdivision toggle, default FBS", () => {
+    expect(resolveCalendarKey("Football")).toBe("FBS");
+    expect(resolveCalendarKey("Football", { footballSubdivision: "FCS" })).toBe("FCS");
+  });
+  it("no-calendar sports fall to Other", () => {
+    for (const s of ["Soccer", "Swimming", "Tennis", "Wrestling", "Ice Hockey", "Field Hockey", "Rowing", "Water Polo"] as const) {
+      expect(resolveCalendarKey(s)).toBe("Other");
+    }
+  });
+});

--- a/tests/unit/utils/recruitingCalendar/resolver.spec.ts
+++ b/tests/unit/utils/recruitingCalendar/resolver.spec.ts
@@ -16,6 +16,10 @@ describe("resolveCalendarKey", () => {
     expect(resolveCalendarKey("Basketball", { gender: null })).toBe("MBB"); // default men's
     expect(resolveCalendarKey("Basketball", { gender: "prefer_not_to_say" })).toBe("MBB");
   });
+  it("normalizes gender case — a capitalized 'Female' still resolves to the women's calendar", () => {
+    expect(resolveCalendarKey("Basketball", { gender: "Female" })).toBe("WBB");
+    expect(resolveCalendarKey("Basketball", { gender: "FEMALE" })).toBe("WBB");
+  });
   it("golf: men→MGO, else Other", () => {
     expect(resolveCalendarKey("Golf", { gender: "male" })).toBe("MGO");
     expect(resolveCalendarKey("Golf", { gender: "female" })).toBe("Other");

--- a/utils/ncaaRecruitingCalendar.ts
+++ b/utils/ncaaRecruitingCalendar.ts
@@ -228,6 +228,11 @@ export const ALL_MILESTONES: Milestone[] = [
  * Get upcoming milestones filtered by date, phase, and division
  * @param params - Configuration object
  * @returns Array of upcoming milestones, sorted by date
+ *
+ * Superseded by the sport-aware `getUpcomingMilestones` in
+ * `~/utils/recruitingCalendar/resolver.ts` — this legacy, non-sport-aware
+ * version is retained only because its own existing tests still cover it.
+ * Retire in a follow-up once those tests are ported/removed.
  */
 export function getUpcomingMilestones(params: {
   currentDate?: Date;

--- a/utils/ncaaRecruitingCalendar.ts
+++ b/utils/ncaaRecruitingCalendar.ts
@@ -23,144 +23,11 @@ export interface Milestone {
   description?: string;
 }
 
-/**
- * NCAA Division I Recruiting Calendar for 2026
- * Dead periods = No recruiting contact allowed
- * Quiet periods = Limited contact, no in-person visits
- * Contact/Evaluation = Normal recruiting allowed
- */
-export const RECRUITING_CALENDAR_2026: RecruitingPeriod[] = [
-  // Dead Periods (No contact permitted)
-  {
-    type: "dead",
-    // eslint-disable-next-line local/no-date-only-string-constructor -- pre-existing pattern outside Phase 7's assigned sweep (planning/audit-2026-07-27-findings.md cluster); flagged for a follow-up pass, not fixed here to keep this phase scoped.
-    start: new Date("2026-11-22"),
-    // eslint-disable-next-line local/no-date-only-string-constructor -- pre-existing pattern outside Phase 7's assigned sweep (planning/audit-2026-07-27-findings.md cluster); flagged for a follow-up pass, not fixed here to keep this phase scoped.
-    end: new Date("2026-11-29"),
-    division: "D1",
-    description: "Thanksgiving Break",
-  },
-  {
-    type: "dead",
-    // eslint-disable-next-line local/no-date-only-string-constructor -- pre-existing pattern outside Phase 7's assigned sweep (planning/audit-2026-07-27-findings.md cluster); flagged for a follow-up pass, not fixed here to keep this phase scoped.
-    start: new Date("2026-12-20"),
-    // eslint-disable-next-line local/no-date-only-string-constructor -- pre-existing pattern outside Phase 7's assigned sweep (planning/audit-2026-07-27-findings.md cluster); flagged for a follow-up pass, not fixed here to keep this phase scoped.
-    end: new Date("2027-01-03"),
-    division: "D1",
-    description: "Winter Break",
-  },
-  {
-    type: "dead",
-    // eslint-disable-next-line local/no-date-only-string-constructor -- pre-existing pattern outside Phase 7's assigned sweep (planning/audit-2026-07-27-findings.md cluster); flagged for a follow-up pass, not fixed here to keep this phase scoped.
-    start: new Date("2027-03-15"),
-    // eslint-disable-next-line local/no-date-only-string-constructor -- pre-existing pattern outside Phase 7's assigned sweep (planning/audit-2026-07-27-findings.md cluster); flagged for a follow-up pass, not fixed here to keep this phase scoped.
-    end: new Date("2027-04-10"),
-    division: "D1",
-    description: "Spring Break / Early Season",
-  },
-
-  // Quiet Periods (Limited contact only)
-  {
-    type: "quiet",
-    // eslint-disable-next-line local/no-date-only-string-constructor -- pre-existing pattern outside Phase 7's assigned sweep (planning/audit-2026-07-27-findings.md cluster); flagged for a follow-up pass, not fixed here to keep this phase scoped.
-    start: new Date("2026-09-01"),
-    // eslint-disable-next-line local/no-date-only-string-constructor -- pre-existing pattern outside Phase 7's assigned sweep (planning/audit-2026-07-27-findings.md cluster); flagged for a follow-up pass, not fixed here to keep this phase scoped.
-    end: new Date("2026-09-10"),
-    division: "D1",
-    description: "Dead Period for Freshmen",
-  },
-];
-
-/**
- * Check if a given date falls within a dead period
- * @param date - Date to check
- * @param division - NCAA division (default: D1)
- * @returns true if date is during a dead period
- */
-export function isDeadPeriod(
-  date: Date,
-  division: "D1" | "D2" | "D3" = "D1",
-): boolean {
-  return RECRUITING_CALENDAR_2026.some(
-    (period) =>
-      period.type === "dead" &&
-      period.division === division &&
-      date >= period.start &&
-      date <= period.end,
-  );
-}
-
-/**
- * Check if a given date falls within a quiet period
- * @param date - Date to check
- * @param division - NCAA division (default: D1)
- * @returns true if date is during a quiet period
- */
-export function isQuietPeriod(
-  date: Date,
-  division: "D1" | "D2" | "D3" = "D1",
-): boolean {
-  return RECRUITING_CALENDAR_2026.some(
-    (period) =>
-      period.type === "quiet" &&
-      period.division === division &&
-      date >= period.start &&
-      date <= period.end,
-  );
-}
-
-/**
- * Get the message for a dead period at a given date
- * @param date - Date to check
- * @param division - NCAA division (default: D1)
- * @returns Message describing the dead period, or null if not in dead period
- */
-export function getDeadPeriodMessage(
-  date: Date,
-  division: "D1" | "D2" | "D3" = "D1",
-): string | null {
-  const period = RECRUITING_CALENDAR_2026.find(
-    (p) =>
-      p.type === "dead" &&
-      p.division === division &&
-      date >= p.start &&
-      date <= p.end,
-  );
-
-  if (!period) return null;
-
-  return `Dead period - no recruiting contact permitted per NCAA rules (${period.description})`;
-}
-
-/**
- * Get the next dead period from a given date
- * @param date - Starting date to check from (default: today)
- * @param division - NCAA division (default: D1)
- * @returns Next dead period or null if none found
- */
-export function getNextDeadPeriod(
-  date: Date = new Date(),
-  division: "D1" | "D2" | "D3" = "D1",
-): RecruitingPeriod | null {
-  const futurePeriods = RECRUITING_CALENDAR_2026.filter(
-    (p) => p.type === "dead" && p.division === division && p.start >= date,
-  );
-
-  if (futurePeriods.length === 0) return null;
-
-  return futurePeriods.sort((a, b) => a.start.getTime() - b.start.getTime())[0];
-}
-
-/**
- * Get all recruiting periods for a division
- * @param division - NCAA division (default: D1)
- * @returns Array of recruiting periods
- */
-export function getRecruitingCalendar(
-  division: "D1" | "D2" | "D3" = "D1",
-): RecruitingPeriod[] {
-  return RECRUITING_CALENDAR_2026.filter((p) => p.division === division);
-}
+// NOTE: dead/quiet period data (RECRUITING_CALENDAR_2026) and the queries
+// over it (isDeadPeriod/isQuietPeriod/getDeadPeriodMessage/getNextDeadPeriod/
+// getRecruitingCalendar) were sportless and D1-only; they now live sport-aware
+// in ~/utils/recruitingCalendar (see resolver.ts + calendarData.ts). Only the
+// still-generic milestone lists and helpers below remain here.
 
 // ============================================================================
 // MILESTONE CALENDAR - Important dates for recruiting timeline
@@ -264,6 +131,10 @@ export const ACT_TEST_DATES_2026: Milestone[] = [
   },
 ];
 
+// NOTE: pre-existing division-value bug, tracked separately — these entries
+// use "DI" (not the "D1" value everything else in this file uses), so
+// division-scoped filters silently exclude them. Not fixed here; fixing would
+// surface previously-hidden milestones, an unrelated behavior change.
 export const NCAA_DEADLINES_2026: Milestone[] = [
   {
     date: "2026-04-01",
@@ -340,35 +211,10 @@ export const COLLEGE_APPLICATION_DEADLINES_2026: Milestone[] = [
   },
 ];
 
-export const BASEBALL_SIGNING_PERIODS_2026: Milestone[] = [
-  {
-    date: "2026-11-11",
-    title: "Early Signing Period Begins",
-    type: "signing",
-    division: "D1",
-    description: "D1 early national signing period (Nov 11-13, 2026)",
-  },
-  {
-    date: "2026-11-13",
-    title: "Early Signing Period Ends",
-    type: "signing",
-    division: "D1",
-  },
-  {
-    date: "2027-02-03",
-    title: "Regular Signing Period Begins",
-    type: "signing",
-    division: "D1",
-    description: "D1 regular signing period begins",
-  },
-  {
-    date: "2027-04-15",
-    title: "Regular Signing Period Ends",
-    type: "signing",
-    division: "D1",
-    description: "D1 regular signing period ends",
-  },
-];
+// Sport signing-period milestones (e.g. baseball's early/regular signing
+// periods) are no longer generic — they live on each sport's own
+// `SportCalendar.milestones` in ~/utils/recruitingCalendar/calendarData.ts
+// (see MBA) and are merged in sport-aware by getUpcomingMilestones there.
 
 export const ALL_MILESTONES: Milestone[] = [
   ...SAT_TEST_DATES_2026,
@@ -376,7 +222,6 @@ export const ALL_MILESTONES: Milestone[] = [
   ...NCAA_DEADLINES_2026,
   ...NAIA_DEADLINES_2026,
   ...COLLEGE_APPLICATION_DEADLINES_2026,
-  ...BASEBALL_SIGNING_PERIODS_2026,
 ];
 
 /**

--- a/utils/recruitingCalendar/calendarData.ts
+++ b/utils/recruitingCalendar/calendarData.ts
@@ -25,15 +25,32 @@
  */
 import type { NcaaCalendarKey, SportCalendar } from "./types";
 
+/**
+ * The single NCAA recruiting-calendar season this dataset covers. Bump this
+ * (plus `SEASON_END` and the transcription below it) once a year — every
+ * plain-hyphen `source` URL and the app's disclaimer/staleness check read
+ * from here.
+ */
+export const SEASON = "2026-27";
+
+/** The last date `SEASON`'s data is current through — drives the L6b staleness banner. */
+export const SEASON_END = new Date("2027-07-31T23:59:59Z");
+
 const VERIFIED_ON = "2026-08-23";
 
-const BUCKET = "https://ncaaorg.s3.amazonaws.com/compliance/recruiting/calendar/2026-27";
+const BUCKET = `https://ncaaorg.s3.amazonaws.com/compliance/recruiting/calendar/${SEASON}`;
+
+// The "Other" bundle PDF's filename uses an EN DASH (U+2013) in "2026–27",
+// not a hyphen — verified as the real working NCAA URL; a hyphenated form
+// 404s. Kept as its own token, deliberately NOT derived from `SEASON`, so
+// nothing ever silently ASCII-ifies it.
+const OTHER_SEASON_EN_DASH = "2026–27";
 
 // ---------------------------------------------------------------------------
 // MBA — Division I Baseball
 // ---------------------------------------------------------------------------
 const MBA: SportCalendar = {
-  source: `${BUCKET}/2026-27D1Rec_MBARecruitingCalendar.pdf`,
+  source: `${BUCKET}/${SEASON}D1Rec_MBARecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
     {
@@ -120,7 +137,7 @@ const MBA: SportCalendar = {
 // WSB — Division I Softball
 // ---------------------------------------------------------------------------
 const WSB: SportCalendar = {
-  source: `${BUCKET}/2026-27D1Rec_WSBRecruitingCalendar.pdf`,
+  source: `${BUCKET}/${SEASON}D1Rec_WSBRecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
     { type: "contact", start: "2026-08-01", end: "2026-08-09", description: "Contact Period", confidence: "HIGH" },
@@ -214,7 +231,7 @@ const WSB: SportCalendar = {
 // MBB — Division I Men's Basketball
 // ---------------------------------------------------------------------------
 const MBB: SportCalendar = {
-  source: `${BUCKET}/2026-27D1Rec_MBBRecruitingCalendar.pdf`,
+  source: `${BUCKET}/${SEASON}D1Rec_MBBRecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
     { type: "dead", start: "2026-08-01", end: "2026-08-19", description: "Dead Period", confidence: "HIGH" },
@@ -312,7 +329,7 @@ const MBB: SportCalendar = {
 // WBB — Division I Women's Basketball
 // ---------------------------------------------------------------------------
 const WBB: SportCalendar = {
-  source: `${BUCKET}/2026-27D1Rec_WBBRecruitingCalendar.pdf`,
+  source: `${BUCKET}/${SEASON}D1Rec_WBBRecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
     {
@@ -447,7 +464,7 @@ const WBB: SportCalendar = {
 // FBS — Division I Football Bowl Subdivision
 // ---------------------------------------------------------------------------
 const FBS: SportCalendar = {
-  source: `${BUCKET}/2026-27D1Rec_FBSRecruitingCalendar.pdf`,
+  source: `${BUCKET}/${SEASON}D1Rec_FBSRecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
     { type: "dead", start: "2026-08-01", end: "2026-08-31", description: "Dead Period — full month of August", confidence: "HIGH" },
@@ -495,7 +512,7 @@ const FBS: SportCalendar = {
 // FCS — Division I Football Championship Subdivision
 // ---------------------------------------------------------------------------
 const FCS: SportCalendar = {
-  source: `${BUCKET}/2026-27D1Rec_FCSRecruitingCalendar.pdf`,
+  source: `${BUCKET}/${SEASON}D1Rec_FCSRecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
     { type: "dead", start: "2026-08-01", end: "2026-08-31", description: "Dead Period — full month of August", confidence: "HIGH" },
@@ -559,7 +576,7 @@ const FCS: SportCalendar = {
 // XCTF — Division I Cross Country / Track & Field (combined)
 // ---------------------------------------------------------------------------
 const XCTF: SportCalendar = {
-  source: `${BUCKET}/2026-27D1Rec_XCTFRecruitingCalendar.pdf`,
+  source: `${BUCKET}/${SEASON}D1Rec_XCTFRecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
     {
@@ -621,7 +638,7 @@ const XCTF: SportCalendar = {
 // WVB — Division I Women's Volleyball
 // ---------------------------------------------------------------------------
 const WVB: SportCalendar = {
-  source: `${BUCKET}/2026-27D1Rec_WVBRecruitingCalendar.pdf`,
+  source: `${BUCKET}/${SEASON}D1Rec_WVBRecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
     { type: "quiet", start: "2026-08-01", end: "2026-08-31", description: "Quiet Period — in-person contact only on campus", confidence: "MEDIUM" },
@@ -677,7 +694,7 @@ const WVB: SportCalendar = {
 // MGO — Division I Men's Golf
 // ---------------------------------------------------------------------------
 const MGO: SportCalendar = {
-  source: `${BUCKET}/2026-27D1Rec_MGORecruitingCalendar.pdf`,
+  source: `${BUCKET}/${SEASON}D1Rec_MGORecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
     { type: "contact", start: "2026-08-01", end: "2026-11-25", description: "Contact Period", confidence: "MEDIUM" },
@@ -733,7 +750,7 @@ const MGO: SportCalendar = {
 // MLA — Division I Men's Lacrosse
 // ---------------------------------------------------------------------------
 const MLA: SportCalendar = {
-  source: `${BUCKET}/2026-27D1Rec_MLARecruitingCalendar.pdf`,
+  source: `${BUCKET}/${SEASON}D1Rec_MLARecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
     { type: "contact", start: "2026-08-01", end: "2026-08-03", description: "Contact Period", confidence: "MEDIUM" },
@@ -831,7 +848,7 @@ const MLA: SportCalendar = {
 // WLA — Division I Women's Lacrosse
 // ---------------------------------------------------------------------------
 const WLA: SportCalendar = {
-  source: `${BUCKET}/2026-27D1Rec_WLARecruitingCalendar.pdf`,
+  source: `${BUCKET}/${SEASON}D1Rec_WLARecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
     {
@@ -950,6 +967,13 @@ const WLA: SportCalendar = {
 };
 
 // ---------------------------------------------------------------------------
+// OTHER_SOURCE — shared source PDF for the generic OTHER default below and
+// every OTHER_* per-sport sub-calendar (all transcribed from the same D1
+// "Other" bundle PDF).
+// ---------------------------------------------------------------------------
+const OTHER_SOURCE = `${BUCKET}/${OTHER_SEASON_EN_DASH}D1Rec_OtherRecruitingCalendar.pdf`;
+
+// ---------------------------------------------------------------------------
 // Other — Division I "All Other Sports" generic default. Used for app
 // sports with no dedicated NCAA recruiting calendar AND no sport-specific
 // windows enumerated in the "Other" bundle PDF: Tennis, Water Polo, and
@@ -958,7 +982,7 @@ const WLA: SportCalendar = {
 // same PDF) instead of falling back to this generic default.
 // ---------------------------------------------------------------------------
 const OTHER: SportCalendar = {
-  source: `${BUCKET}/2026–27D1Rec_OtherRecruitingCalendar.pdf`,
+  source: OTHER_SOURCE,
   verifiedOn: VERIFIED_ON,
   periods: [
     {
@@ -981,8 +1005,6 @@ const OTHER: SportCalendar = {
 // default above (see resolver.ts + task report for the Wrestling scope note).
 // All cite the same "Other" D1 PDF as OTHER.
 // ---------------------------------------------------------------------------
-const OTHER_SOURCE = `${BUCKET}/2026–27D1Rec_OtherRecruitingCalendar.pdf`;
-
 const OTHER_MSOCCER: SportCalendar = {
   source: OTHER_SOURCE,
   verifiedOn: VERIFIED_ON,
@@ -1281,7 +1303,7 @@ export const D1_CALENDARS: Record<NcaaCalendarKey, SportCalendar> = {
 // scope for this generic fallback).
 // ---------------------------------------------------------------------------
 export const D2_ALL_SPORTS: SportCalendar = {
-  source: `${BUCKET}/2026-27D2Rec_RecruitingCalendar_AllSports.pdf`,
+  source: `${BUCKET}/${SEASON}D2Rec_RecruitingCalendar_AllSports.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
     {

--- a/utils/recruitingCalendar/calendarData.ts
+++ b/utils/recruitingCalendar/calendarData.ts
@@ -1236,9 +1236,13 @@ const OTHER_WWRESTLING: SportCalendar = {
       confidence: "HIGH",
     },
     {
+      // Fragment dates this 2026 but flags the year as ambiguous ("could be
+      // read as generic annual recurrence"); rolled to 2027 for consistency
+      // with every other July period in this file (WLA, MLA, OTHER_WSOCCER)
+      // and because the 2026-27 season calendar runs Aug 2026 -> Jul 2027.
       type: "dead",
-      start: "2026-07-26",
-      end: "2026-08-01",
+      start: "2027-07-26",
+      end: "2027-08-01",
       description:
         "Dead Period — Monday before the National Wrestling Coaches Association Convention through the day of adjournment of the convention",
       confidence: "MEDIUM",

--- a/utils/recruitingCalendar/calendarData.ts
+++ b/utils/recruitingCalendar/calendarData.ts
@@ -952,12 +952,10 @@ const WLA: SportCalendar = {
 // ---------------------------------------------------------------------------
 // Other — Division I "All Other Sports" generic default. Used for app
 // sports with no dedicated NCAA recruiting calendar AND no sport-specific
-// windows enumerated in the "Other" bundle PDF: Tennis, Water Polo, Wrestling
-// (see resolver.ts comment — Wrestling IS enumerated in the source but is
-// deliberately kept on the generic default per task scope), non-male Golf.
-// Soccer, Swimming, Ice Hockey, Rowing, and Field Hockey have their own
-// OTHER_* sub-calendars below (transcribed from the same PDF) instead of
-// falling back to this generic default.
+// windows enumerated in the "Other" bundle PDF: Tennis, Water Polo, and
+// non-male Golf. Soccer, Swimming, Ice Hockey, Rowing, Field Hockey, and
+// Wrestling have their own OTHER_* sub-calendars below (transcribed from the
+// same PDF) instead of falling back to this generic default.
 // ---------------------------------------------------------------------------
 const OTHER: SportCalendar = {
   source: `${BUCKET}/2026–27D1Rec_OtherRecruitingCalendar.pdf`,
@@ -1195,6 +1193,60 @@ const OTHER_FIELDHOCKEY: SportCalendar = {
   milestones: [],
 };
 
+const OTHER_MWRESTLING: SportCalendar = {
+  source: OTHER_SOURCE,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description:
+        "Dead Period — Monday through Thursday of the initial week for the fall signing date for athletics aid agreements",
+      confidence: "HIGH",
+    },
+    {
+      type: "recruiting_shutdown",
+      start: "2026-12-24",
+      end: "2026-12-26",
+      description: "Recruiting Shutdown, Dec 24–26 (label only)",
+      confidence: "HIGH",
+    },
+    {
+      type: "recruiting_shutdown",
+      start: "2027-03-16",
+      end: "2027-03-21",
+      description: "Recruiting Shutdown — Tuesday through Sunday of the NCAA Division I Wrestling Championships",
+      confidence: "HIGH",
+    },
+  ],
+  milestones: [],
+};
+
+const OTHER_WWRESTLING: SportCalendar = {
+  source: OTHER_SOURCE,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description:
+        "Dead Period — Monday through Thursday of the initial week for the fall signing date for athletics aid agreements",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-07-26",
+      end: "2026-08-01",
+      description:
+        "Dead Period — Monday before the National Wrestling Coaches Association Convention through the day of adjournment of the convention",
+      confidence: "MEDIUM",
+    },
+  ],
+  milestones: [],
+};
+
 export const D1_CALENDARS: Record<NcaaCalendarKey, SportCalendar> = {
   MBA,
   WSB,
@@ -1215,6 +1267,8 @@ export const D1_CALENDARS: Record<NcaaCalendarKey, SportCalendar> = {
   OTHER_WICEHOCKEY,
   OTHER_ROWING,
   OTHER_FIELDHOCKEY,
+  OTHER_MWRESTLING,
+  OTHER_WWRESTLING,
 };
 
 // ---------------------------------------------------------------------------

--- a/utils/recruitingCalendar/calendarData.ts
+++ b/utils/recruitingCalendar/calendarData.ts
@@ -950,14 +950,14 @@ const WLA: SportCalendar = {
 };
 
 // ---------------------------------------------------------------------------
-// Other — Division I "All Other Sports" (catch-all for app sports with no
-// dedicated NCAA recruiting calendar: Soccer, Swimming, Tennis, Wrestling,
-// Ice Hockey, Field Hockey, Rowing, Water Polo — and non-male Golf).
-// Only the "ALL OTHER SPORTS" track is used here (the app's true fallback);
-// the per-sport breakdowns in the source fragment (field hockey, women's
-// golf, gymnastics, rowing, ice hockey, soccer, swimming, wrestling) are
-// finer-grained than this project's single "Other" calendar key models, and
-// are not separately surfaced.
+// Other — Division I "All Other Sports" generic default. Used for app
+// sports with no dedicated NCAA recruiting calendar AND no sport-specific
+// windows enumerated in the "Other" bundle PDF: Tennis, Water Polo, Wrestling
+// (see resolver.ts comment — Wrestling IS enumerated in the source but is
+// deliberately kept on the generic default per task scope), non-male Golf.
+// Soccer, Swimming, Ice Hockey, Rowing, and Field Hockey have their own
+// OTHER_* sub-calendars below (transcribed from the same PDF) instead of
+// falling back to this generic default.
 // ---------------------------------------------------------------------------
 const OTHER: SportCalendar = {
   source: `${BUCKET}/2026–27D1Rec_OtherRecruitingCalendar.pdf`,
@@ -969,6 +969,226 @@ const OTHER: SportCalendar = {
       end: "2026-11-12",
       description:
         "Dead Period — Monday through Thursday of the initial week for the fall signing date for athletics aid agreements",
+      confidence: "HIGH",
+    },
+  ],
+  milestones: [],
+};
+
+// ---------------------------------------------------------------------------
+// OTHER_* — per-sport sub-calendars enumerated within the D1 "Other" bundle
+// PDF. Only sports the fragment actually enumerates dead/quiet/
+// recruiting_shutdown windows for get a sub-key; Tennis, Wrestling, and Water
+// Polo have no dedicated table in the source and stay on the generic OTHER
+// default above (see resolver.ts + task report for the Wrestling scope note).
+// All cite the same "Other" D1 PDF as OTHER.
+// ---------------------------------------------------------------------------
+const OTHER_SOURCE = `${BUCKET}/2026–27D1Rec_OtherRecruitingCalendar.pdf`;
+
+const OTHER_MSOCCER: SportCalendar = {
+  source: OTHER_SOURCE,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description:
+        "Dead Period — Monday through Thursday of the initial week for the fall signing date for athletics aid agreements",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-12-11",
+      end: "2026-12-14",
+      description:
+        "Dead Period — Friday through Monday of the NCAA Division I Men's Soccer Championship. A coaching staff member may attend an event conducted in conjunction with and in the host city of the championship.",
+      confidence: "HIGH",
+    },
+    {
+      type: "quiet",
+      start: "2026-12-23",
+      end: "2026-12-25",
+      description: "Quiet Period, Dec 23–25 (label only)",
+      confidence: "HIGH",
+    },
+  ],
+  milestones: [],
+};
+
+const OTHER_WSOCCER: SportCalendar = {
+  source: OTHER_SOURCE,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    {
+      type: "dead",
+      start: "2026-08-01",
+      end: "2026-08-11",
+      description: "Dead Period, Aug 1–11 (label only)",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description:
+        "Dead Period — Monday through Thursday of the initial week for the fall signing date for athletics aid agreements",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-12-16",
+      end: "2027-01-06",
+      description: "Dead Period, Dec 16–Jan 6, 2027 (label only)",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2027-07-28",
+      end: "2027-07-31",
+      description:
+        "For four-year prospective student-athletes, three (3) consecutive weeks starting 21 days following the final date to provide notification of transfer",
+      confidence: "MEDIUM",
+    },
+  ],
+  milestones: [],
+};
+
+const OTHER_SWIM: SportCalendar = {
+  source: OTHER_SOURCE,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    {
+      type: "recruiting_shutdown",
+      start: "2026-08-17",
+      end: "2026-08-23",
+      description: "Recruiting Shutdown — the third Monday in August through the following Sunday",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description:
+        "Dead Period — Monday through Thursday of the initial week for the fall signing date for athletics aid agreements",
+      confidence: "HIGH",
+    },
+    {
+      type: "recruiting_shutdown",
+      start: "2026-12-18",
+      end: "2027-01-07",
+      description: "Recruiting Shutdown, Dec 18–Jan 7, 2027 (label only)",
+      confidence: "HIGH",
+    },
+    {
+      type: "recruiting_shutdown",
+      start: "2027-02-07",
+      end: "2027-02-20",
+      description:
+        "Recruiting Shutdown — 14 consecutive days beginning with the Sunday that is 38 days before the first day of the NCAA Division I Women's Swimming Championship",
+      confidence: "HIGH",
+    },
+  ],
+  milestones: [],
+};
+
+const OTHER_MICEHOCKEY: SportCalendar = {
+  source: OTHER_SOURCE,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description:
+        "Dead Period — Monday through Thursday of the initial week for the fall signing date for athletics aid agreements",
+      confidence: "HIGH",
+    },
+    {
+      // "@ NOON" end-time boundary rounded to the day per the locked edge-case rule.
+      type: "dead",
+      start: "2027-04-07",
+      end: "2027-04-11",
+      description:
+        "Dead Period — Wednesday before the NCAA Division I Men's Ice Hockey Championship to the Sunday after the championship game (effective noon)",
+      confidence: "HIGH",
+    },
+  ],
+  milestones: [],
+};
+
+const OTHER_WICEHOCKEY: SportCalendar = {
+  source: OTHER_SOURCE,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description:
+        "Dead Period — Monday through Thursday of the initial week for the fall signing date for athletics aid agreements",
+      confidence: "HIGH",
+    },
+    {
+      // "@ NOON" end-time boundary rounded to the day per the locked edge-case rule.
+      type: "dead",
+      start: "2027-03-18",
+      end: "2027-03-22",
+      description:
+        "Dead Period — the day prior to the National Collegiate Women's Ice Hockey Championship to the day after the game (effective noon)",
+      confidence: "HIGH",
+    },
+    {
+      type: "quiet",
+      start: "2027-04-26",
+      end: "2027-05-31",
+      description:
+        "Quiet Period — the Monday prior to the American Hockey Coaches Association Convention through May 31",
+      confidence: "HIGH",
+    },
+  ],
+  milestones: [],
+};
+
+const OTHER_ROWING: SportCalendar = {
+  source: OTHER_SOURCE,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description:
+        "Dead Period — Monday through Thursday of the initial week for the fall signing date for athletics aid agreements",
+      confidence: "HIGH",
+    },
+    {
+      type: "recruiting_shutdown",
+      start: "2026-12-22",
+      end: "2027-01-02",
+      description: "Recruiting Shutdown, Dec 22–Jan 2, 2027",
+      confidence: "HIGH",
+    },
+  ],
+  milestones: [],
+};
+
+const OTHER_FIELDHOCKEY: SportCalendar = {
+  source: OTHER_SOURCE,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    {
+      type: "quiet",
+      start: "2026-12-20",
+      end: "2026-12-23",
+      description: "Quiet Period (label only; no detail text on source card)",
+      confidence: "HIGH",
+    },
+    {
+      type: "recruiting_shutdown",
+      start: "2026-12-24",
+      end: "2027-01-01",
+      description: "Recruiting Shutdown (label only; no detail text on source card)",
       confidence: "HIGH",
     },
   ],
@@ -988,6 +1208,13 @@ export const D1_CALENDARS: Record<NcaaCalendarKey, SportCalendar> = {
   MLA,
   WLA,
   Other: OTHER,
+  OTHER_MSOCCER,
+  OTHER_WSOCCER,
+  OTHER_SWIM,
+  OTHER_MICEHOCKEY,
+  OTHER_WICEHOCKEY,
+  OTHER_ROWING,
+  OTHER_FIELDHOCKEY,
 };
 
 // ---------------------------------------------------------------------------

--- a/utils/recruitingCalendar/calendarData.ts
+++ b/utils/recruitingCalendar/calendarData.ts
@@ -1,0 +1,1019 @@
+/**
+ * NCAA 2026-27 recruiting-calendar dataset — transcribed from the official
+ * NCAA S3-hosted PDFs (per-sport recruiting calendars, ncaaorg.s3.amazonaws.com).
+ *
+ * Every `SportCalendar.source` cites the exact PDF it was transcribed from;
+ * `verifiedOn` is the date a human/agent last checked the transcription against
+ * that PDF. Every period carries a `confidence` (HIGH/MEDIUM/LOW) reflecting
+ * how directly the PDF (and any cross-checks) support that exact date range.
+ *
+ * Source fragments (read, not re-fetched, to build this file):
+ * - p2-spike-mba-calendar.md            → MBA
+ * - p2-data-softball-basketball.md      → WSB, MBB, WBB
+ * - p2-data-football-track.md           → FBS, FCS, XCTF
+ * - p2-data-vball-golf-lacrosse.md      → WVB, MGO, MLA, WLA
+ * - p2-data-other-d2.md                 → Other (D1 "All Other Sports"), D2_ALL
+ *
+ * Edge cases applied (locked, see plan):
+ * - MBB "TBD" combine windows (NBA G League Combine, NBA Draft Combine, NBPA
+ *   Top 100 Camp) are omitted — the PDF gives no concrete date, only "TBD".
+ * - MLA "@ NOON" boundaries are rounded to the day; "(effective noon)" is
+ *   appended to the description to preserve the intraday detail.
+ * - MBB legend term "Recruiting Period" maps to `contact` (closest of the 5
+ *   required types; the legend's own definition text matches other sports'
+ *   "Contact Period" definition).
+ */
+import type { NcaaCalendarKey, SportCalendar } from "./types";
+
+const VERIFIED_ON = "2026-08-23";
+
+const BUCKET = "https://ncaaorg.s3.amazonaws.com/compliance/recruiting/calendar/2026-27";
+
+// ---------------------------------------------------------------------------
+// MBA — Division I Baseball
+// ---------------------------------------------------------------------------
+const MBA: SportCalendar = {
+  source: `${BUCKET}/2026-27D1Rec_MBARecruitingCalendar.pdf`,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    {
+      type: "contact",
+      start: "2026-08-01",
+      end: "2026-08-16",
+      description:
+        "Contact period opens for rising juniors (Class of 2028) — in-person/off-campus contact, calls, texts, emails, official visits permitted",
+      confidence: "HIGH",
+    },
+    {
+      type: "quiet",
+      start: "2026-08-17",
+      end: "2026-09-10",
+      description: "Quiet period — in-person contact only on campus",
+      confidence: "MEDIUM",
+    },
+    { type: "contact", start: "2026-09-11", end: "2026-10-11", description: "Contact period", confidence: "MEDIUM" },
+    {
+      type: "quiet",
+      start: "2026-10-12",
+      end: "2027-02-28",
+      description:
+        "Quiet period (long fall/early-year window; interrupted by the Nov dead period and two Recruiting Shutdowns)",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description: "Dead period spanning the D1/D2 early signing period open (Nov 11, 2026)",
+      confidence: "HIGH",
+    },
+    {
+      type: "recruiting_shutdown",
+      start: "2026-11-24",
+      end: "2026-11-29",
+      description: "Thanksgiving recruiting shutdown — no contacts, evaluations, visits, or correspondence",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "recruiting_shutdown",
+      start: "2026-12-22",
+      end: "2026-12-27",
+      description: "Winter-holiday recruiting shutdown",
+      confidence: "MEDIUM",
+    },
+    { type: "dead", start: "2027-01-07", end: "2027-01-10", description: "Dead period", confidence: "MEDIUM" },
+    {
+      type: "contact",
+      start: "2027-03-01",
+      end: "2027-07-31",
+      description: "Contact period (spring/summer, season-long — interrupted by 3 dead periods)",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2027-05-31",
+      end: "2027-06-07",
+      description: "Dead period (around College World Series selection/travel window)",
+      confidence: "MEDIUM",
+    },
+    { type: "dead", start: "2027-06-19", end: "2027-06-21", description: "Dead period", confidence: "MEDIUM" },
+    {
+      type: "dead",
+      start: "2027-07-03",
+      end: "2027-07-05",
+      description: "Dead period (July 4th)",
+      confidence: "HIGH",
+    },
+  ],
+  milestones: [
+    {
+      date: "2026-11-11",
+      title: "D1/D2 Early Signing Period Opens",
+      type: "signing",
+      description:
+        "Athletes sign a Written Offer of Athletics Aid (replaced the NLI in Oct 2024) — Class of 2027",
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// WSB — Division I Softball
+// ---------------------------------------------------------------------------
+const WSB: SportCalendar = {
+  source: `${BUCKET}/2026-27D1Rec_WSBRecruitingCalendar.pdf`,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    { type: "contact", start: "2026-08-01", end: "2026-08-09", description: "Contact Period", confidence: "HIGH" },
+    {
+      type: "evaluation",
+      start: "2026-08-10",
+      end: "2026-11-22",
+      description:
+        "Evaluation Period (scholastic practice/competition only); contains a carved-out Dead Period Aug 28–Sep 3 and a denser evaluation window Oct 17–Nov 22",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-08-28",
+      end: "2026-09-03",
+      description: "Dead Period (carved out of the Aug 10–Nov 22 evaluation window)",
+      confidence: "HIGH",
+    },
+    {
+      type: "evaluation",
+      start: "2026-10-17",
+      end: "2026-11-22",
+      description:
+        "Evaluation Period (scholastic AND nonscholastic practice/competition); active only Oct 17–18, 24–25, Oct 31–Nov 1, Nov 7–8, 14–15, 21–22 — nested inside the broader Aug10–Nov22 evaluation period",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description: "Dead Period (carved out of the Oct17–Nov22 evaluation window)",
+      confidence: "HIGH",
+    },
+    {
+      type: "quiet",
+      start: "2026-11-23",
+      end: "2027-01-02",
+      description:
+        "Quiet Period; contains carved-out Recruiting Shutdown Nov 25–29, Dead Period Dec 9–12, Recruiting Shutdown Dec 22–26, Recruiting Shutdown Dec 31–Jan 2",
+      confidence: "HIGH",
+    },
+    {
+      type: "recruiting_shutdown",
+      start: "2026-11-25",
+      end: "2026-11-29",
+      description: "Recruiting Shutdown",
+      confidence: "HIGH",
+    },
+    { type: "dead", start: "2026-12-09", end: "2026-12-12", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "recruiting_shutdown",
+      start: "2026-12-22",
+      end: "2026-12-26",
+      description: "Recruiting Shutdown",
+      confidence: "HIGH",
+    },
+    {
+      type: "recruiting_shutdown",
+      start: "2026-12-31",
+      end: "2027-01-02",
+      description: "Recruiting Shutdown",
+      confidence: "HIGH",
+    },
+    {
+      type: "evaluation",
+      start: "2027-01-03",
+      end: "2027-05-31",
+      description:
+        "Evaluation Period (scholastic practice/competition only; evaluations also permitted during HS regional/state championship competition not falling in a dead period)",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2027-06-01",
+      end: "2027-06-11",
+      description: "Dead Period (WCWS-anchored; dates shift with WCWS schedule)",
+      confidence: "HIGH",
+    },
+    {
+      type: "contact",
+      start: "2027-06-12",
+      end: "2027-07-31",
+      description: "Contact Period (WCWS-anchored; begins the day after the dead period)",
+      confidence: "HIGH",
+    },
+  ],
+  milestones: [],
+};
+
+// ---------------------------------------------------------------------------
+// MBB — Division I Men's Basketball
+// ---------------------------------------------------------------------------
+const MBB: SportCalendar = {
+  source: `${BUCKET}/2026-27D1Rec_MBBRecruitingCalendar.pdf`,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    { type: "dead", start: "2026-08-01", end: "2026-08-19", description: "Dead Period", confidence: "HIGH" },
+    { type: "quiet", start: "2026-08-20", end: "2026-09-08", description: "Quiet Period", confidence: "HIGH" },
+    {
+      type: "contact",
+      start: "2026-09-09",
+      end: "2027-04-30",
+      description:
+        "Recruiting Period (legend term for in-person off-campus contacts+evaluations; mapped to contact); contains 3 carved-out Dead Periods (Nov 9–12, Dec 24–26, Apr 1–8)",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description: "Dead Period (carved out of the Sep9–Apr30 recruiting period)",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-12-24",
+      end: "2026-12-26",
+      description: "Dead Period (carved out of the Sep9–Apr30 recruiting period)",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2027-04-01",
+      end: "2027-04-08",
+      description: "Dead Period (carved out of the Sep9–Apr30 recruiting period)",
+      confidence: "HIGH",
+    },
+    {
+      type: "quiet",
+      start: "2027-05-01",
+      end: "2027-06-30",
+      description:
+        "Quiet Period; contains a dense cluster of nested Evaluation/Dead sub-windows tied to specific camps/combines",
+      confidence: "HIGH",
+    },
+    // TBD combine windows omitted: NBA G League Combine (evaluation, PDF shows "TBD"),
+    // NBA Draft Combine (evaluation, PDF shows "TBD"), NBPA Top 100 Camp (evaluation,
+    // PDF shows "TBD") — no concrete dates published; 2025-26 equivalents were May 8–10,
+    // May 10–17, and Jun 10–11 respectively but the 2026-27 PDF gives no date to transcribe.
+    { type: "dead", start: "2027-05-09", end: "2027-05-09", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "evaluation",
+      start: "2027-05-14",
+      end: "2027-05-16",
+      description:
+        "Evaluation Period — NCAA certified events only and regularly scheduled international scholastic/nonscholastic team practice and competition; begins Friday 8 AM, ends Sunday 4 PM",
+      confidence: "HIGH",
+    },
+    { type: "dead", start: "2027-05-26", end: "2027-06-06", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "evaluation",
+      start: "2027-06-11",
+      end: "2027-06-13",
+      description: "Evaluation Period — for approved NCAA, NFHS and applicable two-year college governing body scholastic events",
+      confidence: "HIGH",
+    },
+    { type: "dead", start: "2027-06-19", end: "2027-06-20", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "evaluation",
+      start: "2027-06-25",
+      end: "2027-06-27",
+      description: "Evaluation Period — for approved NCAA, NFHS and applicable two-year college governing body scholastic events",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2027-07-01",
+      end: "2027-07-31",
+      description:
+        "Dead Period (a PSA may not make an unofficial visit in July unless already signed/deposited); contains a carved-out Evaluation sub-window Jul 8–11, 15–18",
+      confidence: "HIGH",
+    },
+    {
+      type: "evaluation",
+      start: "2027-07-08",
+      end: "2027-07-18",
+      description:
+        "Evaluation Period (active only Jul 8–11 and Jul 15–18, carved out of the Jul1–31 dead period) — NCAA certified events, institutional camps, permissible governing body events, and regularly scheduled international scholastic/nonscholastic team practice and competition; begins Thursday 8 AM, ends Sunday 6 PM",
+      confidence: "HIGH",
+    },
+    { type: "quiet", start: "2027-07-19", end: "2027-07-25", description: "Quiet Period", confidence: "HIGH" },
+    { type: "dead", start: "2027-08-01", end: "2027-08-18", description: "Dead Period", confidence: "HIGH" },
+    { type: "quiet", start: "2027-08-19", end: "2027-08-31", description: "Quiet Period", confidence: "HIGH" },
+  ],
+  milestones: [],
+};
+
+// ---------------------------------------------------------------------------
+// WBB — Division I Women's Basketball
+// ---------------------------------------------------------------------------
+const WBB: SportCalendar = {
+  source: `${BUCKET}/2026-27D1Rec_WBBRecruitingCalendar.pdf`,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    {
+      type: "quiet",
+      start: "2026-08-01",
+      end: "2026-08-31",
+      description: "Quiet Period; contains a carved-out Recruiting Shutdown Aug 10–16",
+      confidence: "HIGH",
+    },
+    {
+      type: "recruiting_shutdown",
+      start: "2026-08-10",
+      end: "2026-08-16",
+      description: "Recruiting Shutdown",
+      confidence: "HIGH",
+    },
+    {
+      type: "contact",
+      start: "2026-09-01",
+      end: "2026-09-30",
+      description:
+        "Contact Period — for seniors and two-year college PSAs only; evaluation period for other PSAs for scholastic activities only",
+      confidence: "HIGH",
+    },
+    {
+      type: "evaluation",
+      start: "2026-10-01",
+      end: "2027-02-28",
+      description: "Evaluation Period — scholastic activities only; contains a carved-out Dead Period Dec 24–26",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-12-24",
+      end: "2026-12-26",
+      description: "Dead Period (carved out of the Oct1–Feb28 evaluation period)",
+      confidence: "HIGH",
+    },
+    {
+      type: "contact",
+      start: "2027-03-01",
+      end: "2027-03-31",
+      description:
+        "Contact Period — for seniors and two-year college PSAs only; evaluation period for other PSAs for scholastic activities only",
+      confidence: "HIGH",
+    },
+    { type: "dead", start: "2027-04-01", end: "2027-04-05", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "quiet",
+      start: "2027-04-06",
+      end: "2027-07-31",
+      description:
+        "Quiet Period; contains a dense cluster of nested Dead/Evaluation/Recruiting-Shutdown sub-windows",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2027-04-22",
+      end: "2027-04-22",
+      description: "Dead Period — for high school and two-year college PSAs only",
+      confidence: "HIGH",
+    },
+    {
+      type: "evaluation",
+      start: "2027-04-23",
+      end: "2027-04-25",
+      description: "Evaluation Period — certified nonscholastic events only",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2027-04-26",
+      end: "2027-04-26",
+      description: "Dead Period — for high school and two-year college PSAs only",
+      confidence: "HIGH",
+    },
+    {
+      type: "recruiting_shutdown",
+      start: "2027-05-03",
+      end: "2027-05-09",
+      description: "Recruiting Shutdown",
+      confidence: "HIGH",
+    },
+    { type: "dead", start: "2027-05-13", end: "2027-05-13", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "evaluation",
+      start: "2027-05-14",
+      end: "2027-05-16",
+      description: "Evaluation Period — certified nonscholastic events only",
+      confidence: "HIGH",
+    },
+    { type: "dead", start: "2027-05-17", end: "2027-05-17", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "dead",
+      start: "2027-06-16",
+      end: "2027-06-16",
+      description: "Dead Period (separate single-day window from May 17, same legend row grouping)",
+      confidence: "HIGH",
+    },
+    {
+      type: "evaluation",
+      start: "2027-06-17",
+      end: "2027-06-19",
+      description:
+        "Evaluation Period (begins Jun 17 @ noon, ends Jun 19 @ 6 PM) — for scholastic events approved by the NCAA and NFHS and intercollegiate events approved by applicable two-year college governing body only",
+      confidence: "HIGH",
+    },
+    { type: "dead", start: "2027-06-20", end: "2027-06-20", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "dead",
+      start: "2027-07-08",
+      end: "2027-07-08",
+      description: "Dead Period (separate single-day window from Jun 20, same legend row grouping)",
+      confidence: "HIGH",
+    },
+    { type: "evaluation", start: "2027-07-09", end: "2027-07-12", description: "Evaluation Period", confidence: "HIGH" },
+    { type: "dead", start: "2027-07-13", end: "2027-07-13", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "dead",
+      start: "2027-07-22",
+      end: "2027-07-22",
+      description: "Dead Period (separate single-day window from Jul 13, same legend row grouping)",
+      confidence: "HIGH",
+    },
+    { type: "evaluation", start: "2027-07-23", end: "2027-07-26", description: "Evaluation Period", confidence: "HIGH" },
+    { type: "dead", start: "2027-07-27", end: "2027-07-27", description: "Dead Period", confidence: "HIGH" },
+  ],
+  milestones: [],
+};
+
+// ---------------------------------------------------------------------------
+// FBS — Division I Football Bowl Subdivision
+// ---------------------------------------------------------------------------
+const FBS: SportCalendar = {
+  source: `${BUCKET}/2026-27D1Rec_FBSRecruitingCalendar.pdf`,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    { type: "dead", start: "2026-08-01", end: "2026-08-31", description: "Dead Period — full month of August", confidence: "HIGH" },
+    {
+      type: "quiet",
+      start: "2026-08-01",
+      end: "2026-09-02",
+      description:
+        "Quiet Period (sub-window): 48 hours before a home contest occurring in August or on Sept. 1–2, through 48 hours after the contest ends",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "evaluation",
+      start: "2026-09-01",
+      end: "2026-11-29",
+      description:
+        "Evaluation Period — 33 (42 for U.S. service academies) evaluation days within this window",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-11-30",
+      end: "2026-12-31",
+      description: "Dead Period (encompasses the Dec 2–4, 2026 early signing period)",
+      confidence: "HIGH",
+    },
+  ],
+  milestones: [
+    {
+      date: "2026-12-02",
+      title: "Early Signing Period Opens (Football)",
+      type: "signing",
+      description: "Early signing period, Dec 2–4, 2026 — falls inside the FBS Nov30–Dec31 Dead Period",
+    },
+    {
+      date: "2027-02-03",
+      title: "Regular (National) Signing Day (Football)",
+      type: "signing",
+      description: "First Wednesday of February; no NCAA-wide end date — varies by institution's own scholarship-award policy",
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// FCS — Division I Football Championship Subdivision
+// ---------------------------------------------------------------------------
+const FCS: SportCalendar = {
+  source: `${BUCKET}/2026-27D1Rec_FCSRecruitingCalendar.pdf`,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    { type: "dead", start: "2026-08-01", end: "2026-08-31", description: "Dead Period — full month of August", confidence: "HIGH" },
+    {
+      type: "quiet",
+      start: "2026-08-01",
+      end: "2026-09-02",
+      description:
+        "Quiet Period (sub-window): 48 hours before a home contest occurring in August or on Sept. 1–2, through 48 hours after the contest ends",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "evaluation",
+      start: "2026-09-01",
+      end: "2026-11-29",
+      description:
+        "Evaluation Period — 33 (42 for U.S. service academies) evaluation days within this window",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-11-30",
+      end: "2026-12-03",
+      description: "Dead Period (immediately precedes/covers start of early signing period)",
+      confidence: "HIGH",
+    },
+    {
+      type: "contact",
+      start: "2026-12-04",
+      end: "2026-12-18",
+      description: "Contact Period (opens the day after early signing starts, in-person off-campus contact permitted)",
+      confidence: "HIGH",
+    },
+    {
+      type: "quiet",
+      start: "2026-12-18",
+      end: "2026-12-20",
+      description: "Quiet Period (short transition window before year-end dead period)",
+      confidence: "HIGH",
+    },
+    { type: "dead", start: "2026-12-21", end: "2026-12-31", description: "Dead Period (year-end)", confidence: "HIGH" },
+  ],
+  milestones: [
+    {
+      date: "2026-12-02",
+      title: "Early Signing Period Opens (Football)",
+      type: "signing",
+      description:
+        "Early signing period, Dec 2–4, 2026 — the Dec 4 FCS Contact-period start lines up exactly with the signing period's last day",
+    },
+    {
+      date: "2027-02-03",
+      title: "Regular (National) Signing Day (Football)",
+      type: "signing",
+      description: "First Wednesday of February; no NCAA-wide end date",
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// XCTF — Division I Cross Country / Track & Field (combined)
+// ---------------------------------------------------------------------------
+const XCTF: SportCalendar = {
+  source: `${BUCKET}/2026-27D1Rec_XCTFRecruitingCalendar.pdf`,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    {
+      type: "contact",
+      start: "2026-08-01",
+      end: "2026-12-13",
+      description:
+        "Contact Period — long fall contact window, interrupted by two short dead-period carve-outs",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description: "Dead Period (carve-out within the Aug1–Dec13 Contact window; likely NCAA XC Championships week)",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-11-21",
+      end: "2026-11-21",
+      description: "Dead Period, single day (carve-out within the same Contact window)",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-12-14",
+      end: "2026-12-26",
+      description: "Dead Period — holiday dead period, between the two long Contact windows",
+      confidence: "HIGH",
+    },
+    {
+      type: "contact",
+      start: "2026-12-27",
+      end: "2027-07-31",
+      description:
+        "Contact Period — long winter/spring/summer contact window, interrupted by two short dead-period carve-outs",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2027-03-12",
+      end: "2027-03-13",
+      description: "Dead Period (carve-out; likely NCAA Indoor T&F Championships week)",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2027-06-09",
+      end: "2027-06-12",
+      description: "Dead Period (carve-out; likely NCAA Outdoor T&F Championships week)",
+      confidence: "HIGH",
+    },
+  ],
+  milestones: [],
+};
+
+// ---------------------------------------------------------------------------
+// WVB — Division I Women's Volleyball
+// ---------------------------------------------------------------------------
+const WVB: SportCalendar = {
+  source: `${BUCKET}/2026-27D1Rec_WVBRecruitingCalendar.pdf`,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    { type: "quiet", start: "2026-08-01", end: "2026-08-31", description: "Quiet Period — in-person contact only on campus", confidence: "MEDIUM" },
+    {
+      type: "contact",
+      start: "2026-09-01",
+      end: "2026-11-30",
+      description: "Contact Period — off-campus in-person contact/evaluation permitted",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description: "Dead Period — no contact/evaluation/visits, nested inside the Sep–Nov contact window",
+      confidence: "HIGH",
+    },
+    {
+      type: "quiet",
+      start: "2026-12-01",
+      end: "2027-01-14",
+      description:
+        "Quiet Period — AVCA awards-banquet incidental contact with honorees is permitted (no recruiting conversation)",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "dead",
+      start: "2026-12-17",
+      end: "2027-01-01",
+      description:
+        "Dead Period — Thursday of the NCAA D1 WVB Championship through the Sunday immediately following; 1-day/1-event evaluation exception within 30-mile radius of championship site",
+      confidence: "HIGH",
+    },
+    {
+      type: "contact",
+      start: "2027-01-15",
+      end: "2027-07-31",
+      description: "Contact Period — off-campus in-person contact/evaluation permitted, minus 6 quiet-period carve-outs",
+      confidence: "MEDIUM",
+    },
+    { type: "quiet", start: "2027-03-01", end: "2027-03-04", description: "Quiet Period (carve-out within the Jan–Jul contact window)", confidence: "MEDIUM" },
+    { type: "quiet", start: "2027-03-08", end: "2027-03-11", description: "Quiet Period (carve-out)", confidence: "MEDIUM" },
+    { type: "quiet", start: "2027-03-15", end: "2027-03-18", description: "Quiet Period (carve-out)", confidence: "MEDIUM" },
+    { type: "quiet", start: "2027-03-22", end: "2027-03-25", description: "Quiet Period (carve-out)", confidence: "MEDIUM" },
+    { type: "quiet", start: "2027-03-29", end: "2027-04-01", description: "Quiet Period (carve-out)", confidence: "MEDIUM" },
+    { type: "quiet", start: "2027-04-05", end: "2027-04-08", description: "Quiet Period (carve-out)", confidence: "MEDIUM" },
+    { type: "quiet", start: "2027-05-01", end: "2027-06-03", description: "Quiet Period (carve-out; final one of the year)", confidence: "MEDIUM" },
+  ],
+  milestones: [],
+};
+
+// ---------------------------------------------------------------------------
+// MGO — Division I Men's Golf
+// ---------------------------------------------------------------------------
+const MGO: SportCalendar = {
+  source: `${BUCKET}/2026-27D1Rec_MGORecruitingCalendar.pdf`,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    { type: "contact", start: "2026-08-01", end: "2026-11-25", description: "Contact Period", confidence: "MEDIUM" },
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description: "Dead Period nested inside the Aug–Nov contact window",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-11-26",
+      end: "2026-11-29",
+      description: "Dead Period — Thanksgiving week",
+      confidence: "HIGH",
+    },
+    {
+      type: "quiet",
+      start: "2026-11-30",
+      end: "2026-12-22",
+      description:
+        "Quiet Period except for Dec 8–10 (dead-period carve-out); the Dec 8–10 dead period remains in effect until 12:01 AM on December 11",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "dead",
+      start: "2026-12-08",
+      end: "2026-12-10",
+      description:
+        "Dead Period carve-out inside the Nov 30–Dec 22 quiet window, for the Golf Coaches Association of America (GCAA) National Convention; legally extends until 12:01 AM Dec 11; showcase/combine evaluation events tied to the convention may still be worked",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-12-23",
+      end: "2027-01-01",
+      description: "Dead Period — Christmas/New Year window",
+      confidence: "HIGH",
+    },
+    {
+      type: "contact",
+      start: "2027-01-02",
+      end: "2027-07-31",
+      description: "Contact Period — remainder of the year, uninterrupted",
+      confidence: "MEDIUM",
+    },
+  ],
+  milestones: [],
+};
+
+// ---------------------------------------------------------------------------
+// MLA — Division I Men's Lacrosse
+// ---------------------------------------------------------------------------
+const MLA: SportCalendar = {
+  source: `${BUCKET}/2026-27D1Rec_MLARecruitingCalendar.pdf`,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    { type: "contact", start: "2026-08-01", end: "2026-08-03", description: "Contact Period", confidence: "MEDIUM" },
+    { type: "quiet", start: "2026-08-04", end: "2026-08-10", description: "Quiet Period", confidence: "MEDIUM" },
+    { type: "dead", start: "2026-08-11", end: "2026-08-31", description: "Dead Period", confidence: "MEDIUM" },
+    {
+      type: "contact",
+      start: "2026-09-01",
+      end: "2026-10-31",
+      description: 'Contact Period — footnoted "No lacrosse evaluations" for the entire month range',
+      confidence: "MEDIUM",
+    },
+    {
+      type: "contact",
+      start: "2026-11-01",
+      end: "2026-11-22",
+      description:
+        'Contact Period — footnoted "No lacrosse evaluations" (continues Sep/Oct\'s carve-out), minus the Nov 9–12 dead-period carve-out',
+      confidence: "MEDIUM",
+    },
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description: "Dead Period nested inside the Nov 1–22 contact window",
+      confidence: "HIGH",
+    },
+    { type: "dead", start: "2026-11-23", end: "2026-11-29", description: "Dead Period — Thanksgiving week", confidence: "HIGH" },
+    {
+      type: "quiet",
+      start: "2026-11-30",
+      end: "2026-12-23",
+      description: "Quiet Period, minus the Dec 9–13 dead-period carve-out",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "dead",
+      start: "2026-12-09",
+      end: "2026-12-13",
+      description:
+        "Dead Period — the first official day of the IMLCA Convention to 12:01 AM on the day after the adjournment of the convention; a coach may still evaluate at the convention's showcase/tournament events",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-12-24",
+      end: "2027-01-03",
+      description: "Dead Period — Christmas/New Year window",
+      confidence: "HIGH",
+    },
+    {
+      type: "contact",
+      start: "2027-01-04",
+      end: "2027-01-18",
+      description: 'Contact Period — footnoted "No lacrosse evaluations"',
+      confidence: "MEDIUM",
+    },
+    { type: "quiet", start: "2027-01-19", end: "2027-02-28", description: "Quiet Period", confidence: "MEDIUM" },
+    {
+      type: "contact",
+      start: "2027-03-01",
+      end: "2027-05-27",
+      description: "Contact Period (no evaluation-blocking footnote — full evaluation allowed, unlike the fall/Jan contact windows)",
+      confidence: "MEDIUM",
+    },
+    {
+      // "@ NOON" end-time boundary rounded to the day per the locked edge-case rule.
+      type: "dead",
+      start: "2027-05-28",
+      end: "2027-06-01",
+      description: 'Dead Period — "MAY 28 – JUN 1 @ NOON" (effective noon)',
+      confidence: "MEDIUM",
+    },
+    {
+      // "@ NOON" start-time boundary rounded to the day per the locked edge-case rule.
+      type: "contact",
+      start: "2027-06-01",
+      end: "2027-07-31",
+      description: 'Contact Period — "JUN 1 @ NOON – JUL 31" (effective noon), minus the Jul 1–10 dead-period carve-out',
+      confidence: "MEDIUM",
+    },
+    {
+      type: "dead",
+      start: "2027-07-01",
+      end: "2027-07-10",
+      description:
+        "Dead Period — a coach may evaluate at the showcase/tournament events held alongside the IMLCA July summer meeting",
+      confidence: "MEDIUM",
+    },
+  ],
+  milestones: [],
+};
+
+// ---------------------------------------------------------------------------
+// WLA — Division I Women's Lacrosse
+// ---------------------------------------------------------------------------
+const WLA: SportCalendar = {
+  source: `${BUCKET}/2026-27D1Rec_WLARecruitingCalendar.pdf`,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    {
+      type: "recruiting_shutdown",
+      start: "2026-08-01",
+      end: "2026-08-14",
+      description: "Recruiting Shutdown — no contacts, evaluations, visits, correspondence, or calls permitted",
+      confidence: "MEDIUM",
+    },
+    { type: "quiet", start: "2026-08-15", end: "2026-08-27", description: "Quiet Period", confidence: "MEDIUM" },
+    { type: "dead", start: "2026-08-28", end: "2026-09-03", description: "Dead Period", confidence: "MEDIUM" },
+    {
+      type: "contact",
+      start: "2026-09-04",
+      end: "2026-11-30",
+      description:
+        "Contact Period — subject to Bylaw 13.1.7.3.1 (evaluations during contact periods limited to regularly scheduled HS/prep/2-yr-college contests and regular scholastic activities), minus 3 carve-outs",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "evaluation",
+      start: "2026-11-06",
+      end: "2026-11-08",
+      description: "Evaluation Period — first of three pre-Thanksgiving weekends, 5 PM Friday – Sunday",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description: "Dead Period nested between the first and second pre-Thanksgiving evaluation weekends",
+      confidence: "HIGH",
+    },
+    {
+      type: "evaluation",
+      start: "2026-11-13",
+      end: "2026-11-15",
+      description: "Evaluation Period — second pre-Thanksgiving weekend, 5 PM Friday – Sunday",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-11-18",
+      end: "2026-11-20",
+      description: "Dead Period — ends on the 20th when IWLCA Convention adjourns",
+      confidence: "HIGH",
+    },
+    {
+      type: "evaluation",
+      start: "2026-11-20",
+      end: "2026-11-22",
+      description:
+        "Evaluation Period — third pre-Thanksgiving weekend; a coach may evaluate ONLY at showcase/tournament events held with the IWLCA (narrower than the first two weekends)",
+      confidence: "HIGH",
+    },
+    {
+      type: "recruiting_shutdown",
+      start: "2026-11-24",
+      end: "2026-11-29",
+      description: "Recruiting Shutdown — Thanksgiving week",
+      confidence: "HIGH",
+    },
+    {
+      type: "contact",
+      start: "2026-12-01",
+      end: "2026-12-30",
+      description: "Contact Period — subject to Bylaw 13.1.7.3.1, minus the Dec 22–26 shutdown carve-out",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "recruiting_shutdown",
+      start: "2026-12-22",
+      end: "2026-12-26",
+      description: "Recruiting Shutdown — Christmas window, nested inside the Dec 1–30 contact period",
+      confidence: "HIGH",
+    },
+    {
+      type: "recruiting_shutdown",
+      start: "2026-12-31",
+      end: "2027-01-02",
+      description: "Recruiting Shutdown — New Year window",
+      confidence: "HIGH",
+    },
+    {
+      type: "contact",
+      start: "2027-01-03",
+      end: "2027-05-27",
+      description: "Contact Period — subject to Bylaw 13.1.7.3.1",
+      confidence: "MEDIUM",
+    },
+    { type: "dead", start: "2027-05-28", end: "2027-05-30", description: "Dead Period", confidence: "MEDIUM" },
+    {
+      type: "contact",
+      start: "2027-05-31",
+      end: "2027-06-10",
+      description: "Contact Period — subject to Bylaw 13.1.7.3.1",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "evaluation",
+      start: "2027-06-11",
+      end: "2027-07-31",
+      description:
+        "Evaluation Period, minus the Jul 2–6 dead-period carve-out; includes an exception allowing one championship-weekend evaluation event within a 100-mile radius of the WLA championship site (with a no-attendance blackout window around the semifinal/final games)",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "dead",
+      start: "2027-07-02",
+      end: "2027-07-06",
+      description: "Dead Period carve-out inside the Jun 11–Jul 31 evaluation window",
+      confidence: "MEDIUM",
+    },
+  ],
+  milestones: [],
+};
+
+// ---------------------------------------------------------------------------
+// Other — Division I "All Other Sports" (catch-all for app sports with no
+// dedicated NCAA recruiting calendar: Soccer, Swimming, Tennis, Wrestling,
+// Ice Hockey, Field Hockey, Rowing, Water Polo — and non-male Golf).
+// Only the "ALL OTHER SPORTS" track is used here (the app's true fallback);
+// the per-sport breakdowns in the source fragment (field hockey, women's
+// golf, gymnastics, rowing, ice hockey, soccer, swimming, wrestling) are
+// finer-grained than this project's single "Other" calendar key models, and
+// are not separately surfaced.
+// ---------------------------------------------------------------------------
+const OTHER: SportCalendar = {
+  source: `${BUCKET}/2026–27D1Rec_OtherRecruitingCalendar.pdf`,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description:
+        "Dead Period — Monday through Thursday of the initial week for the fall signing date for athletics aid agreements",
+      confidence: "HIGH",
+    },
+  ],
+  milestones: [],
+};
+
+export const D1_CALENDARS: Record<NcaaCalendarKey, SportCalendar> = {
+  MBA,
+  WSB,
+  MBB,
+  WBB,
+  FBS,
+  FCS,
+  XCTF,
+  WVB,
+  MGO,
+  MLA,
+  WLA,
+  Other: OTHER,
+};
+
+// ---------------------------------------------------------------------------
+// D2 — "All Other Sports" track (the D2 fallback used across the app; the
+// D2 fragment's separate "DII Football" track is sport-specific and out of
+// scope for this generic fallback).
+// ---------------------------------------------------------------------------
+export const D2_ALL_SPORTS: SportCalendar = {
+  source: `${BUCKET}/2026-27D2Rec_RecruitingCalendar_AllSports.pdf`,
+  verifiedOn: VERIFIED_ON,
+  periods: [
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-11",
+      description:
+        "Signing Date Dead Period, Nov 9 @ 7 AM – Nov 11 @ 7 AM (effective noon-agnostic, rounded to the day). For all other high school prospective student-athletes",
+      confidence: "HIGH",
+    },
+  ],
+  milestones: [],
+};
+
+// D3 has no published NCAA recruiting calendar — fall back to D1's "Other"
+// default track (same source data as D1_CALENDARS.Other; documented choice
+// per the plan, since D3 recruiting rules are the least restrictive/most
+// generic of the three divisions and "Other" is this dataset's own generic
+// default).
+export const D3_FALLBACK: SportCalendar = OTHER;

--- a/utils/recruitingCalendar/index.ts
+++ b/utils/recruitingCalendar/index.ts
@@ -1,0 +1,13 @@
+export type { AppSport, CalendarMilestone, Division, NcaaCalendarKey, RecruitingPeriod, SportCalendar } from "./types";
+export { D1_CALENDARS, D2_ALL_SPORTS, D3_FALLBACK } from "./calendarData";
+export type { ResolveCalendarKeyOptions } from "./resolver";
+export {
+  resolveCalendarKey,
+  getSportCalendar,
+  isDeadPeriod,
+  isQuietPeriod,
+  getDeadPeriodMessage,
+  getNextDeadPeriod,
+  getUpcomingMilestones,
+  type GetUpcomingMilestonesParams,
+} from "./resolver";

--- a/utils/recruitingCalendar/index.ts
+++ b/utils/recruitingCalendar/index.ts
@@ -1,5 +1,5 @@
 export type { AppSport, CalendarMilestone, Division, NcaaCalendarKey, RecruitingPeriod, SportCalendar } from "./types";
-export { D1_CALENDARS, D2_ALL_SPORTS, D3_FALLBACK } from "./calendarData";
+export { D1_CALENDARS, D2_ALL_SPORTS, D3_FALLBACK, SEASON, SEASON_END } from "./calendarData";
 export type { ResolveCalendarKeyOptions } from "./resolver";
 export {
   resolveCalendarKey,
@@ -10,4 +10,6 @@ export {
   getNextDeadPeriod,
   getUpcomingMilestones,
   type GetUpcomingMilestonesParams,
+  GENDER_SPLIT_SPORTS,
+  NO_SPORT_FALLBACK,
 } from "./resolver";

--- a/utils/recruitingCalendar/resolver.ts
+++ b/utils/recruitingCalendar/resolver.ts
@@ -1,4 +1,14 @@
-import type { AppSport, NcaaCalendarKey } from "./types";
+import type { AppSport, CalendarMilestone, Division, NcaaCalendarKey, RecruitingPeriod, SportCalendar } from "./types";
+import { D1_CALENDARS, D2_ALL_SPORTS, D3_FALLBACK } from "./calendarData";
+import { parseLocalDateOnly, exclusiveEndOfDay, formatLocalDateOnly } from "~/utils/localDate";
+import {
+  SAT_TEST_DATES_2026,
+  ACT_TEST_DATES_2026,
+  NCAA_DEADLINES_2026,
+  NAIA_DEADLINES_2026,
+  COLLEGE_APPLICATION_DEADLINES_2026,
+  type Milestone as LegacyMilestone,
+} from "~/utils/ncaaRecruitingCalendar";
 
 export interface ResolveCalendarKeyOptions {
   gender?: string | null;
@@ -71,4 +81,168 @@ export function resolveCalendarKey(sport: AppSport, opts?: ResolveCalendarKeyOpt
   // NCAA recruiting calendar and no sport-specific windows in the "Other"
   // bundle — falls to the generic "Other" default.
   return "Other";
+}
+
+// ============================================================================
+// Sport-aware calendar queries
+// ============================================================================
+
+/**
+ * Resolves the `SportCalendar` that governs a sport's recruiting rules for a
+ * division. D2 and D3 use one shared calendar regardless of sport (per the
+ * NCAA's own "All Other Sports" tracks); D1 resolves per-sport via
+ * `resolveCalendarKey`. `sport` is always required — no silent default.
+ */
+export function getSportCalendar(
+  sport: AppSport,
+  division: Division,
+  opts?: ResolveCalendarKeyOptions,
+): SportCalendar {
+  if (division === "D2") return D2_ALL_SPORTS;
+  if (division === "D3") return D3_FALLBACK;
+
+  const key = resolveCalendarKey(sport, opts);
+  return D1_CALENDARS[key];
+}
+
+/**
+ * `dead` and `recruiting_shutdown` periods both mean "no contact permitted"
+ * (recruiting_shutdown is the stricter of the two — no calls/texts/
+ * correspondence either — but both block contact, which is what
+ * `isDeadPeriod` answers).
+ */
+const BLOCKING_TYPES: ReadonlySet<RecruitingPeriod["type"]> = new Set(["dead", "recruiting_shutdown"]);
+
+function isWithinPeriod(date: Date, period: RecruitingPeriod): boolean {
+  return date >= parseLocalDateOnly(period.start) && date < exclusiveEndOfDay(period.end);
+}
+
+/** True if `date` falls within a dead (or recruiting-shutdown) period for `sport`/`division`. */
+export function isDeadPeriod(
+  date: Date,
+  sport: AppSport,
+  division: Division,
+  opts?: ResolveCalendarKeyOptions,
+): boolean {
+  const calendar = getSportCalendar(sport, division, opts);
+  return calendar.periods.some((period) => BLOCKING_TYPES.has(period.type) && isWithinPeriod(date, period));
+}
+
+/** True if `date` falls within a quiet period for `sport`/`division`. */
+export function isQuietPeriod(
+  date: Date,
+  sport: AppSport,
+  division: Division,
+  opts?: ResolveCalendarKeyOptions,
+): boolean {
+  const calendar = getSportCalendar(sport, division, opts);
+  return calendar.periods.some((period) => period.type === "quiet" && isWithinPeriod(date, period));
+}
+
+/**
+ * Message describing the dead/shutdown period `date` falls within, or `null`
+ * if `date` is not in one.
+ */
+export function getDeadPeriodMessage(
+  date: Date,
+  sport: AppSport,
+  division: Division,
+  opts?: ResolveCalendarKeyOptions,
+): string | null {
+  const calendar = getSportCalendar(sport, division, opts);
+  const period = calendar.periods.find((p) => BLOCKING_TYPES.has(p.type) && isWithinPeriod(date, p));
+  if (!period) return null;
+
+  return `Dead period - no recruiting contact permitted per NCAA rules (${period.description})`;
+}
+
+/** The next dead/recruiting-shutdown period starting on or after `date`, or `null` if none remain. */
+export function getNextDeadPeriod(
+  date: Date,
+  sport: AppSport,
+  division: Division,
+  opts?: ResolveCalendarKeyOptions,
+): RecruitingPeriod | null {
+  const calendar = getSportCalendar(sport, division, opts);
+  const future = calendar.periods
+    .filter((p) => BLOCKING_TYPES.has(p.type) && parseLocalDateOnly(p.start) >= date)
+    .sort((a, b) => a.start.localeCompare(b.start));
+
+  return future[0] ?? null;
+}
+
+function toCalendarMilestone(m: LegacyMilestone): CalendarMilestone {
+  return {
+    date: m.date,
+    title: m.title,
+    type: m.type,
+    url: m.url,
+    description: m.description,
+  };
+}
+
+/**
+ * Still-generic milestone lists (no sport-specific data): SAT/ACT test dates,
+ * NCAA/NAIA eligibility deadlines, and college application deadlines. Sport
+ * signing-period milestones live on each sport's own `SportCalendar` instead
+ * (e.g. MBA's early-signing milestone) — deliberately excluded here.
+ */
+const GENERIC_MILESTONES: LegacyMilestone[] = [
+  ...SAT_TEST_DATES_2026,
+  ...ACT_TEST_DATES_2026,
+  ...NCAA_DEADLINES_2026,
+  ...NAIA_DEADLINES_2026,
+  ...COLLEGE_APPLICATION_DEADLINES_2026,
+];
+
+/** Same division-scoping the legacy `getUpcomingMilestones` used: unscoped or exact/"ALL" match. */
+function matchesDivision(m: LegacyMilestone, division: Division): boolean {
+  return !m.division || m.division === division || m.division === "ALL";
+}
+
+export interface GetUpcomingMilestonesParams {
+  sport: AppSport;
+  division: Division;
+  graduationYear?: number;
+  limit?: number;
+  opts?: ResolveCalendarKeyOptions;
+  /** Overrides "now" — for testability. */
+  currentDate?: Date;
+}
+
+/**
+ * Upcoming milestones for `sport`/`division`: the resolved `SportCalendar`'s
+ * own milestones merged with the still-generic SAT/ACT/NCAA/NAIA/application
+ * deadline lists, filtered by future date, graduation-year relevance
+ * (mirrors the legacy `getUpcomingMilestones` phase buckets), and division —
+ * then sorted ascending and capped at `limit` (default 5).
+ */
+export function getUpcomingMilestones(params: GetUpcomingMilestonesParams): CalendarMilestone[] {
+  const { sport, division, graduationYear, limit = 5, opts, currentDate = new Date() } = params;
+
+  const calendar = getSportCalendar(sport, division, opts);
+  const generic = GENERIC_MILESTONES.filter((m) => matchesDivision(m, division)).map(toCalendarMilestone);
+
+  const currentDateISO = formatLocalDateOnly(currentDate);
+  let combined = [...calendar.milestones, ...generic].filter((m) => m.date >= currentDateISO);
+
+  if (graduationYear) {
+    const currentYear = currentDate.getFullYear();
+    if (graduationYear === currentYear + 3) {
+      // Senior year
+      combined = combined.filter(
+        (m) => m.type === "test" || m.type === "application" || m.type === "signing" || m.type === "ncaa-period",
+      );
+    } else if (graduationYear === currentYear + 2) {
+      // Junior year
+      combined = combined.filter(
+        (m) => m.type === "test" || m.type === "deadline" || m.type === "ncaa-period" || m.type === "application",
+      );
+    } else {
+      // Freshman/Sophomore - focus on tests
+      combined = combined.filter((m) => m.type === "test" || m.type === "ncaa-period");
+    }
+  }
+
+  return combined.sort((a, b) => a.date.localeCompare(b.date)).slice(0, limit);
 }

--- a/utils/recruitingCalendar/resolver.ts
+++ b/utils/recruitingCalendar/resolver.ts
@@ -61,7 +61,7 @@ export const GENDER_SPLIT_SPORTS: Partial<Record<AppSport, { men: NcaaCalendarKe
  */
 export const NO_SPORT_FALLBACK: AppSport = "Tennis";
 
-const isMen = (gender: string | null | undefined): boolean => gender !== "female";
+const isMen = (gender: string | null | undefined): boolean => (gender ?? "").toLowerCase() !== "female";
 
 /**
  * Maps an app sport (plus optional gender/football-subdivision context) to

--- a/utils/recruitingCalendar/resolver.ts
+++ b/utils/recruitingCalendar/resolver.ts
@@ -38,14 +38,28 @@ const SINGLE_CALENDAR_SPORTS: Partial<Record<AppSport, NcaaCalendarKey>> = {
  * Wrestling are "Other"-bundle sports whose PDF enumerates separate men's/
  * women's windows (see calendarData.ts OTHER_MSOCCER/OTHER_WSOCCER/
  * OTHER_MICEHOCKEY/OTHER_WICEHOCKEY/OTHER_MWRESTLING/OTHER_WWRESTLING).
+ *
+ * Exported so UI callers (e.g. `RecruitingCalendar.vue`'s men's/women's
+ * toggle) can reuse this exact set instead of keeping a duplicate in sync.
  */
-const GENDER_SPLIT_SPORTS: Partial<Record<AppSport, { men: NcaaCalendarKey; women: NcaaCalendarKey }>> = {
+export const GENDER_SPLIT_SPORTS: Partial<Record<AppSport, { men: NcaaCalendarKey; women: NcaaCalendarKey }>> = {
   Basketball: { men: "MBB", women: "WBB" },
   Lacrosse: { men: "MLA", women: "WLA" },
   Soccer: { men: "OTHER_MSOCCER", women: "OTHER_WSOCCER" },
   "Ice Hockey": { men: "OTHER_MICEHOCKEY", women: "OTHER_WICEHOCKEY" },
   Wrestling: { men: "OTHER_MWRESTLING", women: "OTHER_WWRESTLING" },
 };
+
+/**
+ * The codebase's neutral sport fallback for any caller not yet wired to pass
+ * the athlete's real sport. "Tennis" has no published NCAA recruiting
+ * calendar of its own, so it resolves to the generic "Other" track — the
+ * least-restrictive, lowest-surprise default (matches the D2/D3 fallback
+ * calendars' own choice). Named + exported so the neutral-default choice
+ * lives in one place instead of being repeated as a bare `?? "Tennis"`
+ * literal at every call site.
+ */
+export const NO_SPORT_FALLBACK: AppSport = "Tennis";
 
 const isMen = (gender: string | null | undefined): boolean => gender !== "female";
 

--- a/utils/recruitingCalendar/resolver.ts
+++ b/utils/recruitingCalendar/resolver.ts
@@ -1,0 +1,70 @@
+import type { AppSport, NcaaCalendarKey } from "./types";
+
+export interface ResolveCalendarKeyOptions {
+  gender?: string | null;
+  footballSubdivision?: "FBS" | "FCS";
+}
+
+/** Sports with a single NCAA recruiting calendar (no gender split). */
+const SINGLE_CALENDAR_SPORTS: Partial<Record<AppSport, NcaaCalendarKey>> = {
+  Baseball: "MBA",
+  Softball: "WSB",
+  Volleyball: "WVB",
+  "Track & Field": "XCTF",
+  "Cross Country": "XCTF",
+};
+
+/** Sports with distinct men's/women's NCAA calendars. */
+const GENDER_SPLIT_SPORTS: Partial<Record<AppSport, { men: NcaaCalendarKey; women: NcaaCalendarKey }>> = {
+  Basketball: { men: "MBB", women: "WBB" },
+  Lacrosse: { men: "MLA", women: "WLA" },
+};
+
+/** App sports with no published NCAA recruiting calendar — always "Other". */
+const NO_CALENDAR_SPORTS: ReadonlySet<AppSport> = new Set<AppSport>([
+  "Soccer",
+  "Swimming",
+  "Tennis",
+  "Wrestling",
+  "Ice Hockey",
+  "Field Hockey",
+  "Rowing",
+  "Water Polo",
+]);
+
+const isMen = (gender: string | null | undefined): boolean => gender !== "female";
+
+/**
+ * Maps an app sport (plus optional gender/football-subdivision context) to
+ * the NCAA recruiting-calendar key that governs its contact-period rules.
+ *
+ * Gender defaults to men's whenever the sport is gender-split and gender is
+ * null, unspecified, "other", or "prefer_not_to_say".
+ */
+export function resolveCalendarKey(sport: AppSport, opts?: ResolveCalendarKeyOptions): NcaaCalendarKey {
+  const gender = opts?.gender;
+
+  if (sport === "Football") {
+    return opts?.footballSubdivision ?? "FBS";
+  }
+
+  if (sport === "Golf") {
+    return isMen(gender) ? "MGO" : "Other";
+  }
+
+  const genderSplit = GENDER_SPLIT_SPORTS[sport];
+  if (genderSplit) {
+    return isMen(gender) ? genderSplit.men : genderSplit.women;
+  }
+
+  const single = SINGLE_CALENDAR_SPORTS[sport];
+  if (single) {
+    return single;
+  }
+
+  if (NO_CALENDAR_SPORTS.has(sport)) {
+    return "Other";
+  }
+
+  return "Other";
+}

--- a/utils/recruitingCalendar/resolver.ts
+++ b/utils/recruitingCalendar/resolver.ts
@@ -5,32 +5,48 @@ export interface ResolveCalendarKeyOptions {
   footballSubdivision?: "FBS" | "FCS";
 }
 
-/** Sports with a single NCAA recruiting calendar (no gender split). */
+/**
+ * Sports with a single NCAA recruiting calendar (no gender split). Includes
+ * three "Other"-bundle sports whose PDF enumerates real dead/quiet/
+ * recruiting_shutdown windows with no men's/women's split: Swimming (combined
+ * "Swimming and Diving" table) and the two NCAA women's-only sports Rowing
+ * and Field Hockey.
+ */
 const SINGLE_CALENDAR_SPORTS: Partial<Record<AppSport, NcaaCalendarKey>> = {
   Baseball: "MBA",
   Softball: "WSB",
   Volleyball: "WVB",
   "Track & Field": "XCTF",
   "Cross Country": "XCTF",
+  Swimming: "OTHER_SWIM",
+  Rowing: "OTHER_ROWING",
+  "Field Hockey": "OTHER_FIELDHOCKEY",
 };
 
-/** Sports with distinct men's/women's NCAA calendars. */
+/**
+ * Sports with distinct men's/women's NCAA calendars. Soccer and Ice Hockey
+ * are "Other"-bundle sports whose PDF enumerates separate men's/women's
+ * windows (see calendarData.ts OTHER_MSOCCER/OTHER_WSOCCER/
+ * OTHER_MICEHOCKEY/OTHER_WICEHOCKEY).
+ */
 const GENDER_SPLIT_SPORTS: Partial<Record<AppSport, { men: NcaaCalendarKey; women: NcaaCalendarKey }>> = {
   Basketball: { men: "MBB", women: "WBB" },
   Lacrosse: { men: "MLA", women: "WLA" },
+  Soccer: { men: "OTHER_MSOCCER", women: "OTHER_WSOCCER" },
+  "Ice Hockey": { men: "OTHER_MICEHOCKEY", women: "OTHER_WICEHOCKEY" },
 };
 
-/** App sports with no published NCAA recruiting calendar — always "Other". */
-const NO_CALENDAR_SPORTS: ReadonlySet<AppSport> = new Set<AppSport>([
-  "Soccer",
-  "Swimming",
-  "Tennis",
-  "Wrestling",
-  "Ice Hockey",
-  "Field Hockey",
-  "Rowing",
-  "Water Polo",
-]);
+/**
+ * App sports with no published NCAA recruiting calendar AND no sport-specific
+ * windows in the "Other" bundle — always the generic "Other" default.
+ *
+ * NOTE: the "Other" bundle PDF does enumerate Men's/Women's Wrestling windows
+ * (Nov dead period + Dec/March recruiting shutdowns), but per task scope
+ * Wrestling is intentionally kept on the generic default rather than split
+ * into its own sub-calendar — see task-2b-report.md "concerns" for the
+ * data-vs-instruction discrepancy this leaves on record.
+ */
+const NO_CALENDAR_SPORTS: ReadonlySet<AppSport> = new Set<AppSport>(["Tennis", "Wrestling", "Water Polo"]);
 
 const isMen = (gender: string | null | undefined): boolean => gender !== "female";
 

--- a/utils/recruitingCalendar/resolver.ts
+++ b/utils/recruitingCalendar/resolver.ts
@@ -37,12 +37,6 @@ const GENDER_SPLIT_SPORTS: Partial<Record<AppSport, { men: NcaaCalendarKey; wome
   Wrestling: { men: "OTHER_MWRESTLING", women: "OTHER_WWRESTLING" },
 };
 
-/**
- * App sports with no published NCAA recruiting calendar AND no sport-specific
- * windows in the "Other" bundle — always the generic "Other" default.
- */
-const NO_CALENDAR_SPORTS: ReadonlySet<AppSport> = new Set<AppSport>(["Tennis", "Water Polo"]);
-
 const isMen = (gender: string | null | undefined): boolean => gender !== "female";
 
 /**
@@ -73,9 +67,8 @@ export function resolveCalendarKey(sport: AppSport, opts?: ResolveCalendarKeyOpt
     return single;
   }
 
-  if (NO_CALENDAR_SPORTS.has(sport)) {
-    return "Other";
-  }
-
+  // Any remaining AppSport (currently: Tennis, Water Polo) has no published
+  // NCAA recruiting calendar and no sport-specific windows in the "Other"
+  // bundle — falls to the generic "Other" default.
   return "Other";
 }

--- a/utils/recruitingCalendar/resolver.ts
+++ b/utils/recruitingCalendar/resolver.ts
@@ -24,29 +24,24 @@ const SINGLE_CALENDAR_SPORTS: Partial<Record<AppSport, NcaaCalendarKey>> = {
 };
 
 /**
- * Sports with distinct men's/women's NCAA calendars. Soccer and Ice Hockey
- * are "Other"-bundle sports whose PDF enumerates separate men's/women's
- * windows (see calendarData.ts OTHER_MSOCCER/OTHER_WSOCCER/
- * OTHER_MICEHOCKEY/OTHER_WICEHOCKEY).
+ * Sports with distinct men's/women's NCAA calendars. Soccer, Ice Hockey, and
+ * Wrestling are "Other"-bundle sports whose PDF enumerates separate men's/
+ * women's windows (see calendarData.ts OTHER_MSOCCER/OTHER_WSOCCER/
+ * OTHER_MICEHOCKEY/OTHER_WICEHOCKEY/OTHER_MWRESTLING/OTHER_WWRESTLING).
  */
 const GENDER_SPLIT_SPORTS: Partial<Record<AppSport, { men: NcaaCalendarKey; women: NcaaCalendarKey }>> = {
   Basketball: { men: "MBB", women: "WBB" },
   Lacrosse: { men: "MLA", women: "WLA" },
   Soccer: { men: "OTHER_MSOCCER", women: "OTHER_WSOCCER" },
   "Ice Hockey": { men: "OTHER_MICEHOCKEY", women: "OTHER_WICEHOCKEY" },
+  Wrestling: { men: "OTHER_MWRESTLING", women: "OTHER_WWRESTLING" },
 };
 
 /**
  * App sports with no published NCAA recruiting calendar AND no sport-specific
  * windows in the "Other" bundle — always the generic "Other" default.
- *
- * NOTE: the "Other" bundle PDF does enumerate Men's/Women's Wrestling windows
- * (Nov dead period + Dec/March recruiting shutdowns), but per task scope
- * Wrestling is intentionally kept on the generic default rather than split
- * into its own sub-calendar — see task-2b-report.md "concerns" for the
- * data-vs-instruction discrepancy this leaves on record.
  */
-const NO_CALENDAR_SPORTS: ReadonlySet<AppSport> = new Set<AppSport>(["Tennis", "Wrestling", "Water Polo"]);
+const NO_CALENDAR_SPORTS: ReadonlySet<AppSport> = new Set<AppSport>(["Tennis", "Water Polo"]);
 
 const isMen = (gender: string | null | undefined): boolean => gender !== "female";
 

--- a/utils/recruitingCalendar/types.ts
+++ b/utils/recruitingCalendar/types.ts
@@ -22,7 +22,9 @@ export type NcaaCalendarKey =
   | "OTHER_MICEHOCKEY"
   | "OTHER_WICEHOCKEY"
   | "OTHER_ROWING"
-  | "OTHER_FIELDHOCKEY";
+  | "OTHER_FIELDHOCKEY"
+  | "OTHER_MWRESTLING"
+  | "OTHER_WWRESTLING";
 
 export type Division = "D1" | "D2" | "D3";
 

--- a/utils/recruitingCalendar/types.ts
+++ b/utils/recruitingCalendar/types.ts
@@ -41,3 +41,35 @@ export type AppSport =
   | "Field Hockey"
   | "Rowing"
   | "Water Polo";
+
+/**
+ * One NCAA recruiting-period window. 5-type taxonomy (spike finding): baseball
+ * uses `recruiting_shutdown` (stricter than `dead` — no calls/texts/correspondence
+ * at all) and has no `evaluation`; basketball/football use `evaluation`. Each
+ * sport's calendar uses only its real subset. `description` preserves the
+ * source legend's exact term.
+ */
+export interface RecruitingPeriod {
+  type: "dead" | "quiet" | "contact" | "evaluation" | "recruiting_shutdown";
+  start: string; // ISO date "YYYY-MM-DD"
+  end: string; // ISO date "YYYY-MM-DD"
+  description: string;
+  confidence: "HIGH" | "MEDIUM" | "LOW"; // transcription confidence (L1/L2 audit trail)
+}
+
+/** Signing dates, test dates, application/eligibility deadlines. */
+export interface CalendarMilestone {
+  date: string; // ISO date "YYYY-MM-DD"
+  title: string;
+  type: "test" | "deadline" | "ncaa-period" | "application" | "signing";
+  url?: string;
+  description?: string;
+}
+
+/** One NCAA calendar key's full period + milestone set, with its citation. */
+export interface SportCalendar {
+  periods: RecruitingPeriod[];
+  milestones: CalendarMilestone[];
+  source: string; // exact NCAA PDF URL this calendar was transcribed from (Layer 1)
+  verifiedOn: string; // ISO date a human last verified against the source (Layer 1 CI guard)
+}

--- a/utils/recruitingCalendar/types.ts
+++ b/utils/recruitingCalendar/types.ts
@@ -15,7 +15,14 @@ export type NcaaCalendarKey =
   | "MGO"
   | "MLA"
   | "WLA"
-  | "Other";
+  | "Other"
+  | "OTHER_MSOCCER"
+  | "OTHER_WSOCCER"
+  | "OTHER_SWIM"
+  | "OTHER_MICEHOCKEY"
+  | "OTHER_WICEHOCKEY"
+  | "OTHER_ROWING"
+  | "OTHER_FIELDHOCKEY";
 
 export type Division = "D1" | "D2" | "D3";
 

--- a/utils/recruitingCalendar/types.ts
+++ b/utils/recruitingCalendar/types.ts
@@ -1,0 +1,43 @@
+/**
+ * NCAA recruiting-calendar key. Each key identifies one NCAA sport calendar
+ * (contact-period rules differ per sport/gender/subdivision). "Other" covers
+ * app sports that have no published NCAA recruiting calendar.
+ */
+export type NcaaCalendarKey =
+  | "MBA"
+  | "WSB"
+  | "MBB"
+  | "WBB"
+  | "FBS"
+  | "FCS"
+  | "XCTF"
+  | "WVB"
+  | "MGO"
+  | "MLA"
+  | "WLA"
+  | "Other";
+
+export type Division = "D1" | "D2" | "D3";
+
+/**
+ * The 17 app sport strings, copied verbatim from `utils/metrics/canonical.ts`
+ * `SPORT_METRICS` keys.
+ */
+export type AppSport =
+  | "Baseball"
+  | "Softball"
+  | "Basketball"
+  | "Football"
+  | "Soccer"
+  | "Volleyball"
+  | "Track & Field"
+  | "Cross Country"
+  | "Swimming"
+  | "Golf"
+  | "Tennis"
+  | "Wrestling"
+  | "Lacrosse"
+  | "Ice Hockey"
+  | "Field Hockey"
+  | "Rowing"
+  | "Water Polo";


### PR DESCRIPTION
Follow-up to the merged gender-field PR (#434 merged Phase 1 only). This carries the calendar itself, which landed on the branch after #434 merged.

## Contents (13 commits)
- **Data + resolver:** `utils/recruitingCalendar/` — 21 NCAA calendar keys (12 base + 9 OTHER_* per-sport sub-calendars) transcribed from official 2026-27 NCAA PDFs (cited, confidence-tagged), resolver for all 17 sports (gender-split, Football FBS/FCS, Golf, Other-bundle, null→men's).
- **Rewire:** retires the `BASEBALL_` constant; `ruleEngine` gates timeline-task generation on the athlete's real sport (regression-tested — non-baseball athletes no longer suppressed by baseball dead dates); dashboard + timeline sport-aware; `RecruitingCalendar` widget mounted on dashboard + timeline with M/W + FBS/FCS toggles, L6a compliance disclaimer + PDF link, L6b staleness banner.
- **Phase 5:** `scripts/check-ncaa-calendar-cycle.mjs` next-cycle checker + `docs/recruiting-calendar-refresh.md`; a quarterly cloud routine opens a re-transcribe issue when the next NCAA cycle publishes.
- SEASON constants + `.github/CODEOWNERS` gate on the calendar data.

## Tests
~250 module tests + regression sweeps green; type-check clean. Ran via subagent-driven development (per-task + whole-branch opus review = fix-then-ship; the one real bug — banner showed enclosing period over nested dead carve-out — fixed + re-reviewed).

## Not covered
Device/browser verification (unit + type-check only). Pre-existing `division:"DI"` milestone typo + 2 pre-existing LogMetricModal failures untouched.

https://claude.ai/code/session_01AWiAGdNsWYRjvHQo9hRv43