### PR TITLE
fix(comms): resolve hometown city/state from Settings home location

### DIFF
--- a/composables/useTemplateResolver.ts
+++ b/composables/useTemplateResolver.ts
@@ -252,6 +252,7 @@ export const useTemplateResolver = () => {
         events: entities.event,
       },
       prefs: athleteCtx.prefs,
+      locationPrefs: athleteCtx.locationPrefs,
       metrics: athleteCtx.metrics,
       derived: athleteCtx.derived,
       authored,

--- a/tests/unit/composables/useTemplateResolver.spec.ts
+++ b/tests/unit/composables/useTemplateResolver.spec.ts
@@ -17,6 +17,16 @@ const h = vi.hoisted(() => {
     },
     { key: "coachSalutation", source_type: "computed", source_path: null },
     { key: "daysSinceContact", source_type: "computed", source_path: null },
+    {
+      key: "hometownCity",
+      source_type: "column",
+      source_path: "pref:location.city",
+    },
+    {
+      key: "hometownState",
+      source_type: "column",
+      source_path: "pref:location.state",
+    },
   ];
   const RESULTS: Record<string, { data: unknown; error: unknown }> = {
     template_variables: { data: registryRows, error: null },
@@ -169,6 +179,27 @@ describe("useTemplateResolver", () => {
       // values map drives the variables panel
       expect(result.values.playerName).toBe("Jordan Ellis");
       expect(result.values.daysSinceContact).toBeUndefined();
+    });
+
+    it("carries locationPrefs so hometown city/state resolve from Settings home location", async () => {
+      const resolver = useTemplateResolver();
+      const athleteCtx = {
+        tables: { users: { id: "athlete1" } },
+        locationPrefs: { city: "Dublin", state: "OH" },
+        derived: {},
+      } as unknown as Awaited<
+        ReturnType<typeof resolver.buildAthleteContext>
+      >;
+
+      const result = await resolver.resolveTemplate(
+        { subject: "", body: "{{hometownCity}}, {{hometownState}}" },
+        {},
+        athleteCtx,
+      );
+
+      expect(result.values.hometownCity).toBe("Dublin");
+      expect(result.values.hometownState).toBe("OH");
+      expect(result.body).toBe("Dublin, OH");
     });
 
     it("resolves [[gate|text]] optional spans — no bracket leak into fields", async () => {


### PR DESCRIPTION
## Bug

The composer's **Complete your info** step flagged **Hometown city** / **Hometown state** as missing ("Add this in your profile") even when the user had already set their home location in Settings.

## Root cause

No string mismatch — the paths already line up:

- Registry (`template_variables`, live DB): `pref:location.city` / `pref:location.state`
- Settings writes: `user_preferences` category `location`, jsonb keys `city` / `state`
- `buildAthleteContext` correctly loads that into `athleteCtx.locationPrefs`

But `resolveTemplate` (`composables/useTemplateResolver.ts`) rebuilt a fresh `ResolverContext` from `athleteCtx` and **omitted `locationPrefs`**. So `resolveSourcePath("pref:location.*")` read `ctx.locationPrefs?.[key]` → `undefined` → var dropped. The missing-info step derives from these resolved `values`, so the fields showed as missing.

## Fix

Carry `locationPrefs` into the rebuilt context (one line). RED→GREEN unit test added asserting hometown city/state resolve from `locationPrefs`.

## Test plan

- [x] New test RED before fix (undefined), GREEN after
- [x] resolver + missing-info specs: 57 pass
- [x] `type-check` clean, `eslint .` clean
- [ ] manual QA: set home location in Settings → composer no longer prompts for hometown

## Parity

Web fix. iOS uses the same shared DB registry (`pref:location.*`); its Swift resolver may or may not have the same context-rebuild drop — **iOS check still pending** (flagged, not verified this session).

https://claude.ai/code/session_01MHgpJRwbbAXSsFXCywot8B