### PR TITLE
fix(comm): raise SMS compose cap 160 → 480 for iOS parity

### DIFF
--- a/components/Communication/MessageComposer.vue
+++ b/components/Communication/MessageComposer.vue
@@ -74,18 +74,18 @@
                     >Message</label
                   >
                   <span v-if="!isEmail" class="text-xs text-slate-500"
-                    >{{ channel.composer.value.body.length }}/160</span
+                    >{{ channel.composer.value.body.length }}/{{ SMS_TEXT_LIMIT }}</span
                   >
                 </div>
                 <textarea
                   v-model="channel.composer.value.body"
                   :rows="isEmail ? 6 : 4"
-                  :maxlength="isEmail ? undefined : 160"
+                  :maxlength="isEmail ? undefined : SMS_TEXT_LIMIT"
                   class="w-full px-3 py-2 rounded-lg border border-slate-300 text-slate-900 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm"
                   placeholder="Your message..."
                 />
                 <p v-if="!isEmail" class="text-xs text-slate-500 mt-2">
-                  SMS limited to 160 characters
+                  Texts are limited to {{ SMS_TEXT_LIMIT }} characters
                 </p>
               </div>
 
@@ -176,6 +176,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, nextTick } from "vue";
 import { useFocusTrap } from "~/composables/useFocusTrap";
+import { SMS_TEXT_LIMIT } from "~/utils/phone";
 import type { ChannelController } from "~/composables/useQuickCommunication";
 import type { Coach } from "~/types/models";
 

--- a/scripts/check-ncaa-calendar-cycle.mjs
+++ b/scripts/check-ncaa-calendar-cycle.mjs
@@ -69,7 +69,6 @@ async function main() {
   );
 
   const found = results.filter((r) => r.status === 200);
-  const missing = results.filter((r) => r.status !== 200);
 
   console.log(`NCAA calendar cycle check — season ${season}`);
   console.log(`  transcribed season: ${CURRENT_SEASON}`);

--- a/tests/unit/components/Communication/MessageComposer.spec.ts
+++ b/tests/unit/components/Communication/MessageComposer.spec.ts
@@ -88,8 +88,8 @@ describe("MessageComposer", () => {
   it("hides the subject field and shows the SMS counter for the text channel", () => {
     const wrapper = mountComposer(buildController("text"));
     expect(wrapper.find('input[placeholder="Email subject..."]').exists()).toBe(false);
-    expect(wrapper.text()).toContain("/160");
-    expect(wrapper.text()).toContain("SMS limited to 160 characters");
+    expect(wrapper.text()).toContain("/480");
+    expect(wrapper.text()).toContain("Texts are limited to 480 characters");
   });
 
   it("renders the live preview segments, marking unresolved tokens", () => {

--- a/utils/phone.ts
+++ b/utils/phone.ts
@@ -8,6 +8,14 @@
 
 const E164_US = /^\+1\d{10}$/;
 
+/**
+ * Max characters for a coach outreach text. 480 ≈ 3 SMS segments — Messages
+ * concatenates multipart texts natively, so legitimately long multi-event
+ * templates can send. Matches iOS `QuickCommunicationViewModel.textLimit`
+ * (raised from the old one-segment 160 for web/iOS parity).
+ */
+export const SMS_TEXT_LIMIT = 480;
+
 /** Digits only, with a leading US country code stripped when present. */
 export function nationalDigits(input: string): string {
   const digits = input.replace(/\D/g, "");


### PR DESCRIPTION
## What

Web capped coach texts at **160** (one SMS segment); iOS caps at **480** (~3 segments) and literally carried a `// NOTE: web still caps at 160 — parity divergence, revisit on web` comment. Long multi-event outreach templates were truncated on web but not iOS.

- New `SMS_TEXT_LIMIT = 480` in `utils/phone.ts`, matching iOS `QuickCommunicationViewModel.textLimit`.
- `MessageComposer.vue` uses it for the textarea `maxlength`, the character counter (`/480`), and the helper text. Messages concatenates multipart texts natively, so a 3-segment cap sends fine.

## Parity

Closes the divergence iOS flagged. iOS unchanged (already at 480).

## Note

Second commit re-applies the same one-line lint fix as #445 (pre-existing unused `missing` on develop) so this branch's pre-push `eslint .` passes — idempotent, resolves cleanly whichever merges first.

## Testing

- `MessageComposer` spec updated to assert the 480 counter + copy
- type-check + lint + audit clean; 7964 unit tests pass

https://claude.ai/code/session_01FgqZNX32XLT6KDudKmsQ9L