### PR TITLE
feat(templates): share communication templates across the family unit

### DIFF
--- a/composables/useCommunicationTemplates.ts
+++ b/composables/useCommunicationTemplates.ts
@@ -1,6 +1,8 @@
-import { ref, computed, type ComputedRef, type Ref } from "vue";
+import { ref, computed, inject, type ComputedRef, type Ref } from "vue";
 import { useSupabase } from "./useSupabase";
 import { useUserStore } from "~/stores/user";
+import { useActiveFamily } from "./useActiveFamily";
+import { useFamilyContext } from "./useFamilyContext";
 import { createClientLogger } from "~/utils/logger";
 import { renderTemplate as renderText } from "~/utils/templateResolver";
 import type { CommunicationTemplate } from "~/types/models";
@@ -102,6 +104,19 @@ export const useCommunicationTemplates = (): {
   const supabase = useSupabase();
   const userStore = useUserStore();
 
+  // Family scope: templates are shared across the whole family unit (a parent can
+  // proofread/tweak a template the player sends). Prefer the injected context so
+  // a parent switching athletes re-scopes correctly; fall back to the singleton.
+  const injectedFamily =
+    inject<ReturnType<typeof useActiveFamily>>("activeFamily");
+  if (!injectedFamily) {
+    logger.warn(
+      "[useCommunicationTemplates] activeFamily injection failed, using " +
+        "singleton fallback. May cause sync issues when parent switches athletes.",
+    );
+  }
+  const activeFamily = injectedFamily ?? useFamilyContext();
+
   // State
   const templates = ref<CommunicationTemplate[]>([]);
   const isLoading = ref(false);
@@ -134,11 +149,17 @@ export const useCommunicationTemplates = (): {
     error.value = null;
 
     try {
-      // Fetch user templates AND predefined templates
+      // Fetch this family's templates AND predefined/global templates. RLS
+      // enforces the same scope; the explicit filter keeps the payload tight and
+      // still returns predefined rows (family_unit_id NULL) via the OR.
+      const familyId = activeFamily.activeFamilyId?.value;
+      const scopeFilter = familyId
+        ? `family_unit_id.eq.${familyId},is_predefined.eq.true`
+        : `is_predefined.eq.true`;
       const response = await supabase
         .from("communication_templates")
         .select("*")
-        .or(`user_id.eq.${userStore.user.id},is_predefined.eq.true`)
+        .or(scopeFilter)
         .order("updated_at", { ascending: false });
       const { data, error: err } = response as {
         data: CommunicationTemplate[] | null;
@@ -188,6 +209,7 @@ export const useCommunicationTemplates = (): {
 
       const newTemplate: CommunicationTemplateInsert = {
         user_id: userStore.user.id,
+        family_unit_id: activeFamily.activeFamilyId?.value ?? undefined,
         name,
         type,
         subject: type === "email" ? subject : undefined,
@@ -233,14 +255,14 @@ export const useCommunicationTemplates = (): {
 
     try {
       // .select() lets us confirm a row was actually updated. A 0-row update
-      // (e.g. editing a non-owned predefined/global row) returns NO Supabase
-      // error, so without this it would silently report false success.
+      // (e.g. editing a predefined/global row, or one outside this family) returns
+      // NO Supabase error, so without this it would silently report false success.
+      // RLS scopes writes to the family; no explicit user_id filter needed.
       const updateResponse =
         (await // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (supabase.from("communication_templates") as any)
           .update(updates)
           .eq("id", id)
-          .eq("user_id", userStore.user.id)
           .select()) as {
           data: CommunicationTemplate[] | null;
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -253,7 +275,7 @@ export const useCommunicationTemplates = (): {
       if (!data || data.length === 0) {
         throw new Error(
           "No template was updated — it may be a read-only built-in " +
-            "template or not owned by you.",
+            "template or belong to another family.",
         );
       }
 
@@ -278,11 +300,11 @@ export const useCommunicationTemplates = (): {
     error.value = null;
 
     try {
+      // RLS scopes deletes to the family; predefined built-ins are blocked by policy.
       const { error: err } = await supabase
         .from("communication_templates")
         .delete()
-        .eq("id", id)
-        .eq("user_id", userStore.user.id);
+        .eq("id", id);
 
       if (err) throw err;
 

--- a/planning/iOS_SPEC_family-shared-templates-2026-08-24.md
+++ b/planning/iOS_SPEC_family-shared-templates-2026-08-24.md
@@ -1,0 +1,88 @@
+# iOS Handoff — Family-Shared Communication Templates
+
+**Source of truth:** web `feat/family-shared-templates`. Parity task.
+**Date:** 2026-08-24
+**DB:** migration already APPLIED LIVE to `xpxzhqghxecsjhvklsqg` (serves prod+QA). iOS
+needs no schema work — only client query/scoping changes.
+
+## What changed & why
+
+`communication_templates` was user-scoped (`user_id` owner only) — a template a
+user created was private to that account, invisible even to linked family
+members. Product decision: templates belong to the **whole family** so a parent
+can proofread/tweak a template the player then sends. This matches every other
+domain table (schools, coaches, documents, interactions, athlete_messages) which
+are family-symmetric.
+
+## DB shape now (live)
+
+- New column `communication_templates.family_unit_id uuid` → FK `family_units(id)`
+  `ON DELETE CASCADE`, indexed.
+- `BEFORE INSERT OR UPDATE` trigger `derive_family_unit_id()` stamps it from the
+  writer's `user_id` when unambiguous (never raises).
+- RLS replaced: **one permissive policy per verb**, all keyed on
+  `family_unit_id IN (SELECT family_unit_id FROM family_members WHERE user_id = auth.uid())`.
+  - SELECT also OR's `is_predefined = true` (global built-ins stay visible to all).
+  - INSERT/UPDATE/DELETE additionally require `is_predefined IS NOT TRUE`
+    (users can't create/modify/delete built-ins).
+- Predefined rows: `is_predefined = true`, `user_id` NULL, `family_unit_id` NULL.
+
+## iOS changes required
+
+File: `Features/CommunicationTemplates/Services/CommunicationTemplatesService.swift`
+(all template Supabase access lives here — confirmed).
+
+### 1. Model — add family_unit_id
+`Models/CommunicationTemplate.swift`: add `familyUnitId: UUID?`
+(CodingKey `family_unit_id`). Optional/nullable (predefined rows have NULL).
+
+### 2. fetchTemplates() — scope by family, not user
+Current `or` filter (lines ~55–57):
+```
+user_id.eq.<userId>,is_predefined.eq.true
+```
+Change to family scope. Resolve the **active family unit id** the same way iOS
+already does for schools/coaches (the app has an active-family concept for the
+parent athlete-switcher — reuse it). Then:
+```
+family_unit_id.eq.<activeFamilyId>,is_predefined.eq.true
+```
+If no active family id is resolvable, fall back to `is_predefined.eq.true` only
+(don't send an empty/invalid filter). RLS enforces the same scope server-side, so
+this filter is for payload tightness + correct behavior, not security.
+
+### 3. create (TemplatePayload) — stamp family_unit_id
+Add `family_unit_id: <activeFamilyId>` to the insert payload alongside `user_id`.
+The DB trigger also derives it, but stamp explicitly for the parent-writing case
+(a parent's `user_id` must resolve to the athlete's family — explicit stamp is
+unambiguous). Keep `user_id` = current session user (authorship/audit).
+
+### 4. update / delete — drop any user_id filter
+If iOS filters update/delete by `user_id`, remove it — RLS now scopes to the
+family. Filter by `id` only (matches web). A 0-row update/delete now means
+"built-in or another family," not "not yours."
+
+## Behavior after change (both platforms)
+
+- Any family member (parent or player) sees, edits, deletes any family template.
+- Built-in/predefined templates: visible to all, editable by none (customizing
+  one creates an owned family copy — web does this in TemplateEditor; verify iOS
+  parity if it offers "customize built-in").
+- Author (`user_id`) is retained for provenance but no longer gates access.
+
+## Web reference (for exact parity)
+
+- Composable: `composables/useCommunicationTemplates.ts`
+  - `loadTemplates` — family-or-predefined `.or()` filter
+  - `createTemplate` — stamps `family_unit_id: activeFamily.activeFamilyId`
+  - `updateTemplate` / `deleteTemplate` — `id`-only filter, RLS-scoped
+- Migration: `supabase/migrations/20260906000000_family_shared_communication_templates.sql`
+- Tests: `tests/unit/composables/useCommunicationTemplates.familyScope.spec.ts`
+
+## Verify (iOS)
+
+1. Parent account, switch to athlete → create a template → sign in as that player
+   → template appears, is editable.
+2. Player creates a template → parent (viewing that athlete) sees + edits it.
+3. Two different families do NOT see each other's templates.
+4. Predefined built-ins still list for everyone; edit/delete blocked.

--- a/supabase/migrations/20260906000000_family_shared_communication_templates.sql
+++ b/supabase/migrations/20260906000000_family_shared_communication_templates.sql
@@ -1,0 +1,102 @@
+-- Family-share communication templates.
+--
+-- communication_templates predates the family model and shipped user-scoped
+-- (user_id owner only). Every other domain table (schools, interactions,
+-- documents, coaches, performance, athlete_messages) carries family_unit_id and
+-- a single permissive family policy per verb. This brings templates to the same
+-- shape so a parent can proofread/tweak a template the player then sends.
+--
+-- Predefined/global templates (is_predefined = true, user_id NULL,
+-- family_unit_id NULL) remain readable by everyone and unmodifiable by users.
+--
+-- Reuses the generic BEFORE INSERT OR UPDATE derive_family_unit_id() trigger
+-- (Phase-1, 20260805000000) — it resolves family_unit_id from the row's user_id
+-- when the owner belongs to exactly one family unit, and never raises.
+
+-- 1. Column + index (matches athlete_messages: FK to family_units, cascade).
+ALTER TABLE public.communication_templates
+  ADD COLUMN IF NOT EXISTS family_unit_id uuid
+  REFERENCES public.family_units(id) ON DELETE CASCADE;
+
+CREATE INDEX IF NOT EXISTS idx_communication_templates_family_unit_id
+  ON public.communication_templates (family_unit_id);
+
+-- 2. Derive family_unit_id on write (reuses the generic Phase-1 trigger; the app
+--    also stamps it explicitly on create). Predefined rows have NULL user_id, so
+--    the trigger leaves their family_unit_id NULL — intended (global scope).
+DROP TRIGGER IF EXISTS trg_communication_templates_derive_family_unit_id
+  ON public.communication_templates;
+CREATE TRIGGER trg_communication_templates_derive_family_unit_id
+  BEFORE INSERT OR UPDATE ON public.communication_templates
+  FOR EACH ROW EXECUTE FUNCTION public.derive_family_unit_id();
+
+-- 3. Backfill existing user-owned rows (unambiguous single-family owners only;
+--    predefined rows and any ambiguous/orphan owners stay NULL). Verified live
+--    2026-08-24: 2 user templates, 0 orphans, 0 ambiguous.
+UPDATE public.communication_templates t
+SET family_unit_id = fm.family_unit_id
+FROM (
+  -- HAVING guarantees a single distinct value; min(text)::uuid picks it
+  -- (uuid has no native max/min aggregate).
+  SELECT user_id, min(family_unit_id::text)::uuid AS family_unit_id
+  FROM public.family_members
+  GROUP BY user_id
+  HAVING count(DISTINCT family_unit_id) = 1
+) fm
+WHERE t.user_id = fm.user_id
+  AND t.family_unit_id IS NULL
+  AND (t.is_predefined IS NOT TRUE);
+
+-- 4. Cut RLS over to family scope (single permissive policy per verb).
+--    Drop the legacy owner-only manage policy and the standalone predefined-view
+--    policy; the new SELECT policy folds predefined visibility into its OR.
+DROP POLICY IF EXISTS "Users can manage own templates" ON public.communication_templates;
+DROP POLICY IF EXISTS "Users can view predefined templates" ON public.communication_templates;
+
+-- SELECT: any member of the row's family, plus all predefined/global templates.
+CREATE POLICY communication_templates_select_family
+  ON public.communication_templates FOR SELECT TO authenticated
+  USING (
+    is_predefined = true
+    OR family_unit_id IN (
+      SELECT family_unit_id FROM public.family_members WHERE user_id = auth.uid()
+    )
+  );
+
+-- INSERT: only into a family the writer belongs to. is_predefined stays false for
+-- user writes (built-ins are seeded server-side, never via this policy).
+CREATE POLICY communication_templates_insert_family
+  ON public.communication_templates FOR INSERT TO authenticated
+  WITH CHECK (
+    is_predefined IS NOT TRUE
+    AND family_unit_id IN (
+      SELECT family_unit_id FROM public.family_members WHERE user_id = auth.uid()
+    )
+  );
+
+-- UPDATE: any family member may edit a family template; cannot retarget it to
+-- another family or flip it into a predefined built-in.
+CREATE POLICY communication_templates_update_family
+  ON public.communication_templates FOR UPDATE TO authenticated
+  USING (
+    is_predefined IS NOT TRUE
+    AND family_unit_id IN (
+      SELECT family_unit_id FROM public.family_members WHERE user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    is_predefined IS NOT TRUE
+    AND family_unit_id IN (
+      SELECT family_unit_id FROM public.family_members WHERE user_id = auth.uid()
+    )
+  );
+
+-- DELETE: any family member may delete a family template.
+CREATE POLICY communication_templates_delete_family
+  ON public.communication_templates FOR DELETE TO authenticated
+  USING (
+    is_predefined IS NOT TRUE
+    AND family_unit_id IN (
+      SELECT family_unit_id FROM public.family_members WHERE user_id = auth.uid()
+    )
+  );

--- a/tests/unit/composables/useCommunicationTemplates.familyScope.spec.ts
+++ b/tests/unit/composables/useCommunicationTemplates.familyScope.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ref } from "vue";
+import { useCommunicationTemplates } from "~/composables/useCommunicationTemplates";
+
+// Capture the arguments the composable passes to Supabase so we can assert the
+// family-scoped query/insert shape without a live DB.
+const captured: { orFilter?: string; insertPayload?: Record<string, unknown> } =
+  {};
+
+vi.mock("~/composables/useSupabase", () => ({
+  useSupabase: vi.fn(() => ({
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        or: vi.fn((filter: string) => {
+          captured.orFilter = filter;
+          return {
+            order: vi.fn(() => Promise.resolve({ data: [], error: null })),
+          };
+        }),
+      })),
+      insert: vi.fn((rows: Record<string, unknown>[]) => {
+        captured.insertPayload = rows[0];
+        return {
+          select: vi.fn(() => ({
+            single: vi.fn(() =>
+              Promise.resolve({
+                data: { id: "t1", ...rows[0] },
+                error: null,
+              }),
+            ),
+          })),
+        };
+      }),
+    })),
+  })),
+}));
+
+vi.mock("~/stores/user", () => ({
+  useUserStore: vi.fn(() => ({ user: { id: "user1" } })),
+}));
+
+// Force the singleton fallback path (inject returns undefined in a bare test) to
+// resolve to a known family unit.
+vi.mock("~/composables/useFamilyContext", () => ({
+  useFamilyContext: vi.fn(() => ({
+    activeFamilyId: ref("fam-123"),
+  })),
+}));
+
+describe("useCommunicationTemplates — family scope", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    captured.orFilter = undefined;
+    captured.insertPayload = undefined;
+  });
+
+  it("loadTemplates filters by the active family plus predefined templates", async () => {
+    const composable = useCommunicationTemplates();
+    await composable.loadTemplates();
+
+    expect(captured.orFilter).toBe(
+      "family_unit_id.eq.fam-123,is_predefined.eq.true",
+    );
+  });
+
+  it("createTemplate stamps the active family_unit_id on the new row", async () => {
+    const composable = useCommunicationTemplates();
+    await composable.createTemplate("Intro", "email", "Hi coach", "Subject");
+
+    expect(captured.insertPayload).toMatchObject({
+      user_id: "user1",
+      family_unit_id: "fam-123",
+      name: "Intro",
+      type: "email",
+    });
+  });
+});

--- a/types/database.ts
+++ b/types/database.ts
@@ -446,6 +446,7 @@ export type Database = {
           contact_window: string;
           created_at: string | null;
           description: string | null;
+          family_unit_id: string | null;
           id: string;
           is_favorite: boolean | null;
           is_predefined: boolean | null;
@@ -469,6 +470,7 @@ export type Database = {
           contact_window?: string;
           created_at?: string | null;
           description?: string | null;
+          family_unit_id?: string | null;
           id?: string;
           is_favorite?: boolean | null;
           is_predefined?: boolean | null;
@@ -492,6 +494,7 @@ export type Database = {
           contact_window?: string;
           created_at?: string | null;
           description?: string | null;
+          family_unit_id?: string | null;
           id?: string;
           is_favorite?: boolean | null;
           is_predefined?: boolean | null;


### PR DESCRIPTION
## What

Communication templates were **user-scoped** (`user_id` owner only) — a template one family member created was private to that account, invisible even to linked parent/player. This makes templates **family-scoped**, matching every other domain table (schools, coaches, documents, interactions, athlete_messages).

**Why:** a parent can proofread/tweak a template the player then sends. Product decision confirmed with Chris.

## Changes

- **Migration `20260906000000` (already applied live to `xpxzhqghxecsjhvklsqg`):**
  - `family_unit_id uuid` + FK `family_units(id) ON DELETE CASCADE` + index
  - Reuses the generic `derive_family_unit_id()` BEFORE INSERT/UPDATE trigger
  - Backfills existing user rows (verified: 2 backfilled, 0 orphan, 0 ambiguous)
  - Replaces owner-only RLS with **one permissive policy per verb**, family-join scoped. SELECT also OR's `is_predefined` (global built-ins stay visible to all); write verbs require `is_predefined IS NOT TRUE`.
- **`useCommunicationTemplates`:** load/create scope by `activeFamilyId`; update/delete drop the `user_id` filter (RLS enforces family now).
- **Types:** patched `types/database.ts` for `family_unit_id`.
- **iOS parity:** handoff spec at `planning/iOS_SPEC_family-shared-templates-2026-08-24.md`.

## Behavior after

- Any family member views/edits/deletes any family template.
- Predefined built-ins: visible to all, editable by none.
- Different families never see each other's templates.

## Test plan

- [x] `npm run type-check` — clean
- [x] `eslint` composable — 0 errors
- [x] Template unit cluster — 89 pass (incl. new `useCommunicationTemplates.familyScope.spec.ts`)
- [x] Migration applied + verified live (34 predefined, 2 backfilled, 0 orphan; 4 clean policies)
- [ ] CI full suite + Vercel QA

⚠️ **Migration already applied live** (single DB serves prod+QA) — schema is live now; the migration file rides in on this PR so `main` sees it on promote.

https://claude.ai/code/session_01MHgpJRwbbAXSsFXCywot8B