### PR TITLE
fix(web): right-align milestone dates for iOS parity

### DIFF
--- a/components/Timeline/UpcomingMilestones.vue
+++ b/components/Timeline/UpcomingMilestones.vue
@@ -24,18 +24,20 @@
         <div class="font-medium text-slate-900 group-hover:text-slate-950">
           {{ milestone.title }}
         </div>
-        <div class="mt-0.5 text-xs text-slate-500">
-          {{ formatDate(milestone.date) }}
-        </div>
         <div v-if="milestone.description" class="mt-1 text-xs text-slate-600">
           {{ milestone.description }}
         </div>
       </div>
-      <div
-        v-if="milestone.url"
-        class="shrink-0 text-slate-400 transition group-hover:text-slate-600"
-      >
-        ↗
+      <div class="shrink-0 text-right">
+        <div class="text-xs text-slate-500">
+          {{ formatDate(milestone.date) }}
+        </div>
+        <div
+          v-if="milestone.url"
+          class="mt-0.5 text-slate-400 transition group-hover:text-slate-600"
+        >
+          ↗
+        </div>
       </div>
     </a>
   </div>
@@ -96,9 +98,6 @@
             <div class="font-medium text-slate-900 group-hover:text-slate-950">
               {{ milestone.title }}
             </div>
-            <div class="mt-0.5 text-xs text-slate-500">
-              {{ formatDate(milestone.date) }}
-            </div>
             <div
               v-if="milestone.description"
               class="mt-1 text-xs text-slate-600"
@@ -106,11 +105,16 @@
               {{ milestone.description }}
             </div>
           </div>
-          <div
-            v-if="milestone.url"
-            class="shrink-0 text-slate-400 transition group-hover:text-slate-600"
-          >
-            ↗
+          <div class="shrink-0 text-right">
+            <div class="text-xs text-slate-500">
+              {{ formatDate(milestone.date) }}
+            </div>
+            <div
+              v-if="milestone.url"
+              class="mt-0.5 text-slate-400 transition group-hover:text-slate-600"
+            >
+              ↗
+            </div>
           </div>
         </a>
       </div>


### PR DESCRIPTION
## Summary

Parity follow-up from iOS device QA (iOS side: PR #58). Restructures each milestone row in `components/Timeline/UpcomingMilestones.vue` so title + description sit left and the date is right-aligned — matching the iOS milestone row where the date lives in a trailing VStack.

**Both row branches updated** (they were duplicated):
- **bare** branch (embedded in RecruitingCalendar widget)
- **card** branch (standalone Upcoming Milestones card)

### Before → After

- **Before:** `[icon] [title / date / description stacked] [↗]`
- **After:** `[icon] [title, description below | flex-1] [date, ↗ below | shrink-0 text-right]`

Rows are already full-width, so equal-width holds. Same date format + icon retained.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run audit:tokens` — 0 errors
- [x] Affected unit tests: `UpcomingMilestones.spec.ts` + `RecruitingCalendar.merge.spec.ts` — 16 passed

https://claude.ai/code/session_01CijwYM8hiqfJupD8SdLWae