### PR TITLE
feat(ui): animated completion check preserving native input

### DIFF
--- a/components/Dashboard/QuickTasksWidget.vue
+++ b/components/Dashboard/QuickTasksWidget.vue
@@ -98,13 +98,11 @@
             : 'border-slate-200 bg-white hover:border-blue-300',
         ]"
       >
-        <input
-          type="checkbox"
+        <DesignSystemFormAnimatedCheck
           :id="`task-${task.id}`"
-          :checked="task.completed"
-          @change="$emit('toggle-task', task.id)"
-          class="h-5 w-5 cursor-pointer rounded-md border-2 border-slate-300 checked:border-blue-500 checked:bg-blue-500 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          :model-value="task.completed"
           :aria-label="`${task.text}, toggle completion status`"
+          @update:model-value="$emit('toggle-task', task.id)"
         />
         <label
           :for="`task-${task.id}`"

--- a/components/DesignSystem/Form/AnimatedCheck.vue
+++ b/components/DesignSystem/Form/AnimatedCheck.vue
@@ -1,0 +1,91 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+export type AnimatedCheckSize = "sm" | "md";
+
+interface Props {
+  /** Two-way bound checked state. Undefined is treated as unchecked. */
+  modelValue?: boolean;
+  disabled?: boolean;
+  size?: AnimatedCheckSize;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: false,
+  disabled: false,
+  size: "md",
+});
+
+const emit = defineEmits<{
+  "update:modelValue": [value: boolean];
+}>();
+
+// Native input stays the source of truth: any @change / data-testid / aria-*
+// the caller passes is forwarded straight onto it.
+defineOptions({ inheritAttrs: false });
+
+const sizeClass = computed(() => (props.size === "sm" ? "h-5 w-5" : "h-6 w-6"));
+
+function onChange(event: Event) {
+  emit("update:modelValue", (event.target as HTMLInputElement).checked);
+}
+</script>
+
+<template>
+  <label
+    class="group relative inline-flex items-center gap-2"
+    :class="disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'"
+  >
+    <!-- Real checkbox: keyboard, focus, screen-reader announce, form semantics.
+         Visually hidden, drives the SVG below purely via CSS peer state. -->
+    <input
+      type="checkbox"
+      class="peer sr-only"
+      :checked="modelValue"
+      :disabled="disabled"
+      v-bind="$attrs"
+      @change="onChange"
+    />
+
+    <svg
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+      class="shrink-0 rounded motion-reduce:[&_*]:!transition-none peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-blue-600 [&_.box]:transition-[stroke] [&_.box]:duration-200 peer-checked:[&_.box]:stroke-emerald-600 [&_.fill]:origin-center [&_.fill]:scale-0 [&_.fill]:transition-transform [&_.fill]:duration-300 [&_.fill]:[transition-timing-function:cubic-bezier(.34,1.56,.64,1)] peer-checked:[&_.fill]:scale-100 [&_.tick]:[stroke-dasharray:22] [&_.tick]:[stroke-dashoffset:22] [&_.tick]:transition-[stroke-dashoffset] [&_.tick]:delay-100 [&_.tick]:duration-300 peer-checked:[&_.tick]:[stroke-dashoffset:0]"
+      :class="sizeClass"
+    >
+      <rect
+        class="box stroke-slate-300"
+        x="1.5"
+        y="1.5"
+        width="21"
+        height="21"
+        rx="6"
+        fill="none"
+        stroke-width="2"
+      />
+      <rect
+        class="fill fill-emerald-500"
+        x="1.5"
+        y="1.5"
+        width="21"
+        height="21"
+        rx="6"
+      />
+      <path
+        class="tick stroke-white"
+        d="M6.5 12.5 L10.5 16 L17.5 8"
+        fill="none"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+
+    <span
+      v-if="$slots.default"
+      class="text-sm font-medium text-slate-700 transition-colors group-hover:text-slate-900"
+    >
+      <slot />
+    </span>
+  </label>
+</template>

--- a/components/DesignSystem/index.ts
+++ b/components/DesignSystem/index.ts
@@ -16,6 +16,7 @@ export { default as DSFieldError } from "./FieldError.vue";
 export { default as DSCardSkeleton } from "./CardSkeleton.vue";
 export { default as DSChartSkeleton } from "./ChartSkeleton.vue";
 export { default as DSListSkeleton } from "./ListSkeleton.vue";
+export { default as DSAnimatedCheck } from "./Form/AnimatedCheck.vue";
 
 // Re-export types for external use
 export type { ButtonVariant, ButtonColor, ButtonSize } from "./Button.vue";
@@ -23,6 +24,7 @@ export type { CardPadding } from "./Card.vue";
 export type { GradientColor } from "./GradientCard.vue";
 export type { BadgeColor, BadgeVariant, BadgeSize } from "./Badge.vue";
 export type { InputSize } from "./Input.vue";
+export type { AnimatedCheckSize } from "./Form/AnimatedCheck.vue";
 export type { Toast, ToastType } from "~/types/toast";
 export type { LoadingStateVariant } from "./LoadingState.vue";
 export type {

--- a/components/Settings/PlayerDetailsBasicsTab.vue
+++ b/components/Settings/PlayerDetailsBasicsTab.vue
@@ -137,44 +137,24 @@
         </div>
 
         <div class="space-y-4 rounded-2xl bg-slate-50 p-4 md:col-span-2">
-          <label class="group flex cursor-pointer items-center gap-3">
-            <div class="relative flex items-center">
-              <input
-                v-model="form.allow_share_phone"
-                type="checkbox"
-                data-testid="share-phone"
-                @change="triggerSave"
-                class="peer h-6 w-6 cursor-pointer appearance-none rounded-lg border border-slate-300 bg-white shadow-sm transition-all checked:border-blue-600 checked:bg-blue-600"
-              />
-              <UIcon
-                name="i-heroicons-check"
-                class="pointer-events-none absolute top-1 left-1 h-4 w-4 stroke-[3] text-white opacity-0 peer-checked:opacity-100"
-              />
-            </div>
-            <span
-              class="text-sm font-bold text-slate-600 transition group-hover:text-slate-900"
+          <DesignSystemFormAnimatedCheck
+            v-model="form.allow_share_phone"
+            data-testid="share-phone"
+            @update:model-value="triggerSave"
+          >
+            <span class="text-sm font-bold text-slate-600"
               >Show phone number to verified coaches</span
             >
-          </label>
-          <label class="group flex cursor-pointer items-center gap-3">
-            <div class="relative flex items-center">
-              <input
-                v-model="form.allow_share_email"
-                type="checkbox"
-                data-testid="share-email"
-                @change="triggerSave"
-                class="peer h-6 w-6 cursor-pointer appearance-none rounded-lg border border-slate-300 bg-white shadow-sm transition-all checked:border-blue-600 checked:bg-blue-600"
-              />
-              <UIcon
-                name="i-heroicons-check"
-                class="pointer-events-none absolute top-1 left-1 h-4 w-4 stroke-[3] text-white opacity-0 peer-checked:opacity-100"
-              />
-            </div>
-            <span
-              class="text-sm font-bold text-slate-600 transition group-hover:text-slate-900"
+          </DesignSystemFormAnimatedCheck>
+          <DesignSystemFormAnimatedCheck
+            v-model="form.allow_share_email"
+            data-testid="share-email"
+            @update:model-value="triggerSave"
+          >
+            <span class="text-sm font-bold text-slate-600"
               >Show email to verified coaches</span
             >
-          </label>
+          </DesignSystemFormAnimatedCheck>
         </div>
       </div>
 

--- a/components/Timeline/TaskItem.vue
+++ b/components/Timeline/TaskItem.vue
@@ -4,17 +4,8 @@
     class="flex items-start gap-3 rounded-xl border border-slate-200 bg-white p-3 transition hover:border-slate-300"
   >
     <!-- Checkbox -->
-    <input
-      type="checkbox"
-      :checked="isCompleted"
-      :disabled="isViewingAsParent || isLocked"
-      @change="$emit('toggle-complete', task.id)"
-      :class="[
-        'mt-1 h-4 w-4 shrink-0 rounded-sm border-slate-300 text-blue-600 transition',
-        isViewingAsParent || isLocked
-          ? 'cursor-not-allowed opacity-50'
-          : 'cursor-pointer',
-      ]"
+    <span
+      class="mt-0.5 shrink-0"
       :title="
         isViewingAsParent
           ? 'Parents can view tasks but cannot mark them complete'
@@ -22,7 +13,15 @@
             ? 'Complete prerequisites to unlock this task'
             : 'Mark task complete'
       "
-    />
+    >
+      <DesignSystemFormAnimatedCheck
+        size="sm"
+        :model-value="isCompleted"
+        :disabled="isViewingAsParent || isLocked"
+        aria-label="Mark task complete"
+        @update:model-value="$emit('toggle-complete', task.id)"
+      />
+    </span>
 
     <!-- Task content -->
     <div

--- a/pages/admin/signup.vue
+++ b/pages/admin/signup.vue
@@ -250,12 +250,11 @@
 
             <!-- Terms and Conditions -->
             <div class="rounded-lg border border-slate-200 bg-slate-50 p-4">
-              <label class="flex cursor-pointer items-start gap-3">
-                <input
-                  v-model="agreeToTerms"
-                  type="checkbox"
-                  class="mt-1 rounded-sm border-slate-300 text-blue-600 focus:ring-blue-500"
-                />
+              <DesignSystemFormAnimatedCheck
+                v-model="agreeToTerms"
+                size="sm"
+                class="items-start"
+              >
                 <span class="text-sm text-slate-700">
                   I agree to the
                   <NuxtLink
@@ -270,7 +269,7 @@
                     >Privacy Policy</NuxtLink
                   >
                 </span>
-              </label>
+              </DesignSystemFormAnimatedCheck>
             </div>
 
             <!-- Submit -->

--- a/pages/tasks/index.vue
+++ b/pages/tasks/index.vue
@@ -163,13 +163,6 @@ const filteredTasks = computed(() => {
   });
 });
 
-const taskCheckboxClass = (taskId: string) => [
-  "mt-1 w-5 h-5 text-blue-600 rounded-sm shrink-0",
-  isViewingAsParent.value || isTaskLocked(taskId)
-    ? "opacity-50 cursor-not-allowed"
-    : "cursor-pointer",
-];
-
 const taskCheckboxTitle = (taskId: string): string => {
   if (isViewingAsParent.value)
     return "Parents can view tasks but cannot mark them complete";
@@ -502,22 +495,21 @@ const onUrgencyFilterChange = () => {
           <div class="p-4">
             <div class="flex items-start gap-4">
               <!-- Checkbox -->
-              <input
-                type="checkbox"
-                :data-testid="`task-checkbox-${task.id}`"
-                class="task-checkbox"
-                :checked="task.athlete_task?.status === 'completed'"
-                :disabled="isViewingAsParent || isTaskLocked(task.id)"
-                @change="
-                  handleToggleTask(
-                    task.id,
-                    task.athlete_task?.status || 'not_started',
-                  )
-                "
-                :class="taskCheckboxClass(task.id)"
-                :title="taskCheckboxTitle(task.id)"
-                :aria-label="taskCheckboxAriaLabel(task)"
-              />
+              <span class="shrink-0" :title="taskCheckboxTitle(task.id)">
+                <DesignSystemFormAnimatedCheck
+                  size="sm"
+                  :data-testid="`task-checkbox-${task.id}`"
+                  :model-value="task.athlete_task?.status === 'completed'"
+                  :disabled="isViewingAsParent || isTaskLocked(task.id)"
+                  :aria-label="taskCheckboxAriaLabel(task)"
+                  @update:model-value="
+                    handleToggleTask(
+                      task.id,
+                      task.athlete_task?.status || 'not_started',
+                    )
+                  "
+                />
+              </span>
 
               <!-- Task Info -->
               <div class="min-w-0 flex-1">

--- a/planning/iOS_SPEC_animated-completion-checkbox-2026-08-24.md
+++ b/planning/iOS_SPEC_animated-completion-checkbox-2026-08-24.md
@@ -1,0 +1,184 @@
+# iOS Spec — Animated Completion Checkbox
+
+> **Prepared:** 2026-08-24
+> **Web branch:** `fix/soak-nightly-failures`
+> **Purpose:** Bring the new web completion-feedback animation (`DesignSystemFormAnimatedCheck`) to iOS so task, terms, and consent commit moments get the same satisfying "spring + tick" confirmation, using native SF Symbol effects rather than a custom animation.
+
+---
+
+## Feature Overview
+
+When a user commits a meaningful boolean — completing a task, accepting Terms & Conditions, or toggling a coach-visibility consent — the checkbox now animates: an emerald rounded box springs in (scale + bouncy overshoot) and a white checkmark strokes on a beat later. It is purely presentational confirmation; the underlying checkbox/switch remains the source of truth for state, accessibility, and form semantics. Motion is fully suppressed under Reduce Motion (the state simply snaps).
+
+This is a **UI-polish / animation** feature. There is **no API, no data model, and no persistence change** — every rollout site already has working toggle logic on both platforms. The only thing being ported is the *completion animation and its accessibility/Reduce-Motion behavior*.
+
+---
+
+## Web Implementation Summary
+
+### Files Changed
+- `components/DesignSystem/Form/AnimatedCheck.vue` — **new** primitive. A real `<input type="checkbox" class="sr-only">` stays the source of truth (keyboard, focus, screen-reader announce, form semantics); a sibling `<svg>` renders the visual state purely via CSS `peer-checked:` selectors. `v-bind="$attrs"` forwards `@change` / `data-testid` / `aria-*` straight onto the native input. Props: `modelValue?: boolean`, `disabled?: boolean`, `size?: "sm" | "md"`. Emits `update:modelValue`.
+- `components/DesignSystem/index.ts` — registers/exports the new component (`DesignSystemFormAnimatedCheck`).
+- `components/Timeline/TaskItem.vue` — task complete toggle now uses AnimatedCheck.
+- `components/Dashboard/QuickTasksWidget.vue` — quick-task complete toggle.
+- `pages/tasks/index.vue` — task-list status toggle.
+- `pages/admin/signup.vue` — accept Terms & Conditions checkbox.
+- `components/Settings/PlayerDetailsBasicsTab.vue` — "Show phone to verified coaches" **and** "Show email to verified coaches" consent toggles.
+
+### DB/Migration Changes
+None. This is presentational only.
+
+### Web Animation Spec (source of truth)
+Extracted from `AnimatedCheck.vue`. iOS should reproduce the *feel*, not the literal CSS.
+
+| Element | Property animated | Timing | Easing |
+|---|---|---|---|
+| Emerald fill box (`.fill`) | `transform: scale(0 → 1)`, `transform-origin: center` | ~300 ms | `cubic-bezier(.34, 1.56, .64, 1)` (bouncy overshoot / spring) |
+| White tick (`.tick`) | `stroke-dashoffset: 22 → 0` (strokes on) | ~300 ms, **~100 ms delay** after box starts | ease (default) |
+| Box outline (`.box`) | `stroke` color slate-300 → emerald-600 | ~200 ms | linear |
+| Reduce Motion | `motion-reduce:[&_*]:!transition-none` — **all transitions disabled**, state snaps instantly | 0 ms | none |
+
+- **Unchecked** state: slate-300 rounded-square outline, no fill, no tick.
+- **Checked** state: emerald-500 filled rounded box, emerald-600 outline, white tick.
+- **Focus:** `peer-focus-visible` draws a 2px blue-600 focus ring on the SVG (driven by the hidden native input's focus).
+- **Colors:** emerald-500 fill / emerald-600 stroke. iOS twin: `Color.successGreen` (already defined as `Brand.emerald600` in `Core/Theme/AppColors.swift`).
+
+---
+
+## Existing iOS Files (parity-check results)
+
+No `AnimatedCheck` component and **no `symbolEffect` usage anywhere** in the iOS repo — the bounce is net-new. Each web rollout site already has a working iOS counterpart; the work is adding the completion animation + Reduce-Motion gating to them (and reconciling the deltas below).
+
+| # | Web site | iOS file | Current iOS rendering | Parity status |
+|---|---|---|---|---|
+| 1 | `Timeline/TaskItem.vue` (task complete) | `Features/Timeline/Components/PhaseCardTaskRow.swift` | `Button` → `Image(systemName: task.statusIconName)` w/ `task.statusColor` | **MATCH** — SF Symbol already; add bounce |
+| 2 | `Dashboard/QuickTasksWidget.vue` | `Features/Dashboard/Components/QuickTaskRow.swift` | `Button(action: onToggle)` → `Image(systemName: task.isCompleted ? "checkmark.circle.fill" : "circle")` w/ `Color.successGreen` | **MATCH** — exact twin; add bounce |
+| 3 | `pages/tasks/index.vue` (task list) | `Features/Tasks/Components/TaskCard.swift` (inside `Features/Tasks/Views/TasksListView.swift`) | `Button` → `Image(systemName: task.effectiveStatus == .completed ? "checkmark.circle.fill" : "circle")` w/ `Color.successGreen` | **MATCH** — exact twin; add bounce |
+| 4 | `pages/admin/signup.vue` (accept Terms) | `Features/Auth/Components/TermsCheckbox.swift` (used by `Features/Auth/Views/SignupView.swift`) | `Button` → `Image(systemName: isChecked ? "checkmark.square.fill" : "square")` w/ **`Color.accentBlue`** (blue, **square**) | **GAP** — see Delta A |
+| 5 | `PlayerDetailsBasicsTab.vue` — show phone to coaches | `Features/Preferences/Views/Tabs/BasicsTab.swift` → `toggleRow(...)` `keyPath: \.allowSharePhone` | native `Toggle` (**switch**), label "Share phone with coaches" | **GAP** — see Delta B |
+| 6 | `PlayerDetailsBasicsTab.vue` — show email to coaches | `Features/Preferences/Views/Tabs/BasicsTab.swift` → `toggleRow(...)` `keyPath: \.allowShareEmail` | native `Toggle` (**switch**), label "Share email with coaches" | **GAP** — see Delta B |
+
+---
+
+## Parity Deltas (web is source of truth — resolve explicitly)
+
+> **✅ RESOLVED by Chris 2026-08-24 — build to these, deltas below are background:**
+> - **Delta A → Retint to emerald + bounce.** Keep the `checkmark.square.fill` square glyph on Terms, recolor checked tint to `Color.successGreen`, add gated `.symbolEffect(.bounce)`. Do NOT switch to the circle glyph.
+> - **Delta B → Keep native `Toggle` switches** for the two consent controls (intentional platform divergence — no bounce). Still update the labels to match web copy exactly (see below).
+> - **Exact web consent labels (verified against web source):** `"Show phone number to verified coaches"` and `"Show email to verified coaches"`. Update iOS labels to these strings verbatim; keep keys `allowSharePhone` / `allowShareEmail`.
+
+### Delta A — Terms checkbox is a **blue square**, web is an **emerald box**
+`TermsCheckbox.swift` renders `checkmark.square.fill` / `square` tinted `Color.accentBlue`. The web AnimatedCheck springs an **emerald** rounded box + white tick.
+
+- **Recommended:** keep the **square** SF Symbol (`checkmark.square.fill`) for Terms since it reads as a "form checkbox" not a "task done" circle, but switch the checked tint to `Color.successGreen` to match web's emerald and add `.symbolEffect(.bounce)` on check. This gives visual parity (emerald + bounce) while staying idiomatic.
+- **Alternative (stricter literal parity):** switch to `checkmark.circle.fill` to match the exact glyph the task sites use. Decide with Chris — the web uses one shared component everywhere, so the *most faithful* port is one emerald bouncing check glyph at all six sites.
+- **Do not** silently leave it blue — that is the parity gap this spec exists to surface.
+
+### Delta B — Consent controls are native **switches** on iOS, **checkboxes** on web
+`BasicsTab.swift` uses `Toggle` (iOS switch) for the two coach-visibility consents. Web uses the AnimatedCheck checkbox. A `Toggle` has no checkmark glyph to bounce.
+
+- **Recommended:** keep the native `Toggle` **switch** on iOS. A switch is the platform-idiomatic control for a settings-style boolean, its animation is already native, and forcing a custom checkbox here would fight iOS conventions. The bounce animation is a checkmark affordance and does not apply to a switch. Treat this as **intentional platform divergence** and document it, rather than replacing the switch.
+- **If Chris wants literal parity:** replace the two `toggleRow` switches with a checkbox-style control (`checkmark.circle.fill` + `.symbolEffect(.bounce)`, emerald) matching the task sites. This is a UX change to the Basics tab, not just an animation add — call it out before building.
+- **Label delta (independent of control choice):** web labels are "Show phone to verified coaches" / "Show email to verified coaches"; iOS labels are "Share phone with coaches" / "Share email with coaches". Web is source of truth → update iOS labels to "Show phone to verified coaches" / "Show email to verified coaches" (verify the "verified" qualifier matches the actual web copy before changing). Underlying keys `allowSharePhone` / `allowShareEmail` are fine to keep.
+
+---
+
+## What iOS Needs to Build
+
+No new screens. This is an **animation + Reduce-Motion pass** over existing completion controls, plus the two delta reconciliations above.
+
+### Suggested shared helper
+
+Add a small reusable modifier / view so all six (or four, if consents stay switches) sites animate identically and handle Reduce Motion in one place. Sketch:
+
+```swift
+import SwiftUI
+
+/// Native twin of web `DesignSystemFormAnimatedCheck`.
+/// A checkmark glyph that bounces in on completion, respecting Reduce Motion.
+struct AnimatedCheckIcon: View {
+    let isOn: Bool
+    /// "checkmark.circle.fill"/"circle" for tasks; "checkmark.square.fill"/"square" for terms.
+    var filledSymbol: String = "checkmark.circle.fill"
+    var emptySymbol: String = "circle"
+    var onColor: Color = .successGreen
+    var offColor: Color = .secondary
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        Image(systemName: isOn ? filledSymbol : emptySymbol)
+            .foregroundStyle(isOn ? onColor : offColor)
+            // Bounce only on genuine completion, and only when motion is allowed.
+            .symbolEffect(.bounce, value: reduceMotion ? false : isOn)
+    }
+}
+```
+
+- `.symbolEffect(.bounce, value:)` fires the bounce whenever `value` changes to a new truthy transition. Gating `value` on `reduceMotion` means that under Reduce Motion the symbol simply swaps with no bounce.
+- Keep the existing `Button` / `Toggle` wrappers, accessibility labels, hints, and `@ScaledMetric` sizing at each call site — only the inner `Image` swaps to `AnimatedCheckIcon` (or gains the `.symbolEffect`).
+- **Only animate genuine commit moments** (task complete, terms accept, consent grant). Do **not** attach the bounce to rapid/bulk interactions (filter chips, multi-select, bulk status changes) — matches the web guidance.
+
+### Reduce-Motion handling (required)
+- Read `@Environment(\.accessibilityReduceMotion)` in each animating view (or the shared helper). When true, skip the bounce and snap to the new state. Equivalent to the web's `motion-reduce:` transition suppression.
+- (Optional, belt-and-suspenders) `UIAccessibility.isReduceMotionEnabled` is the UIKit equivalent if any call site is not a SwiftUI `View`; prefer the environment value in SwiftUI.
+
+---
+
+## API Endpoints to Call
+
+**None.** No network work in this feature. Existing toggle handlers (`onToggle`, `isChecked.toggle()`, `Toggle` bindings, task status services) are unchanged.
+
+---
+
+## Data Models (Swift)
+
+**None new.** Reuses existing `TaskWithStatus` / `AthleteTaskStatus` / `QuickTask` / `PlayerDetails.allowSharePhone` / `allowShareEmail`. No `Codable` changes.
+
+---
+
+## Business Rules to Enforce Client-Side
+
+- The animation is **presentational only** — it must never gate, delay, or block the state write. State updates immediately; the bounce plays over the already-committed state (same as web, where the native input is the source of truth).
+- Bounce fires **only on the false→true (completion) transition** of a genuine commit control, and only when Reduce Motion is off.
+- Disabled/locked controls (e.g. locked tasks) must not bounce and must retain their existing disabled affordance.
+- Accessibility parity: the native control keeps its `accessibilityLabel` / `accessibilityValue` ("Completed"/"Not completed", "Checked"/"Unchecked") / `accessibilityHint`. The animated glyph stays `accessibilityHidden(true)` (it already is in `TermsCheckbox`).
+
+---
+
+## Excluded Items (No iOS Work Needed)
+
+- **DB migrations / RLS** — none; presentational feature.
+- **API routes** — none; no `$fetch` involved on web either.
+- **Animation library** — web uses none (pure CSS); iOS uses native `.symbolEffect`, no third-party dependency.
+- **Email / CSRF / auth flows** — untouched.
+
+---
+
+## Dependencies
+
+- iOS 17+ for `.symbolEffect(.bounce, value:)` (symbol effects are iOS 17 API). Confirm the deployment target supports it; if the app still targets iOS 16, gate the effect with `if #available(iOS 17, *)` and fall back to a plain glyph swap (or a small `withAnimation(.spring)` scale on the icon).
+- Existing controls at all six sites (already present) — this is an enhancement, not a new screen.
+
+---
+
+## Notes for iOS Claude
+
+- The web component's whole design intent is **"native checkbox stays the source of truth, visual layer is decoration."** iOS already honors this everywhere (Button/Toggle drive state, Image is `accessibilityHidden`). Preserve that — do not move state into the animation.
+- Tasks sites are a near-zero-risk change: they *already* render `checkmark.circle.fill` + `Color.successGreen`. Literally just add the gated `.symbolEffect(.bounce)`.
+- Resolve **Delta A** (terms blue-square vs emerald) and **Delta B** (consent switch vs checkbox + label copy) with Chris before building — these are UX decisions, not mechanical ports. Recommendations are in the Deltas section; the strictest-parity path is one emerald bouncing `checkmark.circle.fill` at all six sites.
+- `Color.successGreen` already equals `Brand.emerald600` — reuse it; do not introduce a new green.
+- Match the web's ~300 ms spring feel: `.bounce` is a good default. If you hand-roll (iOS 16 fallback), `.spring(response: 0.3, dampingFraction: 0.6)` approximates `cubic-bezier(.34,1.56,.64,1)`.
+
+---
+
+## Test Checklist
+
+1. **Task complete (all 3 task sites):** tap an incomplete task → glyph fills emerald and bounces once; state persists; tapping again un-completes with no bounce (no false→true transition).
+2. **Reduce Motion ON** (Settings → Accessibility → Motion → Reduce Motion): complete a task → glyph swaps to filled emerald instantly, **no bounce**. Verify at every animating site.
+3. **Terms acceptance (signup):** tap the Terms checkbox → checkmark appears with the agreed animation/color per the Delta A decision; the "I agree" state gates signup exactly as before.
+4. **Consent toggles (Basics tab):** toggle "Show phone to verified coaches" / "Show email to verified coaches" → state saves as before; behavior matches the Delta B decision (switch retained, or checkbox with bounce). Confirm labels read "Show … to verified coaches".
+5. **VoiceOver:** each control announces its label + value ("Completed"/"Not completed", "Checked"/"Unchecked") + hint; the decorative glyph is not separately announced.
+6. **Dynamic Type (XXL):** glyphs scale with `@ScaledMetric` sizing; layout does not clip; bounce still reads.
+7. **Disabled/locked task:** no bounce, no state change, disabled affordance intact.
+8. **iOS 16 fallback (if applicable):** on a device below the symbol-effects minimum, completion still swaps state and color with a graceful (or absent) animation — no crash, no missing glyph.

--- a/tests/unit/components/Dashboard/QuickTasksWidget.spec.ts
+++ b/tests/unit/components/Dashboard/QuickTasksWidget.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { mount } from "@vue/test-utils";
 import QuickTasksWidget from "~/components/Dashboard/QuickTasksWidget.vue";
+import DesignSystemFormAnimatedCheck from "~/components/DesignSystem/Form/AnimatedCheck.vue";
 
 type Task = {
   id: string;
@@ -20,6 +21,9 @@ const mountWidget = (props: { tasks?: Task[]; showTasks?: boolean } = {}) =>
     props: {
       tasks: props.tasks ?? [],
       showTasks: props.showTasks ?? true,
+    },
+    global: {
+      components: { DesignSystemFormAnimatedCheck },
     },
   });
 

--- a/tests/unit/components/DesignSystem/Form/AnimatedCheck.spec.ts
+++ b/tests/unit/components/DesignSystem/Form/AnimatedCheck.spec.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import AnimatedCheck from "~/components/DesignSystem/Form/AnimatedCheck.vue";
+
+describe("AnimatedCheck", () => {
+  it("renders a real native checkbox (a11y/form semantics preserved)", () => {
+    const wrapper = mount(AnimatedCheck, { props: { modelValue: false } });
+    const input = wrapper.find('input[type="checkbox"]');
+    expect(input.exists()).toBe(true);
+  });
+
+  it("keeps the native input in the DOM but visually hidden (sr-only + peer)", () => {
+    const wrapper = mount(AnimatedCheck, { props: { modelValue: false } });
+    const input = wrapper.find('input[type="checkbox"]');
+    expect(input.classes()).toContain("sr-only");
+    expect(input.classes()).toContain("peer");
+  });
+
+  it("renders the animated SVG tick", () => {
+    const wrapper = mount(AnimatedCheck, { props: { modelValue: false } });
+    expect(wrapper.find("svg .tick").exists()).toBe(true);
+  });
+
+  it("is checked when modelValue is true", () => {
+    const wrapper = mount(AnimatedCheck, { props: { modelValue: true } });
+    expect(
+      (wrapper.find('input[type="checkbox"]').element as HTMLInputElement)
+        .checked,
+    ).toBe(true);
+  });
+
+  it("is unchecked when modelValue is false", () => {
+    const wrapper = mount(AnimatedCheck, { props: { modelValue: false } });
+    expect(
+      (wrapper.find('input[type="checkbox"]').element as HTMLInputElement)
+        .checked,
+    ).toBe(false);
+  });
+
+  it("emits update:modelValue with true when checked", async () => {
+    const wrapper = mount(AnimatedCheck, { props: { modelValue: false } });
+    await wrapper.find('input[type="checkbox"]').setValue(true);
+    expect(wrapper.emitted("update:modelValue")).toEqual([[true]]);
+  });
+
+  it("emits update:modelValue with false when unchecked", async () => {
+    const wrapper = mount(AnimatedCheck, { props: { modelValue: true } });
+    await wrapper.find('input[type="checkbox"]').setValue(false);
+    expect(wrapper.emitted("update:modelValue")).toEqual([[false]]);
+  });
+
+  it("disables the native input when disabled", () => {
+    const wrapper = mount(AnimatedCheck, {
+      props: { modelValue: false, disabled: true },
+    });
+    expect(
+      (wrapper.find('input[type="checkbox"]').element as HTMLInputElement)
+        .disabled,
+    ).toBe(true);
+    expect(wrapper.find("label").classes()).toContain("cursor-not-allowed");
+  });
+
+  it("renders slot content as the label", () => {
+    const wrapper = mount(AnimatedCheck, {
+      props: { modelValue: false },
+      slots: { default: "Accept terms" },
+    });
+    expect(wrapper.text()).toContain("Accept terms");
+  });
+
+  it("forwards attrs (data-testid, aria-label) onto the native input", () => {
+    const wrapper = mount(AnimatedCheck, {
+      props: { modelValue: false },
+      attrs: { "data-testid": "share-phone", "aria-label": "Share phone" },
+    });
+    const input = wrapper.find('input[type="checkbox"]');
+    expect(input.attributes("data-testid")).toBe("share-phone");
+    expect(input.attributes("aria-label")).toBe("Share phone");
+  });
+
+  it("still fires a caller-supplied @change handler (native event pass-through)", async () => {
+    let fired = 0;
+    const wrapper = mount(AnimatedCheck, {
+      props: { modelValue: false },
+      attrs: { onChange: () => (fired += 1) },
+    });
+    await wrapper.find('input[type="checkbox"]').setValue(true);
+    expect(fired).toBe(1);
+  });
+
+  it("respects reduced-motion (no forced animation)", () => {
+    const wrapper = mount(AnimatedCheck, { props: { modelValue: false } });
+    expect(wrapper.find("svg").classes().join(" ")).toContain("motion-reduce");
+  });
+});

--- a/tests/unit/components/Timeline/TaskItem.spec.ts
+++ b/tests/unit/components/Timeline/TaskItem.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { mount } from "@vue/test-utils";
 import TaskItem from "~/components/Timeline/TaskItem.vue";
+import DesignSystemFormAnimatedCheck from "~/components/DesignSystem/Form/AnimatedCheck.vue";
 import type { TaskWithStatus } from "~/types/timeline";
 
 /**
@@ -41,6 +42,7 @@ function mountTaskItem(isViewingAsParent: boolean) {
   return mount(TaskItem, {
     props: { task: baseTask },
     global: {
+      components: { DesignSystemFormAnimatedCheck },
       provide: {
         activeFamily: {
           isViewingAsParent: { value: isViewingAsParent },


### PR DESCRIPTION
## What

New `DesignSystemFormAnimatedCheck` — an animated completion checkbox that **keeps the real native `<input type=checkbox>` as the source of truth** (keyboard, focus, screen-reader announce, form semantics). An SVG check renders on top, driven purely by CSS `:checked`: an emerald rounded box springs in (scale + bouncy easing) and a white tick strokes on. Honors `prefers-reduced-motion` (instant, no motion). No animation library — CSP-safe, self-contained, passes `audit:tokens`.

Attrs (`data-testid` / `aria-label` / `@change`) forward to the input; focus ring forwarded via `peer-focus-visible`.

## Where (completion/commit moments only)

- **Task completion:** `TaskItem`, `QuickTasksWidget`, `pages/tasks/index`
- **Accept Terms:** `admin/signup`
- **Coach-visibility consent:** `PlayerDetailsBasicsTab` (phone + email)

Filters, bulk-select, and rapid metric toggles were **deliberately left** as plain checkboxes — animation there is noise + perf cost in loops.

## iOS parity

Handoff spec included: `planning/iOS_SPEC_animated-completion-checkbox-2026-08-24.md`. Decisions locked (Chris): Terms → retint emerald + bounce (keep square glyph); consent → keep native switches, update labels to web copy; 3 task rows already emerald+circle → add gated `.symbolEffect(.bounce)`.

## Test plan

- [x] New component unit test — 12/12 (native input preserved, attrs forward, reduced-motion, emits)
- [x] Full unit suite — **8033 pass** / 0 fail / 63 skip
- [x] `type-check` 0 errors, `eslint .` 0 errors, `audit:tokens` 0 errors
- [ ] E2E watch: `parent-tasks.spec.ts:203` asserts task checkbox `toBeVisible()` — now `sr-only` (1px box, no `visibility:hidden`), should still count visible + reads `toBeDisabled()` off forwarded attr

https://claude.ai/code/session_01MHgpJRwbbAXSsFXCywot8B