### PR TITLE
refactor(player-details): split 450-line form composable into focused units

### DIFF
--- a/composables/useCoreCourses.ts
+++ b/composables/useCoreCourses.ts
@@ -1,0 +1,31 @@
+import { ref, type Ref } from "vue";
+import type { PlayerDetails } from "~/types/models";
+
+/**
+ * Core-courses list editing for the player-details form. Mutates the shared
+ * `form` ref and triggers an autosave on every change (add dedupes case-exactly
+ * and ignores blanks). Extracted from usePlayerDetailsForm.
+ */
+export function useCoreCourses(
+  form: Ref<PlayerDetails>,
+  triggerSave: () => void,
+) {
+  const newCourseInput = ref("");
+
+  const addCourse = (): void => {
+    const trimmed = newCourseInput.value.trim();
+    if (!trimmed || form.value.core_courses?.includes(trimmed)) return;
+    form.value.core_courses = [...(form.value.core_courses ?? []), trimmed];
+    newCourseInput.value = "";
+    triggerSave();
+  };
+
+  const removeCourse = (idx: number): void => {
+    form.value.core_courses = (form.value.core_courses ?? []).filter(
+      (_, i) => i !== idx,
+    );
+    triggerSave();
+  };
+
+  return { newCourseInput, addCourse, removeCourse };
+}

--- a/composables/usePlayerDetailsForm.ts
+++ b/composables/usePlayerDetailsForm.ts
@@ -1,6 +1,5 @@
 import { ref, computed, watch } from "vue";
 import { usePreferenceManager } from "~/composables/usePreferenceManager";
-import { useAppToast } from "~/composables/useAppToast";
 import { useSportsPositionLookup } from "~/composables/useSportsPositionLookup";
 import { useAutoSave } from "~/composables/useAutoSave";
 import {
@@ -10,12 +9,26 @@ import {
   normalizePositions as normalizePositionsForSport,
 } from "~/utils/positions/canonical";
 import { formatPhoneDisplay, toStoredPhone } from "~/utils/phone";
-import { normalizeHandle, type SocialPlatform } from "~/utils/social";
 import {
   calculateProfileCompleteness,
   isHomeLocationPresent,
 } from "~/utils/profileCompletenessCalculation";
 import { useVideoLinks } from "~/composables/useVideoLinks";
+import { useCoreCourses } from "~/composables/useCoreCourses";
+import {
+  useTravelTeams,
+  buildLegacyTravelTeam,
+} from "~/composables/useTravelTeams";
+import { useSocialHandles } from "~/composables/useSocialHandles";
+import {
+  BATS_OPTIONS,
+  THROWS_OPTIONS,
+  CAMPUS_SIZE_OPTIONS,
+  GENDER_OPTIONS,
+  COST_SENSITIVITY_OPTIONS,
+  SOCIAL_INPUTS,
+  GRADE_LEVELS,
+} from "~/utils/playerDetails/formOptions";
 import type { PlayerDetails, TravelTeam } from "~/types/models";
 
 /**
@@ -31,38 +44,7 @@ export function usePlayerDetailsForm() {
     getHomeLocation,
   } = usePreferenceManager();
   const { links: videoLinks, load: loadVideoLinks } = useVideoLinks();
-  const { showToast } = useAppToast();
   const { commonSports, getPositionsBySport } = useSportsPositionLookup();
-
-  const BATS_OPTIONS = [
-    { value: "R", label: "Right" },
-    { value: "L", label: "Left" },
-    { value: "S", label: "Switch" },
-  ] as const;
-
-  const THROWS_OPTIONS = [
-    { value: "R", label: "Right" },
-    { value: "L", label: "Left" },
-  ] as const;
-
-  const CAMPUS_SIZE_OPTIONS = [
-    { value: "small" as const, label: "Small (<5K)" },
-    { value: "medium" as const, label: "Mid (5K–25K)" },
-    { value: "large" as const, label: "Large (25K+)" },
-  ];
-
-  const GENDER_OPTIONS = [
-    { value: "male" as const, label: "Male" },
-    { value: "female" as const, label: "Female" },
-    { value: "other" as const, label: "Other" },
-    { value: "prefer_not_to_say" as const, label: "Prefer not to say" },
-  ];
-
-  const COST_SENSITIVITY_OPTIONS = [
-    { value: "high" as const, label: "High" },
-    { value: "medium" as const, label: "Medium" },
-    { value: "low" as const, label: "Low" },
-  ];
 
   const heightFeet = ref<number | undefined>(undefined);
   const heightInches = ref<number | undefined>(undefined);
@@ -176,6 +158,14 @@ export function usePlayerDetailsForm() {
     },
   });
 
+  // List-editing + social-handle concerns operate on the shared form + autosave.
+  const { newCourseInput, addCourse, removeCourse } = useCoreCourses(
+    form,
+    triggerSave,
+  );
+  const { addTravelTeam, removeTravelTeam } = useTravelTeams(form, triggerSave);
+  const { handleSocialBlur } = useSocialHandles(form, triggerSave);
+
   watch(
     () => form.value.primary_sport,
     (sport, previousSport) => {
@@ -240,136 +230,6 @@ export function usePlayerDetailsForm() {
     const [item] = list.splice(index, 1);
     list.splice(target, 0, item);
   };
-
-  const newCourseInput = ref("");
-
-  const addCourse = () => {
-    const trimmed = newCourseInput.value.trim();
-    if (!trimmed || form.value.core_courses?.includes(trimmed)) return;
-    form.value.core_courses = [...(form.value.core_courses ?? []), trimmed];
-    newCourseInput.value = "";
-    triggerSave();
-  };
-
-  const removeCourse = (idx: number) => {
-    form.value.core_courses = (form.value.core_courses ?? []).filter(
-      (_, i) => i !== idx,
-    );
-    triggerSave();
-  };
-
-  const buildLegacyTravelTeam = (details: PlayerDetails): TravelTeam[] => {
-    if (
-      details.travel_team_year === undefined &&
-      !details.travel_team_name &&
-      !details.travel_team_coach
-    ) {
-      return [];
-    }
-    return [
-      {
-        year: details.travel_team_year,
-        name: details.travel_team_name ?? "",
-        coach: details.travel_team_coach ?? "",
-      },
-    ];
-  };
-
-  const addTravelTeam = () => {
-    form.value.travel_teams = [
-      ...(form.value.travel_teams ?? []),
-      { year: undefined, name: "", coach: "" },
-    ];
-  };
-
-  const removeTravelTeam = (idx: number) => {
-    form.value.travel_teams = (form.value.travel_teams ?? []).filter(
-      (_, i) => i !== idx,
-    );
-    triggerSave();
-  };
-
-  const SOCIAL_PLATFORMS: Record<string, SocialPlatform | null> = {
-    twitter_handle: "twitter",
-    instagram_handle: "instagram",
-    tiktok_handle: "tiktok",
-    facebook_url: null,
-  };
-
-  function handleSocialBlur(key: string, value: string) {
-    const platform = SOCIAL_PLATFORMS[key];
-    if (!platform) return;
-
-    const { handle, isShortUrl } = normalizeHandle(value, platform);
-    (form.value as Record<string, unknown>)[key] = handle;
-
-    if (isShortUrl) {
-      showToast(
-        "Short links can't be used as handles — enter your username directly.",
-        "warning",
-      );
-    }
-
-    triggerSave();
-  }
-
-  const socialInputs: {
-    key: keyof PlayerDetails;
-    label: string;
-    prefix?: string;
-    placeholder: string;
-  }[] = [
-    {
-      key: "twitter_handle",
-      label: "Twitter / X",
-      prefix: "@",
-      placeholder: "username",
-    },
-    {
-      key: "instagram_handle",
-      label: "Instagram",
-      prefix: "@",
-      placeholder: "username",
-    },
-    {
-      key: "tiktok_handle",
-      label: "TikTok",
-      prefix: "@",
-      placeholder: "username",
-    },
-    {
-      key: "facebook_url",
-      label: "Facebook URL",
-      placeholder: "https://facebook.com/...",
-    },
-  ];
-
-  const gradeLevels = [
-    {
-      key: "9",
-      label: "9th Grade (Freshman)",
-      teamKey: "ninth_grade_team",
-      coachKey: "ninth_grade_coach",
-    },
-    {
-      key: "10",
-      label: "10th Grade (Sophomore)",
-      teamKey: "tenth_grade_team",
-      coachKey: "tenth_grade_coach",
-    },
-    {
-      key: "11",
-      label: "11th Grade (Junior)",
-      teamKey: "eleventh_grade_team",
-      coachKey: "eleventh_grade_coach",
-    },
-    {
-      key: "12",
-      label: "12th Grade (Senior)",
-      teamKey: "twelfth_grade_team",
-      coachKey: "twelfth_grade_coach",
-    },
-  ] as const;
 
   const load = async () => {
     await Promise.all([loadAllPreferences(), loadVideoLinks()]);
@@ -437,8 +297,8 @@ export function usePlayerDetailsForm() {
     addTravelTeam,
     removeTravelTeam,
     handleSocialBlur,
-    socialInputs,
-    gradeLevels,
+    socialInputs: SOCIAL_INPUTS,
+    gradeLevels: GRADE_LEVELS,
     BATS_OPTIONS,
     THROWS_OPTIONS,
     CAMPUS_SIZE_OPTIONS,

--- a/composables/useSocialHandles.ts
+++ b/composables/useSocialHandles.ts
@@ -1,0 +1,37 @@
+import type { Ref } from "vue";
+import { useAppToast } from "~/composables/useAppToast";
+import { normalizeHandle } from "~/utils/social";
+import { SOCIAL_PLATFORMS } from "~/utils/playerDetails/formOptions";
+import type { PlayerDetails } from "~/types/models";
+
+/**
+ * Social-handle blur normalization for the player-details form. On blur, strips a
+ * pasted handle/URL down to the bare username (per platform), writes it back to
+ * the form, warns when a short link was pasted, and autosaves. facebook_url has
+ * no platform normalizer → left as-is. Extracted from usePlayerDetailsForm.
+ */
+export function useSocialHandles(
+  form: Ref<PlayerDetails>,
+  triggerSave: () => void,
+) {
+  const { showToast } = useAppToast();
+
+  const handleSocialBlur = (key: string, value: string): void => {
+    const platform = SOCIAL_PLATFORMS[key];
+    if (!platform) return;
+
+    const { handle, isShortUrl } = normalizeHandle(value, platform);
+    (form.value as Record<string, unknown>)[key] = handle;
+
+    if (isShortUrl) {
+      showToast(
+        "Short links can't be used as handles — enter your username directly.",
+        "warning",
+      );
+    }
+
+    triggerSave();
+  };
+
+  return { handleSocialBlur };
+}

--- a/composables/useTravelTeams.ts
+++ b/composables/useTravelTeams.ts
@@ -1,0 +1,50 @@
+import type { Ref } from "vue";
+import type { PlayerDetails, TravelTeam } from "~/types/models";
+
+/**
+ * Seed the multi-row travel_teams list from the legacy single-team scalar fields
+ * the first time an athlete opens the new UI (no travel_teams stored yet).
+ * Returns [] when the legacy fields are all empty. Pure.
+ */
+export function buildLegacyTravelTeam(details: PlayerDetails): TravelTeam[] {
+  if (
+    details.travel_team_year === undefined &&
+    !details.travel_team_name &&
+    !details.travel_team_coach
+  ) {
+    return [];
+  }
+  return [
+    {
+      year: details.travel_team_year,
+      name: details.travel_team_name ?? "",
+      coach: details.travel_team_coach ?? "",
+    },
+  ];
+}
+
+/**
+ * Travel-team list editing for the player-details form. Adding a blank row does
+ * NOT autosave (nothing to persist until the athlete types); removing does.
+ * Extracted from usePlayerDetailsForm.
+ */
+export function useTravelTeams(
+  form: Ref<PlayerDetails>,
+  triggerSave: () => void,
+) {
+  const addTravelTeam = (): void => {
+    form.value.travel_teams = [
+      ...(form.value.travel_teams ?? []),
+      { year: undefined, name: "", coach: "" },
+    ];
+  };
+
+  const removeTravelTeam = (idx: number): void => {
+    form.value.travel_teams = (form.value.travel_teams ?? []).filter(
+      (_, i) => i !== idx,
+    );
+    triggerSave();
+  };
+
+  return { addTravelTeam, removeTravelTeam };
+}

--- a/tests/unit/composables/playerDetailsForm.parts.spec.ts
+++ b/tests/unit/composables/playerDetailsForm.parts.spec.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ref } from "vue";
+import { useCoreCourses } from "~/composables/useCoreCourses";
+import {
+  useTravelTeams,
+  buildLegacyTravelTeam,
+} from "~/composables/useTravelTeams";
+import { useSocialHandles } from "~/composables/useSocialHandles";
+import type { PlayerDetails } from "~/types/models";
+
+const showToast = vi.fn();
+vi.mock("~/composables/useAppToast", () => ({
+  useAppToast: () => ({ showToast }),
+}));
+
+const makeForm = (over: Partial<PlayerDetails> = {}) =>
+  ref<PlayerDetails>({ core_courses: [], travel_teams: [], ...over } as PlayerDetails);
+
+beforeEach(() => showToast.mockClear());
+
+describe("useCoreCourses", () => {
+  it("adds a trimmed course, clears the input, and autosaves", () => {
+    const form = makeForm();
+    const save = vi.fn();
+    const { newCourseInput, addCourse } = useCoreCourses(form, save);
+    newCourseInput.value = "  Algebra II  ";
+    addCourse();
+    expect(form.value.core_courses).toEqual(["Algebra II"]);
+    expect(newCourseInput.value).toBe("");
+    expect(save).toHaveBeenCalledOnce();
+  });
+
+  it("ignores blank input and exact duplicates without saving", () => {
+    const form = makeForm({ core_courses: ["Chem"] });
+    const save = vi.fn();
+    const { newCourseInput, addCourse } = useCoreCourses(form, save);
+    newCourseInput.value = "   ";
+    addCourse();
+    newCourseInput.value = "Chem";
+    addCourse();
+    expect(form.value.core_courses).toEqual(["Chem"]);
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("removes a course by index and autosaves", () => {
+    const form = makeForm({ core_courses: ["A", "B", "C"] });
+    const save = vi.fn();
+    const { removeCourse } = useCoreCourses(form, save);
+    removeCourse(1);
+    expect(form.value.core_courses).toEqual(["A", "C"]);
+    expect(save).toHaveBeenCalledOnce();
+  });
+});
+
+describe("useTravelTeams", () => {
+  it("appends a blank row WITHOUT autosaving (nothing to persist yet)", () => {
+    const form = makeForm();
+    const save = vi.fn();
+    const { addTravelTeam } = useTravelTeams(form, save);
+    addTravelTeam();
+    expect(form.value.travel_teams).toHaveLength(1);
+    expect(form.value.travel_teams?.[0]).toEqual({
+      year: undefined,
+      name: "",
+      coach: "",
+    });
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it("removes a row by index and autosaves", () => {
+    const form = makeForm({
+      travel_teams: [
+        { year: 2024, name: "A", coach: "" },
+        { year: 2025, name: "B", coach: "" },
+      ],
+    });
+    const save = vi.fn();
+    const { removeTravelTeam } = useTravelTeams(form, save);
+    removeTravelTeam(0);
+    expect(form.value.travel_teams).toEqual([{ year: 2025, name: "B", coach: "" }]);
+    expect(save).toHaveBeenCalledOnce();
+  });
+});
+
+describe("buildLegacyTravelTeam", () => {
+  it("returns [] when the legacy scalar fields are all empty", () => {
+    expect(buildLegacyTravelTeam({} as PlayerDetails)).toEqual([]);
+  });
+
+  it("seeds one row from the legacy scalar fields", () => {
+    const rows = buildLegacyTravelTeam({
+      travel_team_year: 2025,
+      travel_team_name: "Scorpions",
+      travel_team_coach: "Reyes",
+    } as PlayerDetails);
+    expect(rows).toEqual([{ year: 2025, name: "Scorpions", coach: "Reyes" }]);
+  });
+});
+
+describe("useSocialHandles", () => {
+  it("normalizes a handle, writes it back, and autosaves", () => {
+    const form = makeForm({ twitter_handle: "" });
+    const save = vi.fn();
+    const { handleSocialBlur } = useSocialHandles(form, save);
+    handleSocialBlur("twitter_handle", "@JordanE");
+    expect(form.value.twitter_handle).toBe("JordanE");
+    expect(save).toHaveBeenCalledOnce();
+  });
+
+  it("no-ops for facebook_url (no platform normalizer) and does not save", () => {
+    const form = makeForm({ facebook_url: "https://facebook.com/x" });
+    const save = vi.fn();
+    const { handleSocialBlur } = useSocialHandles(form, save);
+    handleSocialBlur("facebook_url", "https://facebook.com/x");
+    expect(save).not.toHaveBeenCalled();
+    expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it("warns when a TikTok short link is pasted as a handle", () => {
+    const form = makeForm({ tiktok_handle: "" });
+    const save = vi.fn();
+    const { handleSocialBlur } = useSocialHandles(form, save);
+    // vm.tiktok.com short links are the case normalizeHandle flags as isShortUrl.
+    handleSocialBlur("tiktok_handle", "https://vm.tiktok.com/ZM123/");
+    expect(showToast).toHaveBeenCalledWith(
+      expect.stringContaining("Short links"),
+      "warning",
+    );
+    expect(save).toHaveBeenCalledOnce();
+  });
+});

--- a/utils/playerDetails/formOptions.ts
+++ b/utils/playerDetails/formOptions.ts
@@ -1,0 +1,85 @@
+/**
+ * Static option/config data for the player-details settings form. Extracted from
+ * composables/usePlayerDetailsForm.ts so the composable holds behavior, not ~110
+ * lines of constant tables. Pure data — no reactivity.
+ */
+
+import type { PlayerDetails } from "~/types/models";
+import type { SocialPlatform } from "~/utils/social";
+
+export const BATS_OPTIONS = [
+  { value: "R", label: "Right" },
+  { value: "L", label: "Left" },
+  { value: "S", label: "Switch" },
+] as const;
+
+export const THROWS_OPTIONS = [
+  { value: "R", label: "Right" },
+  { value: "L", label: "Left" },
+] as const;
+
+export const CAMPUS_SIZE_OPTIONS = [
+  { value: "small" as const, label: "Small (<5K)" },
+  { value: "medium" as const, label: "Mid (5K–25K)" },
+  { value: "large" as const, label: "Large (25K+)" },
+];
+
+export const GENDER_OPTIONS = [
+  { value: "male" as const, label: "Male" },
+  { value: "female" as const, label: "Female" },
+  { value: "other" as const, label: "Other" },
+  { value: "prefer_not_to_say" as const, label: "Prefer not to say" },
+];
+
+export const COST_SENSITIVITY_OPTIONS = [
+  { value: "high" as const, label: "High" },
+  { value: "medium" as const, label: "Medium" },
+  { value: "low" as const, label: "Low" },
+];
+
+/** Handle field → normalizer platform. facebook_url stores a full URL (no platform). */
+export const SOCIAL_PLATFORMS: Record<string, SocialPlatform | null> = {
+  twitter_handle: "twitter",
+  instagram_handle: "instagram",
+  tiktok_handle: "tiktok",
+  facebook_url: null,
+};
+
+export const SOCIAL_INPUTS: {
+  key: keyof PlayerDetails;
+  label: string;
+  prefix?: string;
+  placeholder: string;
+}[] = [
+  { key: "twitter_handle", label: "Twitter / X", prefix: "@", placeholder: "username" },
+  { key: "instagram_handle", label: "Instagram", prefix: "@", placeholder: "username" },
+  { key: "tiktok_handle", label: "TikTok", prefix: "@", placeholder: "username" },
+  { key: "facebook_url", label: "Facebook URL", placeholder: "https://facebook.com/..." },
+];
+
+export const GRADE_LEVELS = [
+  {
+    key: "9",
+    label: "9th Grade (Freshman)",
+    teamKey: "ninth_grade_team",
+    coachKey: "ninth_grade_coach",
+  },
+  {
+    key: "10",
+    label: "10th Grade (Sophomore)",
+    teamKey: "tenth_grade_team",
+    coachKey: "tenth_grade_coach",
+  },
+  {
+    key: "11",
+    label: "11th Grade (Junior)",
+    teamKey: "eleventh_grade_team",
+    coachKey: "eleventh_grade_coach",
+  },
+  {
+    key: "12",
+    label: "12th Grade (Senior)",
+    teamKey: "twelfth_grade_team",
+    coachKey: "twelfth_grade_coach",
+  },
+] as const;


### PR DESCRIPTION
## What

`usePlayerDetailsForm` mixed form state, autosave, and several list/handle-editing concerns with **~110 lines of static option tables inline**, and its list-editing logic was untested.

- **`utils/playerDetails/formOptions.ts`** — static tables (bats/throws/campus/gender/cost options, social inputs + platform map, grade levels).
- **`composables/useCoreCourses.ts` / `useTravelTeams.ts` / `useSocialHandles.ts`** — each owns one concern, operating on the shared `form` ref + autosave trigger. `buildLegacyTravelTeam` exported pure.
- `usePlayerDetailsForm` now composes these: **450 → 310 lines**.

## Zero consumer churn

The composable's **public return shape is unchanged** — the player-details page and its tabs consume the exact same API, so no consumer edits (verified by type-check). `useAutoSave` was already its own composable and is untouched.

## Testing

- **10 new unit tests** for the extracted concerns (course dedupe / blank-guard, travel-team add-no-save vs remove-saves, social normalize + TikTok short-link warning) — previously untested logic.
- type-check + lint + audit clean; 7986 unit tests pass.

## Parity

iOS unaffected — pure web-side composable decomposition, no behavior change.

https://claude.ai/code/session_01FgqZNX32XLT6KDudKmsQ9L