### PR TITLE
feat(sports): add Gymnastics + Beach Volleyball (19 sports)

### DIFF
--- a/components/Search/AdvancedFilters.vue
+++ b/components/Search/AdvancedFilters.vue
@@ -295,7 +295,7 @@ interface Props {
   isFiltering: boolean;
 }
 
-// Full sport list from the registry (17 sports) — no baseball-only options.
+// Full sport list from the registry (19 sports) — no baseball-only options.
 const sportOptions = computed(() => Object.keys(SPORT_POSITIONS));
 
 // Full union of metric types across every sport (deduped, ordered), labelled

--- a/composables/useEventMetricsSection.ts
+++ b/composables/useEventMetricsSection.ts
@@ -46,7 +46,7 @@ export function useEventMetricsSection(
     try {
       metricLoading.value = true;
       await createMetric({
-        // metric_type is a registry key (any of 17 sports), not a baseball union.
+        // metric_type is a registry key (any of 19 sports), not a baseball union.
         metric_type: newMetric.metric_type,
         value: newMetric.value!,
         recorded_date: event.value!.start_date,

--- a/scripts/check-ncaa-calendar-cycle.mjs
+++ b/scripts/check-ncaa-calendar-cycle.mjs
@@ -29,16 +29,34 @@ const NEXT_SEASON = "2027-28";
 /** Build the D1 per-sport PDF URLs for a season. Mirrors the real NCAA filenames. */
 export function d1Urls(season) {
   // Most codes follow {season}D1Rec_{CODE}RecruitingCalendar.pdf.
-  const codes = ["MBA", "WSB", "MBB", "WBB", "XCTF", "WVB", "MGO", "MLA", "WLA"];
+  const codes = [
+    "MBA",
+    "WSB",
+    "MBB",
+    "WBB",
+    "XCTF",
+    "WVB",
+    "MGO",
+    "MLA",
+    "WLA",
+  ];
   const urls = codes.map((code) => ({
     code,
     url: `${BUCKET}/${season}/${season}D1Rec_${code}RecruitingCalendar.pdf`,
   }));
   // Football breaks the infix mold: FBS/FCS (no MFB).
-  urls.push({ code: "FBS", url: `${BUCKET}/${season}/${season}D1Rec_FBSRecruitingCalendar.pdf` });
-  urls.push({ code: "FCS", url: `${BUCKET}/${season}/${season}D1Rec_FCSRecruitingCalendar.pdf` });
+  urls.push({
+    code: "FBS",
+    url: `${BUCKET}/${season}/${season}D1Rec_FBSRecruitingCalendar.pdf`,
+  });
+  urls.push({
+    code: "FCS",
+    url: `${BUCKET}/${season}/${season}D1Rec_FCSRecruitingCalendar.pdf`,
+  });
   // The "Other Sports" catch-all uses an EN-DASH (U+2013) in the year in the filename
-  // (verified: the ASCII-hyphen variant 404s).
+  // (verified: the ASCII-hyphen variant 404s). NOTE: this one PDF also carries the
+  // per-sport OTHER_* sub-calendars (soccer/swim/hockey/rowing/field-hockey/wrestling
+  // AND women's gymnastics) — re-transcribing it must refresh all of them.
   const enDashSeason = season.replace("-", "–");
   urls.push({
     code: "Other",
@@ -74,7 +92,9 @@ async function main() {
   console.log(`  transcribed season: ${CURRENT_SEASON}`);
   console.log(`  found ${found.length}/${results.length} published PDFs`);
   for (const r of results) {
-    console.log(`   ${r.status === 200 ? "✓" : "✗"} ${r.code}  (${r.status})  ${r.url}`);
+    console.log(
+      `   ${r.status === 200 ? "✓" : "✗"} ${r.code}  (${r.status})  ${r.url}`,
+    );
   }
 
   const cycleAvailable = season !== CURRENT_SEASON && found.length > 0;

--- a/tests/unit/utils/canonicalPositions.spec.ts
+++ b/tests/unit/utils/canonicalPositions.spec.ts
@@ -298,4 +298,135 @@ describe("canonical positions", () => {
       ]);
     });
   });
+
+  // Snapshot guard for the ENTIRE sport/position vocabulary. Any accidental
+  // sport deletion, rename, or position-list edit fails here loudly — the
+  // per-function specs above only spot-check a handful of sports, so the less
+  // common sports (Field Hockey, Water Polo, Wrestling, Rowing, ...) would
+  // otherwise regress silently. Onboarding, the edit form, and iOS all derive
+  // from this map, so it is the one place worth pinning exactly.
+  describe("SPORT_POSITIONS complete vocabulary (regression guard)", () => {
+    const EXPECTED_VOCABULARY: Record<string, readonly string[]> = {
+      Baseball: [
+        "Pitcher",
+        "Catcher",
+        "First Base",
+        "Second Base",
+        "Third Base",
+        "Shortstop",
+        "Left Field",
+        "Center Field",
+        "Right Field",
+        "Designated Hitter",
+      ],
+      Softball: [
+        "Pitcher",
+        "Catcher",
+        "First Base",
+        "Second Base",
+        "Third Base",
+        "Shortstop",
+        "Left Field",
+        "Center Field",
+        "Right Field",
+        "Designated Hitter",
+      ],
+      Basketball: [
+        "Point Guard",
+        "Shooting Guard",
+        "Small Forward",
+        "Power Forward",
+        "Center",
+      ],
+      Football: [
+        "Quarterback",
+        "Running Back",
+        "Wide Receiver",
+        "Tight End",
+        "Offensive Line",
+        "Defensive Line",
+        "Linebacker",
+        "Defensive Back",
+        "Kicker",
+        "Punter",
+      ],
+      Soccer: ["Goalkeeper", "Defender", "Midfielder", "Forward"],
+      Volleyball: [
+        "Outside Hitter",
+        "Middle Blocker",
+        "Setter",
+        "Libero",
+        "Opposite Hitter",
+        "Defensive Specialist",
+      ],
+      "Track & Field": [
+        "Sprinter",
+        "Distance Runner",
+        "Jumper",
+        "Thrower",
+        "Hurdler",
+      ],
+      Swimming: [
+        "Freestyle",
+        "Backstroke",
+        "Breaststroke",
+        "Butterfly",
+        "Individual Medley",
+        "Diver",
+      ],
+      "Cross Country": ["Runner"],
+      Tennis: ["Singles", "Doubles"],
+      Golf: ["Golfer"],
+      Lacrosse: ["Attackman", "Midfielder", "Defenseman", "Goalie"],
+      "Field Hockey": ["Forward", "Midfielder", "Defender", "Goalkeeper"],
+      "Ice Hockey": ["Forward", "Defenseman", "Goalie"],
+      Wrestling: ["Wrestler"],
+      Rowing: ["Rower"],
+      "Water Polo": ["Field Player", "Goalkeeper"],
+      Gymnastics: [
+        "All-Around",
+        "Vault",
+        "Uneven Bars",
+        "Balance Beam",
+        "Floor Exercise",
+        "Pommel Horse",
+        "Still Rings",
+        "Parallel Bars",
+        "Horizontal Bar",
+      ],
+      "Beach Volleyball": ["Blocker", "Defender"],
+    };
+
+    it("exposes exactly the expected sport keys (no add/drop/rename)", () => {
+      expect(Object.keys(SPORT_POSITIONS).sort()).toEqual(
+        Object.keys(EXPECTED_VOCABULARY).sort(),
+      );
+    });
+
+    it("pins every sport's full position list", () => {
+      expect(SPORT_POSITIONS).toEqual(EXPECTED_VOCABULARY);
+    });
+
+    it.each(Object.keys(EXPECTED_VOCABULARY))(
+      "%s: getCanonicalPositions returns the pinned list",
+      (sport) => {
+        expect(getCanonicalPositions(sport)).toEqual([
+          ...EXPECTED_VOCABULARY[sport],
+        ]);
+      },
+    );
+
+    it("every sport has at least one position and no blank/dupe entries", () => {
+      for (const [sport, positions] of Object.entries(SPORT_POSITIONS)) {
+        expect(positions.length, `${sport} has no positions`).toBeGreaterThan(
+          0,
+        );
+        const trimmed = positions.map((p) => p.trim());
+        expect(trimmed, `${sport} has a blank position`).not.toContain("");
+        expect(new Set(trimmed).size, `${sport} has duplicate positions`).toBe(
+          positions.length,
+        );
+      }
+    });
+  });
 });

--- a/tests/unit/utils/metrics/canonical.spec.ts
+++ b/tests/unit/utils/metrics/canonical.spec.ts
@@ -102,8 +102,8 @@ describe("sport orderings", () => {
       "fielding_pct",
     );
   });
-  it("all 17 sports present", () => {
-    expect(Object.keys(SPORT_METRICS)).toHaveLength(17);
+  it("all 19 sports present", () => {
+    expect(Object.keys(SPORT_METRICS)).toHaveLength(19);
   });
   it("every sport key has a def, and 'other' is never inline", () => {
     for (const [sport, keys] of Object.entries(SPORT_METRICS)) {

--- a/tests/unit/utils/recruitingCalendar/calendarData.spec.ts
+++ b/tests/unit/utils/recruitingCalendar/calendarData.spec.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { D1_CALENDARS, D2_ALL_SPORTS, D3_FALLBACK } from "~/utils/recruitingCalendar/calendarData";
+import {
+  D1_CALENDARS,
+  D2_ALL_SPORTS,
+  D3_FALLBACK,
+} from "~/utils/recruitingCalendar/calendarData";
 
 const ALL_KEYS = [
   "MBA",
@@ -23,8 +27,12 @@ const ALL_KEYS = [
   "OTHER_FIELDHOCKEY",
   "OTHER_MWRESTLING",
   "OTHER_WWRESTLING",
+  "OTHER_WGYM",
 ] as const;
 const ISO = /^\d{4}-\d{2}-\d{2}$/;
+// The dataset's human-verified transcription dates (most on the original pass,
+// OTHER_WGYM added in the gymnastics/beach follow-up).
+const VERIFIED_DATES = ["2026-08-23", "2026-08-25"];
 
 describe("calendarData integrity (L1)", () => {
   it("has every D1 calendar with source + verifiedOn", () => {
@@ -32,7 +40,7 @@ describe("calendarData integrity (L1)", () => {
       const c = D1_CALENDARS[k];
       expect(c, k).toBeTruthy();
       expect(c.source, k).toMatch(/ncaaorg\.s3\.amazonaws\.com/);
-      expect(c.verifiedOn, k).toBe("2026-08-23");
+      expect(VERIFIED_DATES, k).toContain(c.verifiedOn);
       expect(c.periods.length, k).toBeGreaterThan(0);
     }
   });
@@ -42,7 +50,13 @@ describe("calendarData integrity (L1)", () => {
         expect(p.start, `${k} ${p.description}`).toMatch(ISO);
         expect(p.end).toMatch(ISO);
         expect(p.start <= p.end, `${k} ${p.description}`).toBe(true);
-        expect(["dead", "quiet", "contact", "evaluation", "recruiting_shutdown"]).toContain(p.type);
+        expect([
+          "dead",
+          "quiet",
+          "contact",
+          "evaluation",
+          "recruiting_shutdown",
+        ]).toContain(p.type);
         expect(["HIGH", "MEDIUM", "LOW"]).toContain(p.confidence);
       }
   });
@@ -54,10 +68,12 @@ describe("plausibility (L3)", () => {
     // Thanksgiving-ish shutdowns land in Nov; winter shutdowns in Dec/Jan; July-4 dead in Jul.
     for (const k of ALL_KEYS)
       for (const p of D1_CALENDARS[k].periods) {
-        if (/thanksgiving/i.test(p.description)) expect(month(p.start), `${k}`).toBe(11);
+        if (/thanksgiving/i.test(p.description))
+          expect(month(p.start), `${k}`).toBe(11);
         if (/winter|holiday/i.test(p.description) && p.type !== "contact")
           expect([12, 1]).toContain(month(p.start));
-        if (/july 4|independence/i.test(p.description)) expect(month(p.start)).toBe(7);
+        if (/july 4|independence/i.test(p.description))
+          expect(month(p.start)).toBe(7);
       }
   });
   it("no period spans more than ~10 months (catches a swapped start/end year)", () => {
@@ -93,20 +109,29 @@ describe("Other sub-calendars (per-sport bundle expansion)", () => {
     "OTHER_FIELDHOCKEY",
     "OTHER_MWRESTLING",
     "OTHER_WWRESTLING",
+    "OTHER_WGYM",
   ] as const;
   it("each new sub-key's periods differ from the generic Other default (not just a copy/fallback)", () => {
     for (const k of SUB_KEYS) {
       expect(D1_CALENDARS[k].periods.length, k).toBeGreaterThan(0);
-      expect(D1_CALENDARS[k].periods, k).not.toEqual(D1_CALENDARS.Other.periods);
+      expect(D1_CALENDARS[k].periods, k).not.toEqual(
+        D1_CALENDARS.Other.periods,
+      );
     }
   });
   it("soccer sub-calendars are gender-distinct", () => {
-    expect(D1_CALENDARS.OTHER_MSOCCER.periods).not.toEqual(D1_CALENDARS.OTHER_WSOCCER.periods);
+    expect(D1_CALENDARS.OTHER_MSOCCER.periods).not.toEqual(
+      D1_CALENDARS.OTHER_WSOCCER.periods,
+    );
   });
   it("ice hockey sub-calendars are gender-distinct", () => {
-    expect(D1_CALENDARS.OTHER_MICEHOCKEY.periods).not.toEqual(D1_CALENDARS.OTHER_WICEHOCKEY.periods);
+    expect(D1_CALENDARS.OTHER_MICEHOCKEY.periods).not.toEqual(
+      D1_CALENDARS.OTHER_WICEHOCKEY.periods,
+    );
   });
   it("wrestling sub-calendars are gender-distinct", () => {
-    expect(D1_CALENDARS.OTHER_MWRESTLING.periods).not.toEqual(D1_CALENDARS.OTHER_WWRESTLING.periods);
+    expect(D1_CALENDARS.OTHER_MWRESTLING.periods).not.toEqual(
+      D1_CALENDARS.OTHER_WWRESTLING.periods,
+    );
   });
 });

--- a/tests/unit/utils/recruitingCalendar/resolver.spec.ts
+++ b/tests/unit/utils/recruitingCalendar/resolver.spec.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { resolveCalendarKey, NO_SPORT_FALLBACK } from "~/utils/recruitingCalendar/resolver";
+import {
+  resolveCalendarKey,
+  NO_SPORT_FALLBACK,
+} from "~/utils/recruitingCalendar/resolver";
 
 describe("resolveCalendarKey", () => {
   it("maps single-calendar sports", () => {
@@ -14,7 +17,9 @@ describe("resolveCalendarKey", () => {
     expect(resolveCalendarKey("Basketball", { gender: "female" })).toBe("WBB");
     expect(resolveCalendarKey("Lacrosse", { gender: "female" })).toBe("WLA");
     expect(resolveCalendarKey("Basketball", { gender: null })).toBe("MBB"); // default men's
-    expect(resolveCalendarKey("Basketball", { gender: "prefer_not_to_say" })).toBe("MBB");
+    expect(
+      resolveCalendarKey("Basketball", { gender: "prefer_not_to_say" }),
+    ).toBe("MBB");
   });
   it("normalizes gender case — a capitalized 'Female' still resolves to the women's calendar", () => {
     expect(resolveCalendarKey("Basketball", { gender: "Female" })).toBe("WBB");
@@ -28,7 +33,9 @@ describe("resolveCalendarKey", () => {
     expect(resolveCalendarKey("Golf", { gender: null })).toBe("MGO");
     expect(resolveCalendarKey("Golf")).toBe("MGO");
     expect(resolveCalendarKey("Golf", { gender: "other" })).toBe("MGO");
-    expect(resolveCalendarKey("Golf", { gender: "prefer_not_to_say" })).toBe("MGO");
+    expect(resolveCalendarKey("Golf", { gender: "prefer_not_to_say" })).toBe(
+      "MGO",
+    );
     expect(resolveCalendarKey("Golf", { gender: "female" })).toBe("Other");
   });
   it("lacrosse: covers the male and no-opts branches (only WLA/female was previously tested)", () => {
@@ -37,10 +44,12 @@ describe("resolveCalendarKey", () => {
   });
   it("football subdivision toggle, default FBS", () => {
     expect(resolveCalendarKey("Football")).toBe("FBS");
-    expect(resolveCalendarKey("Football", { footballSubdivision: "FCS" })).toBe("FCS");
+    expect(resolveCalendarKey("Football", { footballSubdivision: "FCS" })).toBe(
+      "FCS",
+    );
   });
   it("sports without any published NCAA calendar fall to the generic Other default", () => {
-    for (const s of ["Tennis", "Water Polo"] as const) {
+    for (const s of ["Tennis", "Water Polo", "Beach Volleyball"] as const) {
       expect(resolveCalendarKey(s)).toBe("Other");
     }
   });
@@ -53,23 +62,63 @@ describe("resolveCalendarKey", () => {
     expect(resolveCalendarKey("Field Hockey")).toBe("OTHER_FIELDHOCKEY");
   });
   it("Soccer: gender-split sub-keys, default men's", () => {
-    expect(resolveCalendarKey("Soccer", { gender: "male" })).toBe("OTHER_MSOCCER");
-    expect(resolveCalendarKey("Soccer", { gender: "female" })).toBe("OTHER_WSOCCER");
-    expect(resolveCalendarKey("Soccer", { gender: null })).toBe("OTHER_MSOCCER");
-    expect(resolveCalendarKey("Soccer", { gender: "other" })).toBe("OTHER_MSOCCER");
-    expect(resolveCalendarKey("Soccer", { gender: "prefer_not_to_say" })).toBe("OTHER_MSOCCER");
+    expect(resolveCalendarKey("Soccer", { gender: "male" })).toBe(
+      "OTHER_MSOCCER",
+    );
+    expect(resolveCalendarKey("Soccer", { gender: "female" })).toBe(
+      "OTHER_WSOCCER",
+    );
+    expect(resolveCalendarKey("Soccer", { gender: null })).toBe(
+      "OTHER_MSOCCER",
+    );
+    expect(resolveCalendarKey("Soccer", { gender: "other" })).toBe(
+      "OTHER_MSOCCER",
+    );
+    expect(resolveCalendarKey("Soccer", { gender: "prefer_not_to_say" })).toBe(
+      "OTHER_MSOCCER",
+    );
   });
   it("Ice Hockey: gender-split sub-keys, default men's", () => {
-    expect(resolveCalendarKey("Ice Hockey", { gender: "male" })).toBe("OTHER_MICEHOCKEY");
-    expect(resolveCalendarKey("Ice Hockey", { gender: "female" })).toBe("OTHER_WICEHOCKEY");
-    expect(resolveCalendarKey("Ice Hockey", { gender: null })).toBe("OTHER_MICEHOCKEY");
-    expect(resolveCalendarKey("Ice Hockey", { gender: "prefer_not_to_say" })).toBe("OTHER_MICEHOCKEY");
+    expect(resolveCalendarKey("Ice Hockey", { gender: "male" })).toBe(
+      "OTHER_MICEHOCKEY",
+    );
+    expect(resolveCalendarKey("Ice Hockey", { gender: "female" })).toBe(
+      "OTHER_WICEHOCKEY",
+    );
+    expect(resolveCalendarKey("Ice Hockey", { gender: null })).toBe(
+      "OTHER_MICEHOCKEY",
+    );
+    expect(
+      resolveCalendarKey("Ice Hockey", { gender: "prefer_not_to_say" }),
+    ).toBe("OTHER_MICEHOCKEY");
   });
   it("Wrestling: gender-split sub-keys, default men's", () => {
-    expect(resolveCalendarKey("Wrestling", { gender: "male" })).toBe("OTHER_MWRESTLING");
-    expect(resolveCalendarKey("Wrestling", { gender: "female" })).toBe("OTHER_WWRESTLING");
-    expect(resolveCalendarKey("Wrestling", { gender: null })).toBe("OTHER_MWRESTLING");
-    expect(resolveCalendarKey("Wrestling", { gender: "other" })).toBe("OTHER_MWRESTLING");
-    expect(resolveCalendarKey("Wrestling", { gender: "prefer_not_to_say" })).toBe("OTHER_MWRESTLING");
+    expect(resolveCalendarKey("Wrestling", { gender: "male" })).toBe(
+      "OTHER_MWRESTLING",
+    );
+    expect(resolveCalendarKey("Wrestling", { gender: "female" })).toBe(
+      "OTHER_WWRESTLING",
+    );
+    expect(resolveCalendarKey("Wrestling", { gender: null })).toBe(
+      "OTHER_MWRESTLING",
+    );
+    expect(resolveCalendarKey("Wrestling", { gender: "other" })).toBe(
+      "OTHER_MWRESTLING",
+    );
+    expect(
+      resolveCalendarKey("Wrestling", { gender: "prefer_not_to_say" }),
+    ).toBe("OTHER_MWRESTLING");
+  });
+  it("Gymnastics: women's has its own calendar; men's/unspecified use generic Other", () => {
+    // Only women's gymnastics is enumerated in the "Other" bundle PDF; men's is
+    // folded into "All Other Sports". Default (men's) is the generic Other.
+    expect(resolveCalendarKey("Gymnastics", { gender: "female" })).toBe(
+      "OTHER_WGYM",
+    );
+    expect(resolveCalendarKey("Gymnastics", { gender: "male" })).toBe("Other");
+    expect(resolveCalendarKey("Gymnastics", { gender: null })).toBe("Other");
+    expect(
+      resolveCalendarKey("Gymnastics", { gender: "prefer_not_to_say" }),
+    ).toBe("Other");
   });
 });

--- a/utils/metrics/canonical.ts
+++ b/utils/metrics/canonical.ts
@@ -7,7 +7,7 @@
  * `SPORT_POSITIONS` in `utils/positions/canonical.ts`.
  *
  * Sibling of the positions registry: a `Record<string, ...>` map plus pure
- * helper functions. Populated for all 17 sports.
+ * helper functions. Populated for all 19 sports.
  */
 
 export const OTHER_KEY = "other";
@@ -59,7 +59,7 @@ const def = (
 });
 
 /**
- * Central emoji per metric key across all 17 sports. Keeps every icon surface
+ * Central emoji per metric key across all 19 sports. Keeps every icon surface
  * sport-aware without a baseball-only branch. Mirrors iOS
  * `MetricRegistry.iconByKey` (SF Symbols there, emoji here — values are
  * intentionally per-platform). Unlisted keys fall back to `DEFAULT_ICON`.
@@ -143,6 +143,12 @@ const ICON_BY_KEY: Record<string, string> = {
   // Rowing
   erg_2k: "🚣",
   erg_split: "⏱️",
+  // Gymnastics (Beach Volleyball reuses the indoor volleyball keys above)
+  aa_score: "🤸",
+  vault_score: "🤸",
+  bars_score: "🤸",
+  beam_score: "🤸",
+  floor_score: "🤸",
   // Fallback bucket
   other: DEFAULT_ICON,
 };
@@ -284,6 +290,16 @@ const rowingDefs: MetricDef[] = [
   def("erg_split", "Erg Split", "", dur, true),
 ];
 
+// Gymnastics — judged event scores (higher is better). Women's four events plus
+// All-Around; men's-only events (pommel horse, rings, etc.) use "other".
+const gymnasticsDefs: MetricDef[] = [
+  def("aa_score", "All-Around Score", "", dec(3)),
+  def("vault_score", "Vault Score", "", dec(3)),
+  def("bars_score", "Bars Score", "", dec(3)),
+  def("beam_score", "Beam Score", "", dec(3)),
+  def("floor_score", "Floor Score", "", dec(3)),
+];
+
 // Shared across sports (goals/assists/saves/vertical_jump — one def each).
 const sharedDefs: MetricDef[] = [
   def("goals", "Goals", "count", int),
@@ -305,6 +321,7 @@ const allDefs: MetricDef[] = [
   ...tennisDefs,
   ...wrestlingDefs,
   ...rowingDefs,
+  ...gymnasticsDefs,
   ...sharedDefs,
   def(OTHER_KEY, "Other Metric", "", dec(2)),
 ];
@@ -385,6 +402,16 @@ export const SPORT_METRICS: Record<string, readonly string[]> = {
   "Field Hockey": ["goals", "assists", "saves"],
   Rowing: ["erg_2k", "erg_split"],
   "Water Polo": ["goals", "assists", "saves", "steals"],
+  Gymnastics: [
+    "aa_score",
+    "vault_score",
+    "bars_score",
+    "beam_score",
+    "floor_score",
+  ],
+  // Beach Volleyball reuses the indoor volleyball metric vocabulary (2-player
+  // game, same countable stats) — no new metric defs needed.
+  "Beach Volleyball": ["kills", "aces", "digs", "blocks", "hitting_pct"],
 };
 
 // MARK: Sport metric groups (log-picker section headers — 6 dense sports only)

--- a/utils/metrics/canonical.ts
+++ b/utils/metrics/canonical.ts
@@ -146,9 +146,13 @@ const ICON_BY_KEY: Record<string, string> = {
   // Gymnastics (Beach Volleyball reuses the indoor volleyball keys above)
   aa_score: "🤸",
   vault_score: "🤸",
+  floor_score: "🤸",
   bars_score: "🤸",
   beam_score: "🤸",
-  floor_score: "🤸",
+  pommel_score: "🤸",
+  rings_score: "🤸",
+  pbars_score: "🤸",
+  high_bar_score: "🤸",
   // Fallback bucket
   other: DEFAULT_ICON,
 };
@@ -290,14 +294,20 @@ const rowingDefs: MetricDef[] = [
   def("erg_split", "Erg Split", "", dur, true),
 ];
 
-// Gymnastics — judged event scores (higher is better). Women's four events plus
-// All-Around; men's-only events (pommel horse, rings, etc.) use "other".
+// Gymnastics — judged event scores (higher is better), All-Around plus every
+// artistic event. Vault + Floor Exercise are contested by both genders; Uneven
+// Bars/Balance Beam are women's-only; Pommel Horse/Still Rings/Parallel Bars/
+// High Bar are men's-only. All first-class so coaches recruit by event.
 const gymnasticsDefs: MetricDef[] = [
   def("aa_score", "All-Around Score", "", dec(3)),
   def("vault_score", "Vault Score", "", dec(3)),
-  def("bars_score", "Bars Score", "", dec(3)),
-  def("beam_score", "Beam Score", "", dec(3)),
-  def("floor_score", "Floor Score", "", dec(3)),
+  def("floor_score", "Floor Exercise Score", "", dec(3)),
+  def("bars_score", "Uneven Bars Score", "", dec(3)),
+  def("beam_score", "Balance Beam Score", "", dec(3)),
+  def("pommel_score", "Pommel Horse Score", "", dec(3)),
+  def("rings_score", "Still Rings Score", "", dec(3)),
+  def("pbars_score", "Parallel Bars Score", "", dec(3)),
+  def("high_bar_score", "High Bar Score", "", dec(3)),
 ];
 
 // Shared across sports (goals/assists/saves/vertical_jump — one def each).
@@ -405,9 +415,13 @@ export const SPORT_METRICS: Record<string, readonly string[]> = {
   Gymnastics: [
     "aa_score",
     "vault_score",
+    "floor_score",
     "bars_score",
     "beam_score",
-    "floor_score",
+    "pommel_score",
+    "rings_score",
+    "pbars_score",
+    "high_bar_score",
   ],
   // Beach Volleyball reuses the indoor volleyball metric vocabulary (2-player
   // game, same countable stats) — no new metric defs needed.

--- a/utils/positions/canonical.ts
+++ b/utils/positions/canonical.ts
@@ -89,6 +89,23 @@ export const SPORT_POSITIONS: Record<string, readonly string[]> = {
   Wrestling: ["Wrestler"],
   Rowing: ["Rower"],
   "Water Polo": ["Field Player", "Goalkeeper"],
+  // Gymnastics has "events", not positions; they differ by gender (women's vs
+  // men's artistic). One combined superset + All-Around serves both — coaches
+  // recruit by event specialty. Women's: Vault/Uneven Bars/Balance Beam/Floor;
+  // Men's: Floor/Pommel Horse/Still Rings/Vault/Parallel Bars/Horizontal Bar.
+  Gymnastics: [
+    "All-Around",
+    "Vault",
+    "Uneven Bars",
+    "Balance Beam",
+    "Floor Exercise",
+    "Pommel Horse",
+    "Still Rings",
+    "Parallel Bars",
+    "Horizontal Bar",
+  ],
+  // Beach Volleyball is a 2-player game with two roles, distinct from indoor.
+  "Beach Volleyball": ["Blocker", "Defender"],
 } as const;
 
 /**

--- a/utils/recruitingCalendar/calendarData.ts
+++ b/utils/recruitingCalendar/calendarData.ts
@@ -13,6 +13,7 @@
  * - p2-data-football-track.md           → FBS, FCS, XCTF
  * - p2-data-vball-golf-lacrosse.md      → WVB, MGO, MLA, WLA
  * - p2-data-other-d2.md                 → Other (D1 "All Other Sports"), D2_ALL
+ * - Other bundle PDF, re-read 2026-08-25 → OTHER_WGYM (women's gymnastics)
  *
  * Edge cases applied (locked, see plan):
  * - MBB "TBD" combine windows (NBA G League Combine, NBA Draft Combine, NBPA
@@ -68,7 +69,13 @@ const MBA: SportCalendar = {
       description: "Quiet period — in-person contact only on campus",
       confidence: "MEDIUM",
     },
-    { type: "contact", start: "2026-09-11", end: "2026-10-11", description: "Contact period", confidence: "MEDIUM" },
+    {
+      type: "contact",
+      start: "2026-09-11",
+      end: "2026-10-11",
+      description: "Contact period",
+      confidence: "MEDIUM",
+    },
     {
       type: "quiet",
       start: "2026-10-12",
@@ -81,14 +88,16 @@ const MBA: SportCalendar = {
       type: "dead",
       start: "2026-11-09",
       end: "2026-11-12",
-      description: "Dead period spanning the D1/D2 early signing period open (Nov 11, 2026)",
+      description:
+        "Dead period spanning the D1/D2 early signing period open (Nov 11, 2026)",
       confidence: "HIGH",
     },
     {
       type: "recruiting_shutdown",
       start: "2026-11-24",
       end: "2026-11-29",
-      description: "Thanksgiving recruiting shutdown — no contacts, evaluations, visits, or correspondence",
+      description:
+        "Thanksgiving recruiting shutdown — no contacts, evaluations, visits, or correspondence",
       confidence: "MEDIUM",
     },
     {
@@ -98,22 +107,36 @@ const MBA: SportCalendar = {
       description: "Winter-holiday recruiting shutdown",
       confidence: "MEDIUM",
     },
-    { type: "dead", start: "2027-01-07", end: "2027-01-10", description: "Dead period", confidence: "MEDIUM" },
+    {
+      type: "dead",
+      start: "2027-01-07",
+      end: "2027-01-10",
+      description: "Dead period",
+      confidence: "MEDIUM",
+    },
     {
       type: "contact",
       start: "2027-03-01",
       end: "2027-07-31",
-      description: "Contact period (spring/summer, season-long — interrupted by 3 dead periods)",
+      description:
+        "Contact period (spring/summer, season-long — interrupted by 3 dead periods)",
       confidence: "HIGH",
     },
     {
       type: "dead",
       start: "2027-05-31",
       end: "2027-06-07",
-      description: "Dead period (around College World Series selection/travel window)",
+      description:
+        "Dead period (around College World Series selection/travel window)",
       confidence: "MEDIUM",
     },
-    { type: "dead", start: "2027-06-19", end: "2027-06-21", description: "Dead period", confidence: "MEDIUM" },
+    {
+      type: "dead",
+      start: "2027-06-19",
+      end: "2027-06-21",
+      description: "Dead period",
+      confidence: "MEDIUM",
+    },
     {
       type: "dead",
       start: "2027-07-03",
@@ -140,7 +163,13 @@ const WSB: SportCalendar = {
   source: `${BUCKET}/${SEASON}D1Rec_WSBRecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
-    { type: "contact", start: "2026-08-01", end: "2026-08-09", description: "Contact Period", confidence: "HIGH" },
+    {
+      type: "contact",
+      start: "2026-08-01",
+      end: "2026-08-09",
+      description: "Contact Period",
+      confidence: "HIGH",
+    },
     {
       type: "evaluation",
       start: "2026-08-10",
@@ -153,7 +182,8 @@ const WSB: SportCalendar = {
       type: "dead",
       start: "2026-08-28",
       end: "2026-09-03",
-      description: "Dead Period (carved out of the Aug 10–Nov 22 evaluation window)",
+      description:
+        "Dead Period (carved out of the Aug 10–Nov 22 evaluation window)",
       confidence: "HIGH",
     },
     {
@@ -168,7 +198,8 @@ const WSB: SportCalendar = {
       type: "dead",
       start: "2026-11-09",
       end: "2026-11-12",
-      description: "Dead Period (carved out of the Oct17–Nov22 evaluation window)",
+      description:
+        "Dead Period (carved out of the Oct17–Nov22 evaluation window)",
       confidence: "HIGH",
     },
     {
@@ -186,7 +217,13 @@ const WSB: SportCalendar = {
       description: "Recruiting Shutdown",
       confidence: "HIGH",
     },
-    { type: "dead", start: "2026-12-09", end: "2026-12-12", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "dead",
+      start: "2026-12-09",
+      end: "2026-12-12",
+      description: "Dead Period",
+      confidence: "HIGH",
+    },
     {
       type: "recruiting_shutdown",
       start: "2026-12-22",
@@ -213,14 +250,16 @@ const WSB: SportCalendar = {
       type: "dead",
       start: "2027-06-01",
       end: "2027-06-11",
-      description: "Dead Period (WCWS-anchored; dates shift with WCWS schedule)",
+      description:
+        "Dead Period (WCWS-anchored; dates shift with WCWS schedule)",
       confidence: "HIGH",
     },
     {
       type: "contact",
       start: "2027-06-12",
       end: "2027-07-31",
-      description: "Contact Period (WCWS-anchored; begins the day after the dead period)",
+      description:
+        "Contact Period (WCWS-anchored; begins the day after the dead period)",
       confidence: "HIGH",
     },
   ],
@@ -234,8 +273,20 @@ const MBB: SportCalendar = {
   source: `${BUCKET}/${SEASON}D1Rec_MBBRecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
-    { type: "dead", start: "2026-08-01", end: "2026-08-19", description: "Dead Period", confidence: "HIGH" },
-    { type: "quiet", start: "2026-08-20", end: "2026-09-08", description: "Quiet Period", confidence: "HIGH" },
+    {
+      type: "dead",
+      start: "2026-08-01",
+      end: "2026-08-19",
+      description: "Dead Period",
+      confidence: "HIGH",
+    },
+    {
+      type: "quiet",
+      start: "2026-08-20",
+      end: "2026-09-08",
+      description: "Quiet Period",
+      confidence: "HIGH",
+    },
     {
       type: "contact",
       start: "2026-09-09",
@@ -248,21 +299,24 @@ const MBB: SportCalendar = {
       type: "dead",
       start: "2026-11-09",
       end: "2026-11-12",
-      description: "Dead Period (carved out of the Sep9–Apr30 recruiting period)",
+      description:
+        "Dead Period (carved out of the Sep9–Apr30 recruiting period)",
       confidence: "HIGH",
     },
     {
       type: "dead",
       start: "2026-12-24",
       end: "2026-12-26",
-      description: "Dead Period (carved out of the Sep9–Apr30 recruiting period)",
+      description:
+        "Dead Period (carved out of the Sep9–Apr30 recruiting period)",
       confidence: "HIGH",
     },
     {
       type: "dead",
       start: "2027-04-01",
       end: "2027-04-08",
-      description: "Dead Period (carved out of the Sep9–Apr30 recruiting period)",
+      description:
+        "Dead Period (carved out of the Sep9–Apr30 recruiting period)",
       confidence: "HIGH",
     },
     {
@@ -277,7 +331,13 @@ const MBB: SportCalendar = {
     // NBA Draft Combine (evaluation, PDF shows "TBD"), NBPA Top 100 Camp (evaluation,
     // PDF shows "TBD") — no concrete dates published; 2025-26 equivalents were May 8–10,
     // May 10–17, and Jun 10–11 respectively but the 2026-27 PDF gives no date to transcribe.
-    { type: "dead", start: "2027-05-09", end: "2027-05-09", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "dead",
+      start: "2027-05-09",
+      end: "2027-05-09",
+      description: "Dead Period",
+      confidence: "HIGH",
+    },
     {
       type: "evaluation",
       start: "2027-05-14",
@@ -286,20 +346,34 @@ const MBB: SportCalendar = {
         "Evaluation Period — NCAA certified events only and regularly scheduled international scholastic/nonscholastic team practice and competition; begins Friday 8 AM, ends Sunday 4 PM",
       confidence: "HIGH",
     },
-    { type: "dead", start: "2027-05-26", end: "2027-06-06", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "dead",
+      start: "2027-05-26",
+      end: "2027-06-06",
+      description: "Dead Period",
+      confidence: "HIGH",
+    },
     {
       type: "evaluation",
       start: "2027-06-11",
       end: "2027-06-13",
-      description: "Evaluation Period — for approved NCAA, NFHS and applicable two-year college governing body scholastic events",
+      description:
+        "Evaluation Period — for approved NCAA, NFHS and applicable two-year college governing body scholastic events",
       confidence: "HIGH",
     },
-    { type: "dead", start: "2027-06-19", end: "2027-06-20", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "dead",
+      start: "2027-06-19",
+      end: "2027-06-20",
+      description: "Dead Period",
+      confidence: "HIGH",
+    },
     {
       type: "evaluation",
       start: "2027-06-25",
       end: "2027-06-27",
-      description: "Evaluation Period — for approved NCAA, NFHS and applicable two-year college governing body scholastic events",
+      description:
+        "Evaluation Period — for approved NCAA, NFHS and applicable two-year college governing body scholastic events",
       confidence: "HIGH",
     },
     {
@@ -318,9 +392,27 @@ const MBB: SportCalendar = {
         "Evaluation Period (active only Jul 8–11 and Jul 15–18, carved out of the Jul1–31 dead period) — NCAA certified events, institutional camps, permissible governing body events, and regularly scheduled international scholastic/nonscholastic team practice and competition; begins Thursday 8 AM, ends Sunday 6 PM",
       confidence: "HIGH",
     },
-    { type: "quiet", start: "2027-07-19", end: "2027-07-25", description: "Quiet Period", confidence: "HIGH" },
-    { type: "dead", start: "2027-08-01", end: "2027-08-18", description: "Dead Period", confidence: "HIGH" },
-    { type: "quiet", start: "2027-08-19", end: "2027-08-31", description: "Quiet Period", confidence: "HIGH" },
+    {
+      type: "quiet",
+      start: "2027-07-19",
+      end: "2027-07-25",
+      description: "Quiet Period",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2027-08-01",
+      end: "2027-08-18",
+      description: "Dead Period",
+      confidence: "HIGH",
+    },
+    {
+      type: "quiet",
+      start: "2027-08-19",
+      end: "2027-08-31",
+      description: "Quiet Period",
+      confidence: "HIGH",
+    },
   ],
   milestones: [],
 };
@@ -336,7 +428,8 @@ const WBB: SportCalendar = {
       type: "quiet",
       start: "2026-08-01",
       end: "2026-08-31",
-      description: "Quiet Period; contains a carved-out Recruiting Shutdown Aug 10–16",
+      description:
+        "Quiet Period; contains a carved-out Recruiting Shutdown Aug 10–16",
       confidence: "HIGH",
     },
     {
@@ -358,14 +451,16 @@ const WBB: SportCalendar = {
       type: "evaluation",
       start: "2026-10-01",
       end: "2027-02-28",
-      description: "Evaluation Period — scholastic activities only; contains a carved-out Dead Period Dec 24–26",
+      description:
+        "Evaluation Period — scholastic activities only; contains a carved-out Dead Period Dec 24–26",
       confidence: "HIGH",
     },
     {
       type: "dead",
       start: "2026-12-24",
       end: "2026-12-26",
-      description: "Dead Period (carved out of the Oct1–Feb28 evaluation period)",
+      description:
+        "Dead Period (carved out of the Oct1–Feb28 evaluation period)",
       confidence: "HIGH",
     },
     {
@@ -376,7 +471,13 @@ const WBB: SportCalendar = {
         "Contact Period — for seniors and two-year college PSAs only; evaluation period for other PSAs for scholastic activities only",
       confidence: "HIGH",
     },
-    { type: "dead", start: "2027-04-01", end: "2027-04-05", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "dead",
+      start: "2027-04-01",
+      end: "2027-04-05",
+      description: "Dead Period",
+      confidence: "HIGH",
+    },
     {
       type: "quiet",
       start: "2027-04-06",
@@ -389,7 +490,8 @@ const WBB: SportCalendar = {
       type: "dead",
       start: "2027-04-22",
       end: "2027-04-22",
-      description: "Dead Period — for high school and two-year college PSAs only",
+      description:
+        "Dead Period — for high school and two-year college PSAs only",
       confidence: "HIGH",
     },
     {
@@ -403,7 +505,8 @@ const WBB: SportCalendar = {
       type: "dead",
       start: "2027-04-26",
       end: "2027-04-26",
-      description: "Dead Period — for high school and two-year college PSAs only",
+      description:
+        "Dead Period — for high school and two-year college PSAs only",
       confidence: "HIGH",
     },
     {
@@ -413,7 +516,13 @@ const WBB: SportCalendar = {
       description: "Recruiting Shutdown",
       confidence: "HIGH",
     },
-    { type: "dead", start: "2027-05-13", end: "2027-05-13", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "dead",
+      start: "2027-05-13",
+      end: "2027-05-13",
+      description: "Dead Period",
+      confidence: "HIGH",
+    },
     {
       type: "evaluation",
       start: "2027-05-14",
@@ -421,12 +530,19 @@ const WBB: SportCalendar = {
       description: "Evaluation Period — certified nonscholastic events only",
       confidence: "HIGH",
     },
-    { type: "dead", start: "2027-05-17", end: "2027-05-17", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "dead",
+      start: "2027-05-17",
+      end: "2027-05-17",
+      description: "Dead Period",
+      confidence: "HIGH",
+    },
     {
       type: "dead",
       start: "2027-06-16",
       end: "2027-06-16",
-      description: "Dead Period (separate single-day window from May 17, same legend row grouping)",
+      description:
+        "Dead Period (separate single-day window from May 17, same legend row grouping)",
       confidence: "HIGH",
     },
     {
@@ -437,25 +553,57 @@ const WBB: SportCalendar = {
         "Evaluation Period (begins Jun 17 @ noon, ends Jun 19 @ 6 PM) — for scholastic events approved by the NCAA and NFHS and intercollegiate events approved by applicable two-year college governing body only",
       confidence: "HIGH",
     },
-    { type: "dead", start: "2027-06-20", end: "2027-06-20", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "dead",
+      start: "2027-06-20",
+      end: "2027-06-20",
+      description: "Dead Period",
+      confidence: "HIGH",
+    },
     {
       type: "dead",
       start: "2027-07-08",
       end: "2027-07-08",
-      description: "Dead Period (separate single-day window from Jun 20, same legend row grouping)",
+      description:
+        "Dead Period (separate single-day window from Jun 20, same legend row grouping)",
       confidence: "HIGH",
     },
-    { type: "evaluation", start: "2027-07-09", end: "2027-07-12", description: "Evaluation Period", confidence: "HIGH" },
-    { type: "dead", start: "2027-07-13", end: "2027-07-13", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "evaluation",
+      start: "2027-07-09",
+      end: "2027-07-12",
+      description: "Evaluation Period",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2027-07-13",
+      end: "2027-07-13",
+      description: "Dead Period",
+      confidence: "HIGH",
+    },
     {
       type: "dead",
       start: "2027-07-22",
       end: "2027-07-22",
-      description: "Dead Period (separate single-day window from Jul 13, same legend row grouping)",
+      description:
+        "Dead Period (separate single-day window from Jul 13, same legend row grouping)",
       confidence: "HIGH",
     },
-    { type: "evaluation", start: "2027-07-23", end: "2027-07-26", description: "Evaluation Period", confidence: "HIGH" },
-    { type: "dead", start: "2027-07-27", end: "2027-07-27", description: "Dead Period", confidence: "HIGH" },
+    {
+      type: "evaluation",
+      start: "2027-07-23",
+      end: "2027-07-26",
+      description: "Evaluation Period",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2027-07-27",
+      end: "2027-07-27",
+      description: "Dead Period",
+      confidence: "HIGH",
+    },
   ],
   milestones: [],
 };
@@ -467,7 +615,13 @@ const FBS: SportCalendar = {
   source: `${BUCKET}/${SEASON}D1Rec_FBSRecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
-    { type: "dead", start: "2026-08-01", end: "2026-08-31", description: "Dead Period — full month of August", confidence: "HIGH" },
+    {
+      type: "dead",
+      start: "2026-08-01",
+      end: "2026-08-31",
+      description: "Dead Period — full month of August",
+      confidence: "HIGH",
+    },
     {
       type: "quiet",
       start: "2026-08-01",
@@ -488,7 +642,8 @@ const FBS: SportCalendar = {
       type: "dead",
       start: "2026-11-30",
       end: "2026-12-31",
-      description: "Dead Period (encompasses the Dec 2–4, 2026 early signing period)",
+      description:
+        "Dead Period (encompasses the Dec 2–4, 2026 early signing period)",
       confidence: "HIGH",
     },
   ],
@@ -497,13 +652,15 @@ const FBS: SportCalendar = {
       date: "2026-12-02",
       title: "Early Signing Period Opens (Football)",
       type: "signing",
-      description: "Early signing period, Dec 2–4, 2026 — falls inside the FBS Nov30–Dec31 Dead Period",
+      description:
+        "Early signing period, Dec 2–4, 2026 — falls inside the FBS Nov30–Dec31 Dead Period",
     },
     {
       date: "2027-02-03",
       title: "Regular (National) Signing Day (Football)",
       type: "signing",
-      description: "First Wednesday of February; no NCAA-wide end date — varies by institution's own scholarship-award policy",
+      description:
+        "First Wednesday of February; no NCAA-wide end date — varies by institution's own scholarship-award policy",
     },
   ],
 };
@@ -515,7 +672,13 @@ const FCS: SportCalendar = {
   source: `${BUCKET}/${SEASON}D1Rec_FCSRecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
-    { type: "dead", start: "2026-08-01", end: "2026-08-31", description: "Dead Period — full month of August", confidence: "HIGH" },
+    {
+      type: "dead",
+      start: "2026-08-01",
+      end: "2026-08-31",
+      description: "Dead Period — full month of August",
+      confidence: "HIGH",
+    },
     {
       type: "quiet",
       start: "2026-08-01",
@@ -536,24 +699,33 @@ const FCS: SportCalendar = {
       type: "dead",
       start: "2026-11-30",
       end: "2026-12-03",
-      description: "Dead Period (immediately precedes/covers start of early signing period)",
+      description:
+        "Dead Period (immediately precedes/covers start of early signing period)",
       confidence: "HIGH",
     },
     {
       type: "contact",
       start: "2026-12-04",
       end: "2026-12-18",
-      description: "Contact Period (opens the day after early signing starts, in-person off-campus contact permitted)",
+      description:
+        "Contact Period (opens the day after early signing starts, in-person off-campus contact permitted)",
       confidence: "HIGH",
     },
     {
       type: "quiet",
       start: "2026-12-18",
       end: "2026-12-20",
-      description: "Quiet Period (short transition window before year-end dead period)",
+      description:
+        "Quiet Period (short transition window before year-end dead period)",
       confidence: "HIGH",
     },
-    { type: "dead", start: "2026-12-21", end: "2026-12-31", description: "Dead Period (year-end)", confidence: "HIGH" },
+    {
+      type: "dead",
+      start: "2026-12-21",
+      end: "2026-12-31",
+      description: "Dead Period (year-end)",
+      confidence: "HIGH",
+    },
   ],
   milestones: [
     {
@@ -591,21 +763,24 @@ const XCTF: SportCalendar = {
       type: "dead",
       start: "2026-11-09",
       end: "2026-11-12",
-      description: "Dead Period (carve-out within the Aug1–Dec13 Contact window; likely NCAA XC Championships week)",
+      description:
+        "Dead Period (carve-out within the Aug1–Dec13 Contact window; likely NCAA XC Championships week)",
       confidence: "HIGH",
     },
     {
       type: "dead",
       start: "2026-11-21",
       end: "2026-11-21",
-      description: "Dead Period, single day (carve-out within the same Contact window)",
+      description:
+        "Dead Period, single day (carve-out within the same Contact window)",
       confidence: "HIGH",
     },
     {
       type: "dead",
       start: "2026-12-14",
       end: "2026-12-26",
-      description: "Dead Period — holiday dead period, between the two long Contact windows",
+      description:
+        "Dead Period — holiday dead period, between the two long Contact windows",
       confidence: "HIGH",
     },
     {
@@ -620,14 +795,16 @@ const XCTF: SportCalendar = {
       type: "dead",
       start: "2027-03-12",
       end: "2027-03-13",
-      description: "Dead Period (carve-out; likely NCAA Indoor T&F Championships week)",
+      description:
+        "Dead Period (carve-out; likely NCAA Indoor T&F Championships week)",
       confidence: "HIGH",
     },
     {
       type: "dead",
       start: "2027-06-09",
       end: "2027-06-12",
-      description: "Dead Period (carve-out; likely NCAA Outdoor T&F Championships week)",
+      description:
+        "Dead Period (carve-out; likely NCAA Outdoor T&F Championships week)",
       confidence: "HIGH",
     },
   ],
@@ -641,19 +818,27 @@ const WVB: SportCalendar = {
   source: `${BUCKET}/${SEASON}D1Rec_WVBRecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
-    { type: "quiet", start: "2026-08-01", end: "2026-08-31", description: "Quiet Period — in-person contact only on campus", confidence: "MEDIUM" },
+    {
+      type: "quiet",
+      start: "2026-08-01",
+      end: "2026-08-31",
+      description: "Quiet Period — in-person contact only on campus",
+      confidence: "MEDIUM",
+    },
     {
       type: "contact",
       start: "2026-09-01",
       end: "2026-11-30",
-      description: "Contact Period — off-campus in-person contact/evaluation permitted",
+      description:
+        "Contact Period — off-campus in-person contact/evaluation permitted",
       confidence: "MEDIUM",
     },
     {
       type: "dead",
       start: "2026-11-09",
       end: "2026-11-12",
-      description: "Dead Period — no contact/evaluation/visits, nested inside the Sep–Nov contact window",
+      description:
+        "Dead Period — no contact/evaluation/visits, nested inside the Sep–Nov contact window",
       confidence: "HIGH",
     },
     {
@@ -676,16 +861,59 @@ const WVB: SportCalendar = {
       type: "contact",
       start: "2027-01-15",
       end: "2027-07-31",
-      description: "Contact Period — off-campus in-person contact/evaluation permitted, minus 6 quiet-period carve-outs",
+      description:
+        "Contact Period — off-campus in-person contact/evaluation permitted, minus 6 quiet-period carve-outs",
       confidence: "MEDIUM",
     },
-    { type: "quiet", start: "2027-03-01", end: "2027-03-04", description: "Quiet Period (carve-out within the Jan–Jul contact window)", confidence: "MEDIUM" },
-    { type: "quiet", start: "2027-03-08", end: "2027-03-11", description: "Quiet Period (carve-out)", confidence: "MEDIUM" },
-    { type: "quiet", start: "2027-03-15", end: "2027-03-18", description: "Quiet Period (carve-out)", confidence: "MEDIUM" },
-    { type: "quiet", start: "2027-03-22", end: "2027-03-25", description: "Quiet Period (carve-out)", confidence: "MEDIUM" },
-    { type: "quiet", start: "2027-03-29", end: "2027-04-01", description: "Quiet Period (carve-out)", confidence: "MEDIUM" },
-    { type: "quiet", start: "2027-04-05", end: "2027-04-08", description: "Quiet Period (carve-out)", confidence: "MEDIUM" },
-    { type: "quiet", start: "2027-05-01", end: "2027-06-03", description: "Quiet Period (carve-out; final one of the year)", confidence: "MEDIUM" },
+    {
+      type: "quiet",
+      start: "2027-03-01",
+      end: "2027-03-04",
+      description: "Quiet Period (carve-out within the Jan–Jul contact window)",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "quiet",
+      start: "2027-03-08",
+      end: "2027-03-11",
+      description: "Quiet Period (carve-out)",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "quiet",
+      start: "2027-03-15",
+      end: "2027-03-18",
+      description: "Quiet Period (carve-out)",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "quiet",
+      start: "2027-03-22",
+      end: "2027-03-25",
+      description: "Quiet Period (carve-out)",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "quiet",
+      start: "2027-03-29",
+      end: "2027-04-01",
+      description: "Quiet Period (carve-out)",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "quiet",
+      start: "2027-04-05",
+      end: "2027-04-08",
+      description: "Quiet Period (carve-out)",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "quiet",
+      start: "2027-05-01",
+      end: "2027-06-03",
+      description: "Quiet Period (carve-out; final one of the year)",
+      confidence: "MEDIUM",
+    },
   ],
   milestones: [],
 };
@@ -697,7 +925,13 @@ const MGO: SportCalendar = {
   source: `${BUCKET}/${SEASON}D1Rec_MGORecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
-    { type: "contact", start: "2026-08-01", end: "2026-11-25", description: "Contact Period", confidence: "MEDIUM" },
+    {
+      type: "contact",
+      start: "2026-08-01",
+      end: "2026-11-25",
+      description: "Contact Period",
+      confidence: "MEDIUM",
+    },
     {
       type: "dead",
       start: "2026-11-09",
@@ -753,14 +987,33 @@ const MLA: SportCalendar = {
   source: `${BUCKET}/${SEASON}D1Rec_MLARecruitingCalendar.pdf`,
   verifiedOn: VERIFIED_ON,
   periods: [
-    { type: "contact", start: "2026-08-01", end: "2026-08-03", description: "Contact Period", confidence: "MEDIUM" },
-    { type: "quiet", start: "2026-08-04", end: "2026-08-10", description: "Quiet Period", confidence: "MEDIUM" },
-    { type: "dead", start: "2026-08-11", end: "2026-08-31", description: "Dead Period", confidence: "MEDIUM" },
+    {
+      type: "contact",
+      start: "2026-08-01",
+      end: "2026-08-03",
+      description: "Contact Period",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "quiet",
+      start: "2026-08-04",
+      end: "2026-08-10",
+      description: "Quiet Period",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "dead",
+      start: "2026-08-11",
+      end: "2026-08-31",
+      description: "Dead Period",
+      confidence: "MEDIUM",
+    },
     {
       type: "contact",
       start: "2026-09-01",
       end: "2026-10-31",
-      description: 'Contact Period — footnoted "No lacrosse evaluations" for the entire month range',
+      description:
+        'Contact Period — footnoted "No lacrosse evaluations" for the entire month range',
       confidence: "MEDIUM",
     },
     {
@@ -778,7 +1031,13 @@ const MLA: SportCalendar = {
       description: "Dead Period nested inside the Nov 1–22 contact window",
       confidence: "HIGH",
     },
-    { type: "dead", start: "2026-11-23", end: "2026-11-29", description: "Dead Period — Thanksgiving week", confidence: "HIGH" },
+    {
+      type: "dead",
+      start: "2026-11-23",
+      end: "2026-11-29",
+      description: "Dead Period — Thanksgiving week",
+      confidence: "HIGH",
+    },
     {
       type: "quiet",
       start: "2026-11-30",
@@ -808,12 +1067,19 @@ const MLA: SportCalendar = {
       description: 'Contact Period — footnoted "No lacrosse evaluations"',
       confidence: "MEDIUM",
     },
-    { type: "quiet", start: "2027-01-19", end: "2027-02-28", description: "Quiet Period", confidence: "MEDIUM" },
+    {
+      type: "quiet",
+      start: "2027-01-19",
+      end: "2027-02-28",
+      description: "Quiet Period",
+      confidence: "MEDIUM",
+    },
     {
       type: "contact",
       start: "2027-03-01",
       end: "2027-05-27",
-      description: "Contact Period (no evaluation-blocking footnote — full evaluation allowed, unlike the fall/Jan contact windows)",
+      description:
+        "Contact Period (no evaluation-blocking footnote — full evaluation allowed, unlike the fall/Jan contact windows)",
       confidence: "MEDIUM",
     },
     {
@@ -829,7 +1095,8 @@ const MLA: SportCalendar = {
       type: "contact",
       start: "2027-06-01",
       end: "2027-07-31",
-      description: 'Contact Period — "JUN 1 @ NOON – JUL 31" (effective noon), minus the Jul 1–10 dead-period carve-out',
+      description:
+        'Contact Period — "JUN 1 @ NOON – JUL 31" (effective noon), minus the Jul 1–10 dead-period carve-out',
       confidence: "MEDIUM",
     },
     {
@@ -855,11 +1122,24 @@ const WLA: SportCalendar = {
       type: "recruiting_shutdown",
       start: "2026-08-01",
       end: "2026-08-14",
-      description: "Recruiting Shutdown — no contacts, evaluations, visits, correspondence, or calls permitted",
+      description:
+        "Recruiting Shutdown — no contacts, evaluations, visits, correspondence, or calls permitted",
       confidence: "MEDIUM",
     },
-    { type: "quiet", start: "2026-08-15", end: "2026-08-27", description: "Quiet Period", confidence: "MEDIUM" },
-    { type: "dead", start: "2026-08-28", end: "2026-09-03", description: "Dead Period", confidence: "MEDIUM" },
+    {
+      type: "quiet",
+      start: "2026-08-15",
+      end: "2026-08-27",
+      description: "Quiet Period",
+      confidence: "MEDIUM",
+    },
+    {
+      type: "dead",
+      start: "2026-08-28",
+      end: "2026-09-03",
+      description: "Dead Period",
+      confidence: "MEDIUM",
+    },
     {
       type: "contact",
       start: "2026-09-04",
@@ -872,28 +1152,32 @@ const WLA: SportCalendar = {
       type: "evaluation",
       start: "2026-11-06",
       end: "2026-11-08",
-      description: "Evaluation Period — first of three pre-Thanksgiving weekends, 5 PM Friday – Sunday",
+      description:
+        "Evaluation Period — first of three pre-Thanksgiving weekends, 5 PM Friday – Sunday",
       confidence: "HIGH",
     },
     {
       type: "dead",
       start: "2026-11-09",
       end: "2026-11-12",
-      description: "Dead Period nested between the first and second pre-Thanksgiving evaluation weekends",
+      description:
+        "Dead Period nested between the first and second pre-Thanksgiving evaluation weekends",
       confidence: "HIGH",
     },
     {
       type: "evaluation",
       start: "2026-11-13",
       end: "2026-11-15",
-      description: "Evaluation Period — second pre-Thanksgiving weekend, 5 PM Friday – Sunday",
+      description:
+        "Evaluation Period — second pre-Thanksgiving weekend, 5 PM Friday – Sunday",
       confidence: "HIGH",
     },
     {
       type: "dead",
       start: "2026-11-18",
       end: "2026-11-20",
-      description: "Dead Period — ends on the 20th when IWLCA Convention adjourns",
+      description:
+        "Dead Period — ends on the 20th when IWLCA Convention adjourns",
       confidence: "HIGH",
     },
     {
@@ -915,14 +1199,16 @@ const WLA: SportCalendar = {
       type: "contact",
       start: "2026-12-01",
       end: "2026-12-30",
-      description: "Contact Period — subject to Bylaw 13.1.7.3.1, minus the Dec 22–26 shutdown carve-out",
+      description:
+        "Contact Period — subject to Bylaw 13.1.7.3.1, minus the Dec 22–26 shutdown carve-out",
       confidence: "MEDIUM",
     },
     {
       type: "recruiting_shutdown",
       start: "2026-12-22",
       end: "2026-12-26",
-      description: "Recruiting Shutdown — Christmas window, nested inside the Dec 1–30 contact period",
+      description:
+        "Recruiting Shutdown — Christmas window, nested inside the Dec 1–30 contact period",
       confidence: "HIGH",
     },
     {
@@ -939,7 +1225,13 @@ const WLA: SportCalendar = {
       description: "Contact Period — subject to Bylaw 13.1.7.3.1",
       confidence: "MEDIUM",
     },
-    { type: "dead", start: "2027-05-28", end: "2027-05-30", description: "Dead Period", confidence: "MEDIUM" },
+    {
+      type: "dead",
+      start: "2027-05-28",
+      end: "2027-05-30",
+      description: "Dead Period",
+      confidence: "MEDIUM",
+    },
     {
       type: "contact",
       start: "2027-05-31",
@@ -959,7 +1251,8 @@ const WLA: SportCalendar = {
       type: "dead",
       start: "2027-07-02",
       end: "2027-07-06",
-      description: "Dead Period carve-out inside the Jun 11–Jul 31 evaluation window",
+      description:
+        "Dead Period carve-out inside the Jun 11–Jul 31 evaluation window",
       confidence: "MEDIUM",
     },
   ],
@@ -976,10 +1269,11 @@ const OTHER_SOURCE = `${BUCKET}/${OTHER_SEASON_EN_DASH}D1Rec_OtherRecruitingCale
 // ---------------------------------------------------------------------------
 // Other — Division I "All Other Sports" generic default. Used for app
 // sports with no dedicated NCAA recruiting calendar AND no sport-specific
-// windows enumerated in the "Other" bundle PDF: Tennis, Water Polo, and
-// non-male Golf. Soccer, Swimming, Ice Hockey, Rowing, Field Hockey, and
-// Wrestling have their own OTHER_* sub-calendars below (transcribed from the
-// same PDF) instead of falling back to this generic default.
+// windows enumerated in the "Other" bundle PDF: Tennis, Water Polo, non-male
+// Golf, Beach Volleyball, and men's Gymnastics. Soccer, Swimming, Ice Hockey,
+// Rowing, Field Hockey, Wrestling, and women's Gymnastics have their own OTHER_*
+// sub-calendars below (transcribed from the same PDF) instead of falling back to
+// this generic default.
 // ---------------------------------------------------------------------------
 const OTHER: SportCalendar = {
   source: OTHER_SOURCE,
@@ -1082,7 +1376,8 @@ const OTHER_SWIM: SportCalendar = {
       type: "recruiting_shutdown",
       start: "2026-08-17",
       end: "2026-08-23",
-      description: "Recruiting Shutdown — the third Monday in August through the following Sunday",
+      description:
+        "Recruiting Shutdown — the third Monday in August through the following Sunday",
       confidence: "HIGH",
     },
     {
@@ -1208,7 +1503,8 @@ const OTHER_FIELDHOCKEY: SportCalendar = {
       type: "recruiting_shutdown",
       start: "2026-12-24",
       end: "2027-01-01",
-      description: "Recruiting Shutdown (label only; no detail text on source card)",
+      description:
+        "Recruiting Shutdown (label only; no detail text on source card)",
       confidence: "HIGH",
     },
   ],
@@ -1238,7 +1534,8 @@ const OTHER_MWRESTLING: SportCalendar = {
       type: "recruiting_shutdown",
       start: "2027-03-16",
       end: "2027-03-21",
-      description: "Recruiting Shutdown — Tuesday through Sunday of the NCAA Division I Wrestling Championships",
+      description:
+        "Recruiting Shutdown — Tuesday through Sunday of the NCAA Division I Wrestling Championships",
       confidence: "HIGH",
     },
   ],
@@ -1273,6 +1570,74 @@ const OTHER_WWRESTLING: SportCalendar = {
   milestones: [],
 };
 
+// ---------------------------------------------------------------------------
+// OTHER_WGYM — Women's Gymnastics. Enumerated as its own table in the D1 "Other"
+// bundle PDF (unlike Beach Volleyball and Men's Gymnastics, which the PDF folds
+// into "All Other Sports" — they stay on the generic OTHER default). Transcribed
+// 2026-08-25 directly from the live PDF (source "Updated: August 4, 2026").
+// ---------------------------------------------------------------------------
+const OTHER_WGYM: SportCalendar = {
+  source: OTHER_SOURCE,
+  verifiedOn: "2026-08-25",
+  periods: [
+    {
+      type: "dead",
+      start: "2026-11-09",
+      end: "2026-11-12",
+      description:
+        "Dead Period — Monday through Thursday of the initial week for the fall signing date for athletics aid agreements",
+      confidence: "HIGH",
+    },
+    {
+      type: "recruiting_shutdown",
+      start: "2026-11-26",
+      end: "2026-11-29",
+      description:
+        "Recruiting Shutdown — Thanksgiving Day to the Sunday after Thanksgiving",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2026-12-01",
+      end: "2026-12-30",
+      description: "Dead Period, Dec 1–30 (label only)",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2027-04-14",
+      end: "2027-04-18",
+      description:
+        "Dead Period — The day before the first day of the National Collegiate Gymnastics Championships to noon on the day after the championships (effective noon)",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2027-05-11",
+      end: "2027-05-13",
+      description:
+        "Dead Period — The first day to last day of the coaches association convention",
+      confidence: "HIGH",
+    },
+    {
+      type: "quiet",
+      start: "2027-05-17",
+      end: "2027-05-23",
+      description:
+        "Quiet Period — Monday to Sunday after the USA Gymnastics Developmental Nationals",
+      confidence: "HIGH",
+    },
+    {
+      type: "dead",
+      start: "2027-06-01",
+      end: "2027-06-15",
+      description: "Dead Period, Jun 1–15 (label only)",
+      confidence: "HIGH",
+    },
+  ],
+  milestones: [],
+};
+
 export const D1_CALENDARS: Record<NcaaCalendarKey, SportCalendar> = {
   MBA,
   WSB,
@@ -1295,6 +1660,7 @@ export const D1_CALENDARS: Record<NcaaCalendarKey, SportCalendar> = {
   OTHER_FIELDHOCKEY,
   OTHER_MWRESTLING,
   OTHER_WWRESTLING,
+  OTHER_WGYM,
 };
 
 // ---------------------------------------------------------------------------

--- a/utils/recruitingCalendar/resolver.ts
+++ b/utils/recruitingCalendar/resolver.ts
@@ -1,6 +1,17 @@
-import type { AppSport, CalendarMilestone, Division, NcaaCalendarKey, RecruitingPeriod, SportCalendar } from "./types";
+import type {
+  AppSport,
+  CalendarMilestone,
+  Division,
+  NcaaCalendarKey,
+  RecruitingPeriod,
+  SportCalendar,
+} from "./types";
 import { D1_CALENDARS, D2_ALL_SPORTS, D3_FALLBACK } from "./calendarData";
-import { parseLocalDateOnly, exclusiveEndOfDay, formatLocalDateOnly } from "~/utils/localDate";
+import {
+  parseLocalDateOnly,
+  exclusiveEndOfDay,
+  formatLocalDateOnly,
+} from "~/utils/localDate";
 import {
   SAT_TEST_DATES_2026,
   ACT_TEST_DATES_2026,
@@ -42,7 +53,9 @@ const SINGLE_CALENDAR_SPORTS: Partial<Record<AppSport, NcaaCalendarKey>> = {
  * Exported so UI callers (e.g. `RecruitingCalendar.vue`'s men's/women's
  * toggle) can reuse this exact set instead of keeping a duplicate in sync.
  */
-export const GENDER_SPLIT_SPORTS: Partial<Record<AppSport, { men: NcaaCalendarKey; women: NcaaCalendarKey }>> = {
+export const GENDER_SPLIT_SPORTS: Partial<
+  Record<AppSport, { men: NcaaCalendarKey; women: NcaaCalendarKey }>
+> = {
   Basketball: { men: "MBB", women: "WBB" },
   Lacrosse: { men: "MLA", women: "WLA" },
   Soccer: { men: "OTHER_MSOCCER", women: "OTHER_WSOCCER" },
@@ -61,7 +74,8 @@ export const GENDER_SPLIT_SPORTS: Partial<Record<AppSport, { men: NcaaCalendarKe
  */
 export const NO_SPORT_FALLBACK: AppSport = "Tennis";
 
-const isMen = (gender: string | null | undefined): boolean => (gender ?? "").toLowerCase() !== "female";
+const isMen = (gender: string | null | undefined): boolean =>
+  (gender ?? "").toLowerCase() !== "female";
 
 /**
  * Maps an app sport (plus optional gender/football-subdivision context) to
@@ -70,7 +84,10 @@ const isMen = (gender: string | null | undefined): boolean => (gender ?? "").toL
  * Gender defaults to men's whenever the sport is gender-split and gender is
  * null, unspecified, "other", or "prefer_not_to_say".
  */
-export function resolveCalendarKey(sport: AppSport, opts?: ResolveCalendarKeyOptions): NcaaCalendarKey {
+export function resolveCalendarKey(
+  sport: AppSport,
+  opts?: ResolveCalendarKeyOptions,
+): NcaaCalendarKey {
   const gender = opts?.gender;
 
   if (sport === "Football") {
@@ -91,9 +108,9 @@ export function resolveCalendarKey(sport: AppSport, opts?: ResolveCalendarKeyOpt
     return single;
   }
 
-  // Any remaining AppSport (currently: Tennis, Water Polo) has no published
-  // NCAA recruiting calendar and no sport-specific windows in the "Other"
-  // bundle — falls to the generic "Other" default.
+  // Any remaining AppSport (currently: Tennis, Water Polo, Gymnastics, Beach
+  // Volleyball) has no published NCAA recruiting calendar and no sport-specific
+  // windows in the "Other" bundle — falls to the generic "Other" default.
   return "Other";
 }
 
@@ -125,10 +142,16 @@ export function getSportCalendar(
  * correspondence either — but both block contact, which is what
  * `isDeadPeriod` answers).
  */
-const BLOCKING_TYPES: ReadonlySet<RecruitingPeriod["type"]> = new Set(["dead", "recruiting_shutdown"]);
+const BLOCKING_TYPES: ReadonlySet<RecruitingPeriod["type"]> = new Set([
+  "dead",
+  "recruiting_shutdown",
+]);
 
 function isWithinPeriod(date: Date, period: RecruitingPeriod): boolean {
-  return date >= parseLocalDateOnly(period.start) && date < exclusiveEndOfDay(period.end);
+  return (
+    date >= parseLocalDateOnly(period.start) &&
+    date < exclusiveEndOfDay(period.end)
+  );
 }
 
 /** True if `date` falls within a dead (or recruiting-shutdown) period for `sport`/`division`. */
@@ -139,7 +162,9 @@ export function isDeadPeriod(
   opts?: ResolveCalendarKeyOptions,
 ): boolean {
   const calendar = getSportCalendar(sport, division, opts);
-  return calendar.periods.some((period) => BLOCKING_TYPES.has(period.type) && isWithinPeriod(date, period));
+  return calendar.periods.some(
+    (period) => BLOCKING_TYPES.has(period.type) && isWithinPeriod(date, period),
+  );
 }
 
 /** True if `date` falls within a quiet period for `sport`/`division`. */
@@ -150,7 +175,9 @@ export function isQuietPeriod(
   opts?: ResolveCalendarKeyOptions,
 ): boolean {
   const calendar = getSportCalendar(sport, division, opts);
-  return calendar.periods.some((period) => period.type === "quiet" && isWithinPeriod(date, period));
+  return calendar.periods.some(
+    (period) => period.type === "quiet" && isWithinPeriod(date, period),
+  );
 }
 
 /**
@@ -164,7 +191,9 @@ export function getDeadPeriodMessage(
   opts?: ResolveCalendarKeyOptions,
 ): string | null {
   const calendar = getSportCalendar(sport, division, opts);
-  const period = calendar.periods.find((p) => BLOCKING_TYPES.has(p.type) && isWithinPeriod(date, p));
+  const period = calendar.periods.find(
+    (p) => BLOCKING_TYPES.has(p.type) && isWithinPeriod(date, p),
+  );
   if (!period) return null;
 
   return `Dead period - no recruiting contact permitted per NCAA rules (${period.description})`;
@@ -179,7 +208,9 @@ export function getNextDeadPeriod(
 ): RecruitingPeriod | null {
   const calendar = getSportCalendar(sport, division, opts);
   const future = calendar.periods
-    .filter((p) => BLOCKING_TYPES.has(p.type) && parseLocalDateOnly(p.start) >= date)
+    .filter(
+      (p) => BLOCKING_TYPES.has(p.type) && parseLocalDateOnly(p.start) >= date,
+    )
     .sort((a, b) => a.start.localeCompare(b.start));
 
   return future[0] ?? null;
@@ -231,16 +262,29 @@ export interface GetUpcomingMilestonesParams {
  * (mirrors the legacy `getUpcomingMilestones` phase buckets), and division —
  * then sorted ascending and capped at `limit` (default 5).
  */
-export function getUpcomingMilestones(params: GetUpcomingMilestonesParams): CalendarMilestone[] {
-  const { sport, division, graduationYear, limit = 5, opts, currentDate = new Date() } = params;
+export function getUpcomingMilestones(
+  params: GetUpcomingMilestonesParams,
+): CalendarMilestone[] {
+  const {
+    sport,
+    division,
+    graduationYear,
+    limit = 5,
+    opts,
+    currentDate = new Date(),
+  } = params;
 
   const calendar = getSportCalendar(sport, division, opts);
-  const generic = GENERIC_MILESTONES.filter((m) => matchesDivision(m, division)).map(toCalendarMilestone);
+  const generic = GENERIC_MILESTONES.filter((m) =>
+    matchesDivision(m, division),
+  ).map(toCalendarMilestone);
 
   const currentDateISO = formatLocalDateOnly(currentDate);
-  const byDate = (a: CalendarMilestone, b: CalendarMilestone) => a.date.localeCompare(b.date);
+  const byDate = (a: CalendarMilestone, b: CalendarMilestone) =>
+    a.date.localeCompare(b.date);
   const typeAllowed = gradeTypeFilter(graduationYear, currentDateISO);
-  const isUpcoming = (m: CalendarMilestone) => m.date >= currentDateISO && typeAllowed(m);
+  const isUpcoming = (m: CalendarMilestone) =>
+    m.date >= currentDateISO && typeAllowed(m);
 
   // Two sources, capped differently: the generic SAT/ACT/deadline bucket is
   // capped at `limit` (soonest first) so it can't flood the list, while the
@@ -252,7 +296,10 @@ export function getUpcomingMilestones(params: GetUpcomingMilestonesParams): Cale
   const sportMilestones = calendar.milestones.filter(isUpcoming);
 
   const seen = new Set(cappedGeneric.map((m) => `${m.date}|${m.title}`));
-  const merged = [...cappedGeneric, ...sportMilestones.filter((m) => !seen.has(`${m.date}|${m.title}`))];
+  const merged = [
+    ...cappedGeneric,
+    ...sportMilestones.filter((m) => !seen.has(`${m.date}|${m.title}`)),
+  ];
 
   return merged.sort(byDate);
 }
@@ -276,12 +323,18 @@ function gradeTypeFilter(
   if (yearsOut === 3) {
     // Senior year
     return (m) =>
-      m.type === "test" || m.type === "application" || m.type === "signing" || m.type === "ncaa-period";
+      m.type === "test" ||
+      m.type === "application" ||
+      m.type === "signing" ||
+      m.type === "ncaa-period";
   }
   if (yearsOut === 2) {
     // Junior year
     return (m) =>
-      m.type === "test" || m.type === "deadline" || m.type === "ncaa-period" || m.type === "application";
+      m.type === "test" ||
+      m.type === "deadline" ||
+      m.type === "ncaa-period" ||
+      m.type === "application";
   }
   // Freshman/Sophomore — focus on tests
   return (m) => m.type === "test" || m.type === "ncaa-period";

--- a/utils/recruitingCalendar/resolver.ts
+++ b/utils/recruitingCalendar/resolver.ts
@@ -61,6 +61,9 @@ export const GENDER_SPLIT_SPORTS: Partial<
   Soccer: { men: "OTHER_MSOCCER", women: "OTHER_WSOCCER" },
   "Ice Hockey": { men: "OTHER_MICEHOCKEY", women: "OTHER_WICEHOCKEY" },
   Wrestling: { men: "OTHER_MWRESTLING", women: "OTHER_WWRESTLING" },
+  // Only women's gymnastics has a distinct calendar in the "Other" bundle PDF;
+  // men's gymnastics is folded into "All Other Sports" (generic "Other").
+  Gymnastics: { men: "Other", women: "OTHER_WGYM" },
 };
 
 /**
@@ -108,9 +111,10 @@ export function resolveCalendarKey(
     return single;
   }
 
-  // Any remaining AppSport (currently: Tennis, Water Polo, Gymnastics, Beach
-  // Volleyball) has no published NCAA recruiting calendar and no sport-specific
-  // windows in the "Other" bundle — falls to the generic "Other" default.
+  // Any remaining AppSport (currently: Tennis, Water Polo, Beach Volleyball) has
+  // no published NCAA recruiting calendar and no sport-specific windows in the
+  // "Other" bundle — falls to the generic "Other" default. (Gymnastics is
+  // handled above: women's has its own OTHER_WGYM, men's maps to "Other".)
   return "Other";
 }
 

--- a/utils/recruitingCalendar/types.ts
+++ b/utils/recruitingCalendar/types.ts
@@ -29,7 +29,7 @@ export type NcaaCalendarKey =
 export type Division = "D1" | "D2" | "D3";
 
 /**
- * The 17 app sport strings, copied verbatim from `utils/metrics/canonical.ts`
+ * The 19 app sport strings, copied verbatim from `utils/metrics/canonical.ts`
  * `SPORT_METRICS` keys.
  */
 export type AppSport =
@@ -49,7 +49,9 @@ export type AppSport =
   | "Ice Hockey"
   | "Field Hockey"
   | "Rowing"
-  | "Water Polo";
+  | "Water Polo"
+  | "Gymnastics"
+  | "Beach Volleyball";
 
 /**
  * One NCAA recruiting-period window. 5-type taxonomy (spike finding): baseball

--- a/utils/recruitingCalendar/types.ts
+++ b/utils/recruitingCalendar/types.ts
@@ -24,7 +24,8 @@ export type NcaaCalendarKey =
   | "OTHER_ROWING"
   | "OTHER_FIELDHOCKEY"
   | "OTHER_MWRESTLING"
-  | "OTHER_WWRESTLING";
+  | "OTHER_WWRESTLING"
+  | "OTHER_WGYM";
 
 export type Division = "D1" | "D2" | "D3";
 


### PR DESCRIPTION
## Summary

Extends the canonical sport vocabulary from **17 → 19 sports** across every derived registry in lockstep, plus a real NCAA calendar for women's gymnastics.

### Registry (commit 1)
| Registry | Gymnastics | Beach Volleyball |
|---|---|---|
| positions | 9 artistic events + All-Around (M+W superset) | Blocker, Defender |
| metrics | judged event scores (see below) | reuses indoor VB keys — no new defs |
| services | NCSA (auto — derived from `SPORT_POSITIONS`) | NCSA (auto) |
| attributes | none → `[]` | none → `[]` |

Also closes two prior coverage gaps in the position registry: a full-vocabulary snapshot guard + explicit sport-key set assertion, so any future add/drop/rename fails loudly instead of regressing silently. (This guard is what forces the lockstep.)

### Men's events first-class + women's gymnastics calendar (commit 2)
- **Metrics:** men's artistic events (pommel horse, still rings, parallel bars, high bar) promoted to first-class judged-score defs alongside women's four + All-Around → 9 event metrics. Shared events relabeled (Uneven Bars / Balance Beam / Floor Exercise).
- **Calendar:** transcribed the **real NCAA 2026-27 Women's Gymnastics recruiting calendar** (`OTHER_WGYM`) from the live "Other D1 Sports" bundle PDF — 7 windows, all HIGH confidence, cited, `verifiedOn` 2026-08-25. Gymnastics is now gender-split: women → `OTHER_WGYM`, men → generic `Other` (the PDF folds men's gym into "All Other Sports").
- **Beach Volleyball + men's gymnastics** correctly resolve to the generic `Other` track — verified: neither has a dedicated NCAA PDF, and only women's gym is enumerated in the Other bundle. Not a fallback gap; it's the accurate mapping.
- **Update job:** no new URL (women's gym rides in the Other bundle the quarterly checker already HEAD-checks); added a re-transcription note.

## Test plan
- [x] `npm test` — 8014 pass / 0 fail
- [x] `npm run type-check` — 0 errors
- [x] lint — 0 errors, `audit:tokens` — 0 errors
- [x] New guards: position vocabulary snapshot, gymnastics gender-split resolver, `OTHER_WGYM` calendar integrity

## Notes
- **iOS parity pending** — `MetricRegistry`, positions constants need the same 2 sports + men's events. Web is source of truth; handoff spec next.
- Design decisions (confirmed with owner): gymnastics = combined event superset; beach = beach-specific 2-role model reusing indoor metric keys.

https://claude.ai/code/session_01DGTNSmK7mrLnSHV5799neg