### PR TITLE
refactor: small cleanups — derive ALL_SPORTS + dedup coach interaction refresh

### DIFF
--- a/pages/coaches/[id]/index.vue
+++ b/pages/coaches/[id]/index.vue
@@ -315,6 +315,15 @@ const handleOpenInstagram = () => {
   void logSocialDm();
 };
 
+// School-wide refresh (not coach-filtered): the metrics panel ranks this coach
+// against the school's other coaches, while the log/recent list filter by coach
+// in-page. No-op for a coach without a school.
+const refreshSchoolInteractions = async (): Promise<void> => {
+  if (coach.value?.school_id) {
+    await fetchInteractions({ schoolId: coach.value.school_id });
+  }
+};
+
 // Best-effort: opening a social profile is a hand-off, so like mailto/sms this logs
 // on click. createInteraction is player-role + family gated, so a parent-viewed
 // coach simply won't log — never surface that as an error.
@@ -325,11 +334,7 @@ async function logSocialDm(): Promise<void> {
       ...socialDmInteraction(coach.value),
       occurred_at: new Date().toISOString(),
     });
-    if (coach.value.school_id) {
-      // School-wide (not coach-filtered): the metrics panel ranks this coach
-      // against the school's other coaches; the log/recent list filter by coach.
-      await fetchInteractions({ schoolId: coach.value.school_id });
-    }
+    await refreshSchoolInteractions();
   } catch {
     // swallow — logging is best-effort
   }
@@ -346,12 +351,7 @@ const handleCoachInteractionLogged = async (interactionData: {
       if (updatedCoach) {
         coach.value = updatedCoach;
       }
-
-      if (coach.value?.school_id) {
-        // School-wide (not coach-filtered): the metrics panel ranks this coach
-      // against the school's other coaches; the log/recent list filter by coach.
-      await fetchInteractions({ schoolId: coach.value.school_id });
-      }
+      await refreshSchoolInteractions();
     };
 
     await handleInteractionLogged(interactionData as any, refreshData);

--- a/tests/unit/utils/services/canonical.spec.ts
+++ b/tests/unit/utils/services/canonical.spec.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { servicesForSport, ALL_SERVICE_DEFS } from "~/utils/services/canonical";
+import { SPORT_POSITIONS } from "~/utils/positions/canonical";
+
+describe("servicesForSport", () => {
+  it("returns [] for a nil or unknown sport", () => {
+    expect(servicesForSport(null)).toEqual([]);
+    expect(servicesForSport(undefined)).toEqual([]);
+    expect(servicesForSport("Quidditch")).toEqual([]);
+  });
+
+  it("offers NCSA (the all-sports service) for every sport in the vocabulary", () => {
+    // ALL_SPORTS is derived from SPORT_POSITIONS, so NCSA must resolve for every
+    // canonical sport — this fails if the two registries ever drift apart.
+    for (const sport of Object.keys(SPORT_POSITIONS)) {
+      const keys = servicesForSport(sport).map((d) => d.key);
+      expect(keys, `${sport} should offer NCSA`).toContain("ncsa_id");
+    }
+  });
+
+  it("scopes sport-specific services (Perfect Game is baseball/softball only)", () => {
+    expect(servicesForSport("Baseball").map((d) => d.key)).toContain(
+      "perfect_game_id",
+    );
+    expect(servicesForSport("Basketball").map((d) => d.key)).not.toContain(
+      "perfect_game_id",
+    );
+  });
+
+  it("every service def has a unique key", () => {
+    const keys = ALL_SERVICE_DEFS.map((d) => d.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});

--- a/utils/services/canonical.ts
+++ b/utils/services/canonical.ts
@@ -13,6 +13,7 @@
  */
 
 import { buildPrepBaseballUrl } from "~/utils/recruitingLinks";
+import { SPORT_POSITIONS } from "~/utils/positions/canonical";
 
 /**
  * How a service's public-profile link is derived from its stored value:
@@ -51,26 +52,10 @@ export interface ServiceUrlContext {
   name?: string | null;
 }
 
-/** All 17 sports (keys match `SPORT_POSITIONS`). */
-const ALL_SPORTS: readonly string[] = [
-  "Baseball",
-  "Softball",
-  "Basketball",
-  "Football",
-  "Soccer",
-  "Volleyball",
-  "Track & Field",
-  "Swimming",
-  "Cross Country",
-  "Tennis",
-  "Golf",
-  "Lacrosse",
-  "Field Hockey",
-  "Ice Hockey",
-  "Wrestling",
-  "Rowing",
-  "Water Polo",
-];
+/** Every sport, derived from the canonical position registry — the single source
+ *  of the sport vocabulary — so the "offered for all sports" set (NCSA) can never
+ *  drift from it. Guarded by tests/unit/utils/services/canonical.spec.ts. */
+const ALL_SPORTS: readonly string[] = Object.keys(SPORT_POSITIONS);
 
 const HUDL_SPORTS: readonly string[] = [
   "Football",


### PR DESCRIPTION
Two independent low-risk cleanups from the review backlog, batched.

## 1. Derive `ALL_SPORTS` (drift fix)

`utils/services/canonical.ts` hand-listed the 17 sports as `ALL_SPORTS` — a copy of the canonical vocabulary that could silently drift (a new sport added to positions but forgotten here would lose the all-sports NCSA service). Now derived: `ALL_SPORTS = Object.keys(SPORT_POSITIONS)`.

Verified the derived set is **identical in members and order** to the old hand-list before switching (17 sports, all offering NCSA). New `tests/unit/utils/services/canonical.spec.ts` guards it — every `SPORT_POSITIONS` sport must resolve NCSA, so the two registries can't drift.

## 2. Dedup coach interaction refresh

`pages/coaches/[id]/index.vue` — the school-wide `fetchInteractions` refresh (guarded by `school_id`, with a copy-pasted 2-line comment) appeared verbatim in `logSocialDm` and `handleCoachInteractionLogged`. Extracted `refreshSchoolInteractions()`.

## Testing

Both behavior-preserving. type-check + lint + audit clean; **7980 unit tests pass**; coach detail page spec 23/23.

## Not included

`registryCache` → Pinia was left out deliberately — it's a lateral architectural change, not a small cleanup, and would muddy this PR. Separate follow-up if wanted.

https://claude.ai/code/session_01FgqZNX32XLT6KDudKmsQ9L