### PR TITLE
fix(performance): trend direction resolves from n=2 (half-vs-half)

### DIFF
--- a/tests/unit/utils/metricTrends.spec.ts
+++ b/tests/unit/utils/metricTrends.spec.ts
@@ -38,18 +38,12 @@ describe("computeMetricTrends", () => {
     expect(computeMetricTrends([metric("velo", 80, day(1))])).toEqual([]);
   });
 
-  // Direction compares mean(first 3) to mean(last 3). With <= 3 records those
-  // windows fully overlap → always "stable" (documented quirk of the shipped
-  // algorithm; distinguishing direction needs > 3 records). See explicit test
-  // below. The direction tests therefore use 6 records.
+  // Direction compares mean(earliest half) to mean(latest half), non-overlapping
+  // (middle dropped at odd counts), so it resolves from n=2 upward.
   it("marks a rising higher-is-better metric as improving", () => {
     const trend = computeMetricTrends([
       metric("velo", 80, day(1)),
-      metric("velo", 82, day(2)),
-      metric("velo", 84, day(3)),
-      metric("velo", 90, day(4)),
-      metric("velo", 93, day(5)),
-      metric("velo", 96, day(6)),
+      metric("velo", 96, day(2)),
     ])[0];
     expect(trend.type).toBe("velo");
     expect(trend.trend).toBe("improving");
@@ -58,11 +52,7 @@ describe("computeMetricTrends", () => {
   it("marks a falling higher-is-better metric as declining", () => {
     const trend = computeMetricTrends([
       metric("velo", 96, day(1)),
-      metric("velo", 93, day(2)),
-      metric("velo", 90, day(3)),
-      metric("velo", 84, day(4)),
-      metric("velo", 82, day(5)),
-      metric("velo", 80, day(6)),
+      metric("velo", 80, day(2)),
     ])[0];
     expect(trend.trend).toBe("declining");
   });
@@ -70,11 +60,7 @@ describe("computeMetricTrends", () => {
   it("inverts direction for a lower-is-better metric (falling time improves)", () => {
     const trend = computeMetricTrends([
       metric("low_sprint", 7.5, day(1)),
-      metric("low_sprint", 7.4, day(2)),
-      metric("low_sprint", 7.3, day(3)),
-      metric("low_sprint", 7.0, day(4)),
-      metric("low_sprint", 6.9, day(5)),
-      metric("low_sprint", 6.8, day(6)),
+      metric("low_sprint", 6.8, day(2)),
     ])[0];
     expect(trend.trend).toBe("improving");
   });
@@ -82,23 +68,19 @@ describe("computeMetricTrends", () => {
   it("treats within-1% movement as stable", () => {
     const trend = computeMetricTrends([
       metric("velo", 100, day(1)),
-      metric("velo", 100.1, day(2)),
-      metric("velo", 100.2, day(3)),
-      metric("velo", 100.3, day(4)),
-      metric("velo", 100.4, day(5)),
-      metric("velo", 100.5, day(6)),
+      metric("velo", 100.5, day(2)),
     ])[0];
     expect(trend.trend).toBe("stable");
   });
 
-  it("reports stable for <= 3 records regardless of movement (shipped quirk)", () => {
-    // first3 and last3 windows fully overlap at 3 records → no direction.
-    const trend = computeMetricTrends([
+  it("resolves direction at 3 records by dropping the middle", () => {
+    // half = 1 → first=[80], last=[100]; the middle record is ignored.
+    const improving = computeMetricTrends([
       metric("velo", 80, day(1)),
-      metric("velo", 90, day(2)),
+      metric("velo", 999, day(2)), // middle — dropped, must not sway direction
       metric("velo", 100, day(3)),
     ])[0];
-    expect(trend.trend).toBe("stable");
+    expect(improving.trend).toBe("improving");
   });
 
   it("caps values at the last 10 records, chronologically", () => {

--- a/utils/metricTrends.ts
+++ b/utils/metricTrends.ts
@@ -3,9 +3,11 @@
  * improving/declining/stable logic is unit-testable in isolation.
  *
  * A metric type qualifies once it has >= 2 records. Trend direction compares the
- * mean of the first 3 records to the mean of the last 3 (chronological), with a
- * ±1% dead-band → "stable". Whether higher or lower is better comes from the
- * metric registry per sport (`getMetricDef(type).lowerIsBetter`).
+ * mean of the earliest half of records to the mean of the latest half — the two
+ * halves never overlap (the middle record is dropped at odd counts), so a real
+ * direction shows from the very first two records. A ±1% dead-band → "stable".
+ * Whether higher or lower is better comes from the metric registry per sport
+ * (`getMetricDef(type).lowerIsBetter`).
  */
 
 import { getMetricDef } from "~/utils/metrics/canonical";
@@ -53,8 +55,11 @@ export function computeMetricTrends(
       const max = Math.max(...values);
       const average = mean(values);
 
-      const firstAvg = mean(values.slice(0, 3));
-      const lastAvg = mean(values.slice(-3));
+      // Non-overlapping early vs recent halves (middle dropped at odd counts) so
+      // direction is meaningful from n=2, not just n>=6 as a first3/last3 compare.
+      const half = Math.floor(values.length / 2);
+      const firstAvg = mean(values.slice(0, half));
+      const lastAvg = mean(values.slice(values.length - half));
 
       // Direction ("lower is better") comes from the metric registry, per sport.
       const lowerIsBetter = getMetricDef(type).lowerIsBetter;


### PR DESCRIPTION
## Bug

`computeMetricTrends` compared `mean(first 3)` to `mean(last 3)`. Those windows **fully overlap at ≤3 records** (and partially at 4–5), so a metric read **"stable" regardless of real movement** until it had 6+ records. A 2-point 80→90 jump showed no direction.

## Fix

Compare the earliest `floor(n/2)` records to the latest `floor(n/2)`, dropping the middle record at odd counts so the halves never overlap. Direction now resolves from the first two records. The ±1% dead-band and per-sport `lowerIsBetter` dispatch are unchanged.

```
n=2: [80] vs [90]        -> improving
n=3: [80] vs [100]       -> improving (middle dropped)
n=5: [80,82] vs [88,90]  -> improving (middle dropped)
```

## Stacking

Base is **`refactor/performance-page-split` (PR #441)** — that branch introduces `utils/metricTrends.ts`. **Retarget this to `develop` once #441 merges.**

## Testing

- 11 trend unit tests updated, incl. a drop-the-middle proof (a 999 outlier in the middle of 3 records must not sway direction)
- type-check clean; 7913 unit tests pass

https://claude.ai/code/session_01FgqZNX32XLT6KDudKmsQ9L