### PR TITLE
fix(performance): land half-vs-half trend fix on develop (recover stranded #444)

### DIFF
--- a/scripts/check-ncaa-calendar-cycle.mjs
+++ b/scripts/check-ncaa-calendar-cycle.mjs
@@ -69,7 +69,6 @@ async function main() {
   );
 
   const found = results.filter((r) => r.status === 200);
-  const missing = results.filter((r) => r.status !== 200);
 
   console.log(`NCAA calendar cycle check — season ${season}`);
   console.log(`  transcribed season: ${CURRENT_SEASON}`);

--- a/tests/unit/utils/metricTrends.spec.ts
+++ b/tests/unit/utils/metricTrends.spec.ts
@@ -38,18 +38,12 @@ describe("computeMetricTrends", () => {
     expect(computeMetricTrends([metric("velo", 80, day(1))])).toEqual([]);
   });
 
-  // Direction compares mean(first 3) to mean(last 3). With <= 3 records those
-  // windows fully overlap → always "stable" (documented quirk of the shipped
-  // algorithm; distinguishing direction needs > 3 records). See explicit test
-  // below. The direction tests therefore use 6 records.
+  // Direction compares mean(earliest half) to mean(latest half), non-overlapping
+  // (middle dropped at odd counts), so it resolves from n=2 upward.
   it("marks a rising higher-is-better metric as improving", () => {
     const trend = computeMetricTrends([
       metric("velo", 80, day(1)),
-      metric("velo", 82, day(2)),
-      metric("velo", 84, day(3)),
-      metric("velo", 90, day(4)),
-      metric("velo", 93, day(5)),
-      metric("velo", 96, day(6)),
+      metric("velo", 96, day(2)),
     ])[0];
     expect(trend.type).toBe("velo");
     expect(trend.trend).toBe("improving");
@@ -58,11 +52,7 @@ describe("computeMetricTrends", () => {
   it("marks a falling higher-is-better metric as declining", () => {
     const trend = computeMetricTrends([
       metric("velo", 96, day(1)),
-      metric("velo", 93, day(2)),
-      metric("velo", 90, day(3)),
-      metric("velo", 84, day(4)),
-      metric("velo", 82, day(5)),
-      metric("velo", 80, day(6)),
+      metric("velo", 80, day(2)),
     ])[0];
     expect(trend.trend).toBe("declining");
   });
@@ -70,11 +60,7 @@ describe("computeMetricTrends", () => {
   it("inverts direction for a lower-is-better metric (falling time improves)", () => {
     const trend = computeMetricTrends([
       metric("low_sprint", 7.5, day(1)),
-      metric("low_sprint", 7.4, day(2)),
-      metric("low_sprint", 7.3, day(3)),
-      metric("low_sprint", 7.0, day(4)),
-      metric("low_sprint", 6.9, day(5)),
-      metric("low_sprint", 6.8, day(6)),
+      metric("low_sprint", 6.8, day(2)),
     ])[0];
     expect(trend.trend).toBe("improving");
   });
@@ -82,23 +68,19 @@ describe("computeMetricTrends", () => {
   it("treats within-1% movement as stable", () => {
     const trend = computeMetricTrends([
       metric("velo", 100, day(1)),
-      metric("velo", 100.1, day(2)),
-      metric("velo", 100.2, day(3)),
-      metric("velo", 100.3, day(4)),
-      metric("velo", 100.4, day(5)),
-      metric("velo", 100.5, day(6)),
+      metric("velo", 100.5, day(2)),
     ])[0];
     expect(trend.trend).toBe("stable");
   });
 
-  it("reports stable for <= 3 records regardless of movement (shipped quirk)", () => {
-    // first3 and last3 windows fully overlap at 3 records → no direction.
-    const trend = computeMetricTrends([
+  it("resolves direction at 3 records by dropping the middle", () => {
+    // half = 1 → first=[80], last=[100]; the middle record is ignored.
+    const improving = computeMetricTrends([
       metric("velo", 80, day(1)),
-      metric("velo", 90, day(2)),
+      metric("velo", 999, day(2)), // middle — dropped, must not sway direction
       metric("velo", 100, day(3)),
     ])[0];
-    expect(trend.trend).toBe("stable");
+    expect(improving.trend).toBe("improving");
   });
 
   it("caps values at the last 10 records, chronologically", () => {

--- a/utils/metricTrends.ts
+++ b/utils/metricTrends.ts
@@ -3,9 +3,11 @@
  * improving/declining/stable logic is unit-testable in isolation.
  *
  * A metric type qualifies once it has >= 2 records. Trend direction compares the
- * mean of the first 3 records to the mean of the last 3 (chronological), with a
- * ±1% dead-band → "stable". Whether higher or lower is better comes from the
- * metric registry per sport (`getMetricDef(type).lowerIsBetter`).
+ * mean of the earliest half of records to the mean of the latest half — the two
+ * halves never overlap (the middle record is dropped at odd counts), so a real
+ * direction shows from the very first two records. A ±1% dead-band → "stable".
+ * Whether higher or lower is better comes from the metric registry per sport
+ * (`getMetricDef(type).lowerIsBetter`).
  */
 
 import { getMetricDef } from "~/utils/metrics/canonical";
@@ -53,8 +55,11 @@ export function computeMetricTrends(
       const max = Math.max(...values);
       const average = mean(values);
 
-      const firstAvg = mean(values.slice(0, 3));
-      const lastAvg = mean(values.slice(-3));
+      // Non-overlapping early vs recent halves (middle dropped at odd counts) so
+      // direction is meaningful from n=2, not just n>=6 as a first3/last3 compare.
+      const half = Math.floor(values.length / 2);
+      const firstAvg = mean(values.slice(0, half));
+      const lastAvg = mean(values.slice(values.length - half));
 
       // Direction ("lower is better") comes from the metric registry, per sport.
       const lowerIsBetter = getMetricDef(type).lowerIsBetter;


### PR DESCRIPTION
## Why

**PR #444's fix never reached develop.** It was stacked on `refactor/performance-page-split` (base = that branch, not develop). #441 merged the base to develop *before* #444 landed, so the fix commit ended up only on the now-stale feature branch. develop currently ships the **buggy first3/last3 trend algorithm** (a metric reads "stable" until it has 6+ records).

Retargeting the original branch was not viable — it's based on the pre-merge tree and would revert #439/#440/#442/#443. So this **cherry-picks the fix commit onto current develop**.

## What

- `utils/metricTrends.ts` — direction now compares earliest `floor(n/2)` vs latest `floor(n/2)` (middle dropped at odd counts), resolving from n=2. (cherry-pick of `70efcdcc`)
- `scripts/check-ncaa-calendar-cycle.mjs` — drops an unused `missing` var. **Pre-existing lint error on develop** (from #442) that fails the pre-push `eslint .` for every branch; removing it unblocks pushes. Separate commit.

## Testing

- 11 trend unit tests pass (incl. drop-the-middle proof)
- type-check + lint clean

https://claude.ai/code/session_01FgqZNX32XLT6KDudKmsQ9L