### PR TITLE
test(e2e): entry-flow coverage — onboarding completion, invite creation, minor gating

### DIFF
--- a/tests/e2e/family-invite-creation.spec.ts
+++ b/tests/e2e/family-invite-creation.spec.ts
@@ -1,0 +1,263 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  getSupabaseAdmin,
+  createOneOffTestUser,
+  deleteOneOffTestUser,
+} from "./seed/helpers/supabase-admin";
+import { loginViaForm } from "./helpers/login";
+
+/**
+ * Invite CREATION coverage via the real family-management UI.
+ *
+ * The existing family-invite-flow spec seeds invitations directly in the DB and
+ * only exercises the acceptance half (accept / decline / revoke). It never
+ * drives a user CREATING an invite through the UI, and only ever seeds the
+ * player→parent direction. This spec fills both gaps by driving
+ * `/settings/family-management` (email + role select + submit) for every
+ * direction, then asserting the persisted `family_invitations` row:
+ *
+ *   1. parent → player   (parent-first, then invites their athlete)
+ *   2. player → parent    (player-first, then invites a guardian)
+ *   3. second parent      (a unit that already has player + parent adds a 2nd
+ *                          parent, who then accepts — proving multi-guardian)
+ *
+ * Each test seeds its own per-run family so no shared account state is touched.
+ */
+
+type SupabaseAdmin = ReturnType<typeof getSupabaseAdmin>;
+
+const RUN = Date.now();
+const PASSWORD = "SeedPass123!";
+
+interface SeededUser {
+  email: string;
+  userId: string;
+}
+
+/**
+ * Create a confirmed auth user AND its public.users mirror row (the trigger
+ * mis-defaults non-parent roles and can lag, so we upsert deterministically
+ * off the returned auth id rather than reading it back) so findUserIdByEmail
+ * and family membership both resolve.
+ */
+async function seedUser(
+  supabase: SupabaseAdmin,
+  email: string,
+  role: "player" | "parent",
+  displayName: string,
+): Promise<SeededUser> {
+  const authUser = await createOneOffTestUser({
+    email,
+    password: PASSWORD,
+    displayName,
+    role,
+  });
+  const userId = authUser?.id;
+  if (!userId) throw new Error(`seedUser: ${email} has no auth id after create`);
+  await supabase.from("users").upsert(
+    {
+      id: userId,
+      email,
+      full_name: displayName,
+      role,
+      onboarding_completed: true,
+      phase_milestone_data: {
+        onboarding_complete: true,
+        onboarding_completed_at: new Date().toISOString(),
+      },
+    },
+    { onConflict: "id" },
+  );
+  return { email, userId };
+}
+
+/** Create a family unit and add the given members. Returns the unit id. */
+async function seedFamilyUnit(
+  supabase: SupabaseAdmin,
+  ownerUserId: string,
+  members: { userId: string; role: "player" | "parent" }[],
+): Promise<string> {
+  const { data: unit, error } = await supabase
+    .from("family_units")
+    .insert({
+      family_name: `Invite Creation ${RUN} Family`,
+      created_by_user_id: ownerUserId,
+    })
+    .select("id")
+    .single();
+  if (error || !unit) {
+    throw new Error(`seedFamilyUnit: ${error?.message ?? "no unit returned"}`);
+  }
+  const unitId = unit.id as string;
+  const { error: memberErr } = await supabase.from("family_members").insert(
+    members.map((m) => ({
+      family_unit_id: unitId,
+      user_id: m.userId,
+      role: m.role,
+    })),
+  );
+  if (memberErr) {
+    throw new Error(`seedFamilyUnit members: ${memberErr.message}`);
+  }
+  return unitId;
+}
+
+/** Drive the family-management invite form and submit. */
+async function sendInviteViaUi(
+  page: Page,
+  invitedEmail: string,
+  role: "player" | "parent",
+): Promise<void> {
+  await page.goto("/settings/family-management");
+  await expect(page.locator('[data-testid="invite-member-form"]')).toBeVisible();
+  await page.locator('[data-testid="invite-email-input"]').fill(invitedEmail);
+  await page.locator('[data-testid="invite-role-select"]').selectOption(role);
+  await expect(
+    page.locator('[data-testid="send-invite-submit"]'),
+  ).not.toBeDisabled();
+  await page.locator('[data-testid="send-invite-submit"]').click();
+}
+
+/** The most-recent invitation for an email in a unit, or null. */
+async function findInvite(
+  supabase: SupabaseAdmin,
+  unitId: string,
+  invitedEmail: string,
+): Promise<{ id: string; role: string; status: string } | null> {
+  const { data } = await supabase
+    .from("family_invitations")
+    .select("id, role, status")
+    .eq("family_unit_id", unitId)
+    .eq("invited_email", invitedEmail)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  return (data as { id: string; role: string; status: string } | null) ?? null;
+}
+
+test.describe("Family Invite Creation (UI)", () => {
+  // Serial: each test seeds and tears down its own family; running them on one
+  // worker keeps the shared Supabase project free of overlapping debris.
+  test.describe.configure({ mode: "serial" });
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  const supabase = getSupabaseAdmin();
+  const createdUserEmails: string[] = [];
+  const createdUnitIds: string[] = [];
+
+  test.afterAll(async () => {
+    // Invitations + members are FK-bound to units; delete children first.
+    for (const unitId of createdUnitIds) {
+      await supabase
+        .from("family_invitations")
+        .delete()
+        .eq("family_unit_id", unitId);
+      await supabase.from("family_members").delete().eq("family_unit_id", unitId);
+      await supabase.from("family_units").delete().eq("id", unitId);
+    }
+    for (const email of createdUserEmails) {
+      await deleteOneOffTestUser(email).catch(() => {});
+    }
+  });
+
+  test("parent invites a player (parent → player)", async ({ page }) => {
+    const parentEmail = `inv-parent-p2c-${RUN}@example.com`;
+    const invitedPlayer = `inv-player-target-${RUN}@example.com`;
+    const parent = await seedUser(supabase, parentEmail, "parent", "Parent P2C");
+    const unitId = await seedFamilyUnit(supabase, parent.userId, [
+      { userId: parent.userId, role: "parent" },
+    ]);
+    createdUserEmails.push(parentEmail);
+    createdUnitIds.push(unitId);
+
+    await loginViaForm(page, parentEmail, PASSWORD, /\/(dashboard|schools)/);
+    await sendInviteViaUi(page, invitedPlayer, "player");
+
+    await expect(page.getByText(/Invite sent/i)).toBeVisible({ timeout: 15000 });
+    const invite = await findInvite(supabase, unitId, invitedPlayer);
+    expect(invite).not.toBeNull();
+    expect(invite?.role).toBe("player");
+    expect(invite?.status).toBe("pending");
+  });
+
+  test("player invites a parent (player → parent)", async ({ page }) => {
+    const playerEmail = `inv-player-c2p-${RUN}@example.com`;
+    const invitedParent = `inv-parent-target-${RUN}@example.com`;
+    const player = await seedUser(supabase, playerEmail, "player", "Player C2P");
+    const unitId = await seedFamilyUnit(supabase, player.userId, [
+      { userId: player.userId, role: "player" },
+    ]);
+    createdUserEmails.push(playerEmail);
+    createdUnitIds.push(unitId);
+
+    await loginViaForm(page, playerEmail, PASSWORD, /\/(dashboard|schools)/);
+    await sendInviteViaUi(page, invitedParent, "parent");
+
+    await expect(page.getByText(/Invite sent/i)).toBeVisible({ timeout: 15000 });
+    const invite = await findInvite(supabase, unitId, invitedParent);
+    expect(invite).not.toBeNull();
+    expect(invite?.role).toBe("parent");
+    expect(invite?.status).toBe("pending");
+  });
+
+  test("second parent is invited to an existing family and accepts", async ({
+    page,
+  }) => {
+    const player = await seedUser(
+      supabase,
+      `inv-2p-player-${RUN}@example.com`,
+      "player",
+      "Player 2P",
+    );
+    const parent1 = await seedUser(
+      supabase,
+      `inv-2p-parent1-${RUN}@example.com`,
+      "parent",
+      "Parent One",
+    );
+    const parent2Email = `inv-2p-parent2-${RUN}@example.com`;
+    const parent2 = await seedUser(supabase, parent2Email, "parent", "Parent Two");
+    // A unit that ALREADY contains a player + one parent.
+    const unitId = await seedFamilyUnit(supabase, parent1.userId, [
+      { userId: player.userId, role: "player" },
+      { userId: parent1.userId, role: "parent" },
+    ]);
+    createdUserEmails.push(player.email, parent1.email, parent2Email);
+    createdUnitIds.push(unitId);
+
+    // parent1 invites a SECOND parent through the UI.
+    await loginViaForm(page, parent1.email, PASSWORD, /\/(dashboard|schools)/);
+    await sendInviteViaUi(page, parent2Email, "parent");
+    await expect(page.getByText(/Invite sent/i)).toBeVisible({ timeout: 15000 });
+
+    const invite = await findInvite(supabase, unitId, parent2Email);
+    expect(invite).not.toBeNull();
+    expect(invite?.role).toBe("parent");
+    const token = await (async () => {
+      const { data } = await supabase
+        .from("family_invitations")
+        .select("token")
+        .eq("id", invite!.id)
+        .single();
+      return (data as { token: string }).token;
+    })();
+
+    // parent2 logs in and accepts via the /join link.
+    await page.context().clearCookies();
+    await loginViaForm(page, parent2Email, PASSWORD, /\/(dashboard|schools)/);
+    await page.goto(`/join?token=${token}`);
+    await expect(page.locator('[data-testid="connect-button"]')).toBeVisible({
+      timeout: 15000,
+    });
+    await page.locator('[data-testid="connect-button"]').click();
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15000 });
+
+    // The unit now has TWO parent members.
+    const { data: parents } = await supabase
+      .from("family_members")
+      .select("user_id")
+      .eq("family_unit_id", unitId)
+      .eq("role", "parent");
+    expect((parents ?? []).length).toBe(2);
+  });
+});

--- a/tests/e2e/onboarding-completion.spec.ts
+++ b/tests/e2e/onboarding-completion.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Entry-flow coverage: a brand-new user signing up and driving the onboarding
+ * wizard all the way to the dashboard. The existing signup-flow spec stops at
+ * the post-signup redirect URL; these tests carry the journey through to
+ * completion for BOTH roles — the seam a real first-time user actually hits.
+ *
+ * Each test mints a per-run account (teardown reaps debris users by the
+ * @example.com pattern in global-teardown), so no shared seeded state is
+ * touched and runs stay isolated.
+ */
+
+// Unique suffix per run avoids "already registered" collisions across reruns
+// and parallel workers.
+const RUN = Date.now();
+
+const PASSWORD = "SecurePass123";
+
+/** Signs up a fresh account through the real signup UI. */
+async function signUp(
+  page: Page,
+  role: "player" | "parent",
+  email: string,
+): Promise<void> {
+  await page.goto("/signup");
+  await page.click(`[data-testid="user-type-${role}"]`);
+  await expect(
+    page.locator(`[data-testid="signup-form-${role}"]`),
+  ).toBeVisible();
+
+  await page.fill("#firstName", role === "player" ? "Player" : "Parent");
+  await page.fill("#lastName", "E2E");
+  if (role === "player") {
+    // 18+ so the COPPA / minor-guardian gate never blocks a standalone signup.
+    await page.fill("#dateOfBirth", "2005-01-15");
+  }
+  await page.fill("#email", email);
+  await page.fill("#password", PASSWORD);
+  await page.fill("#confirmPassword", PASSWORD);
+  await page.check("#agreeToTerms");
+
+  await expect(
+    page.locator('[data-testid="signup-button"]'),
+  ).not.toBeDisabled();
+  await page.click('[data-testid="signup-button"]');
+}
+
+test.describe("Onboarding Completion - Full Entry Journey", () => {
+  // These specs must run unauthenticated — they create their own accounts.
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("player: signup → complete wizard → dashboard", async ({ page }) => {
+    const email = `player-onboard-${RUN}@example.com`;
+    await signUp(page, "player", email);
+
+    // Player signup lands on the player onboarding wizard.
+    await expect(page).toHaveURL(/\/onboarding(\/|$|\?)/, { timeout: 15000 });
+    await expect(page).not.toHaveURL(/\/onboarding\/parent/);
+
+    // Step 1 — Welcome
+    await page.getByRole("button", { name: "Next" }).click();
+
+    // Step 2 — Basic Info (graduation year + primary sport + position required)
+    await page
+      .locator("#onboarding-graduation-year")
+      .selectOption({ index: 1 });
+    await page.locator("#onboarding-primary-sport").selectOption("Baseball");
+    // Position select appears once a sport is chosen.
+    await expect(page.locator("#onboarding-primary-position")).toBeVisible();
+    await page
+      .locator("#onboarding-primary-position")
+      .selectOption({ index: 1 });
+    await page.getByRole("button", { name: "Next" }).click();
+
+    // Step 3 — Location (zip required, must be 5 digits to advance)
+    await page.locator('input[autocomplete="postal-code"]').fill("44092");
+    await page.getByRole("button", { name: "Next" }).click();
+
+    // Step 4 — Academics (all optional) → "Review" advances to step 5
+    await page.getByRole("button", { name: "Review" }).click();
+
+    // Step 5 — Invite parent. Complete without inviting.
+    await expect(page.locator('[data-testid="step-5-invite"]')).toBeVisible();
+    await page.getByRole("button", { name: "I'll invite them later" }).click();
+
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15000 });
+  });
+
+  test("parent: signup → complete wizard → dashboard", async ({ page }) => {
+    const email = `parent-onboard-${RUN}@example.com`;
+    await signUp(page, "parent", email);
+
+    // Parent signup lands on the dedicated parent onboarding wizard.
+    await expect(page).toHaveURL(/\/onboarding\/parent/, { timeout: 15000 });
+
+    // Step 1 — Player details (all required to advance)
+    await page.locator('[data-testid="player-name"]').fill("Kid E2E");
+    await page.locator('[data-testid="player-dob"]').fill("2008-05-10");
+    await page
+      .locator('[data-testid="graduation-year"]')
+      .selectOption({ index: 1 });
+    await page.locator('[data-testid="sport"]').selectOption("Baseball");
+    await expect(page.locator('[data-testid="position"]')).toBeVisible();
+    await page.locator('[data-testid="position"]').selectOption({ index: 1 });
+    await page.locator('[data-testid="next-button"]').click();
+
+    // Step 2 — Invite player. Complete via "I'll invite them later".
+    await expect(page.locator('[data-testid="step-2"]')).toBeVisible();
+    await page.locator('[data-testid="skip-invite"]').click();
+
+    await expect(page).toHaveURL(/\/dashboard/, { timeout: 15000 });
+  });
+});

--- a/tests/e2e/signup-flow.spec.ts
+++ b/tests/e2e/signup-flow.spec.ts
@@ -103,6 +103,36 @@ test.describe("Signup Page - Full Flow E2E Tests", () => {
         page.locator("text=not available for players under 13"),
       ).toBeVisible({ timeout: 5000 });
     });
+
+    test("minor (13-17) player is steered to a guardian invite and cannot submit", async ({
+      page,
+    }) => {
+      await page.click('[data-testid="user-type-player"]');
+
+      // DOB ~15 years ago: old enough for COPPA (13+) but a minor (<18), so the
+      // account must be created through a parent/guardian family invite.
+      const fifteenYearsAgo = new Date();
+      fifteenYearsAgo.setFullYear(fifteenYearsAgo.getFullYear() - 15);
+      await page.fill("#firstName", "Minor");
+      await page.fill("#lastName", "Player");
+      await page.fill(
+        "#dateOfBirth",
+        fifteenYearsAgo.toISOString().split("T")[0],
+      );
+      await page.fill("#email", `minor-e2e-${RUN}@example.com`);
+      await page.fill("#password", "SecurePass123");
+      await page.fill("#confirmPassword", "SecurePass123");
+      await page.check("#agreeToTerms");
+
+      // The guardian-invite notice appears and the form cannot be submitted
+      // even with every other field valid + terms agreed.
+      await expect(
+        page.locator('[data-testid="minor-guardian-notice"]'),
+      ).toBeVisible();
+      await expect(
+        page.locator('[data-testid="signup-button"]'),
+      ).toBeDisabled();
+    });
   });
 
   test.describe("Parent Signup Flow", () => {


### PR DESCRIPTION
## Phase 1 of 2 — entry-flow test coverage

Fills the highest-value E2E gaps in the app-entry flows (signup → onboarding → family). Entry is the flow every user hits first, so these went first.

### What's new
| Spec | Covers | Was |
|---|---|---|
| `onboarding-completion.spec.ts` | Real signup → full wizard → `/dashboard`, **player** + **parent** | Existing specs stopped at the post-signup redirect URL |
| `family-invite-creation.spec.ts` | Invite **creation** via family-management UI: **parent→player**, **player→parent**, **2nd parent** to an existing unit + accept | Old suite DB-seeded invites, only player→parent, acceptance-half only |
| `signup-flow.spec.ts` (+1) | **13–17 minor** steered to guardian invite, signup button stays disabled | Only COPPA under-13 block existed |

### Gaps closed (from the coverage audit)
- ✅ Parent-first → invites player (was: no E2E)
- ✅ Player-first → invites parent via UI (was: creation half untested)
- ✅ 2nd parent invited to existing family (was: none)
- ✅ Onboarding completed by parent first (was: redirect-only)
- ✅ Onboarding completed by player first (was: redirect-only)
- ✅ Minor 13–17 gating (was: none)

### Notes
- Specs self-seed per run (per-run `@example.com` accounts + own family units) and clean up in `afterAll`; `global-teardown` reaps any residual debris.
- No source changes — tests only.

### Test plan
- [x] `npx playwright test <3 specs> --project=chromium` → **22/22 pass**
- [x] `tsc --noEmit` clean on new specs
- [ ] CI (e2e.yml) green on this PR

Phase 2 (follow-up PR): unit-test gaps — `signupSchemas`, `useAuth.signup()` metadata call, guardian-consent record write, `family/code/my-code.get.ts`.

https://claude.ai/code/session_01CijwYM8hiqfJupD8SdLWae