### PR TITLE
feat(web): coach detail header + comms analytics card + KPI rings

### DIFF
--- a/components/Coach/detail/CoachCommunicationAnalytics.vue
+++ b/components/Coach/detail/CoachCommunicationAnalytics.vue
@@ -1,0 +1,98 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = defineProps<{
+  sent: number;
+  received: number;
+  responseRate: number;
+}>();
+
+const sentReceivedRatio = computed(() => {
+  const total = props.sent + props.received;
+  return total === 0 ? 0 : (props.sent / total) * 100;
+});
+
+const gaugeDasharray = computed(() => `${props.responseRate} 100`);
+
+const progressCaption = computed(() => {
+  if (props.responseRate >= 75) return "Great Progress";
+  if (props.responseRate >= 40) return "Building Momentum";
+  return "Needs Attention";
+});
+</script>
+
+<template>
+  <section class="flex flex-col gap-3 rounded-xl border border-slate-200 bg-white p-4">
+    <div class="flex items-center justify-between">
+      <h3 class="text-sm font-bold text-slate-900">Communication History &amp; Analytics</h3>
+      <span class="rounded bg-blue-50 px-2 py-1 text-[11px] font-semibold text-blue-500">
+        All Time
+      </span>
+    </div>
+
+    <div class="flex items-center gap-5">
+      <div class="flex flex-1 flex-col gap-3">
+        <div>
+          <div class="flex items-center justify-between">
+            <span class="text-[13px] text-slate-600">Sent / Received</span>
+            <span class="text-[13px] font-bold text-slate-900">{{ sent }} / {{ received }}</span>
+          </div>
+          <div class="mt-1.5 h-1.5 w-full rounded bg-slate-100">
+            <div
+              class="h-full rounded bg-blue-500"
+              :style="{ width: `${sentReceivedRatio}%` }"
+            />
+          </div>
+        </div>
+
+        <div>
+          <div class="flex items-center justify-between">
+            <span class="text-[13px] text-slate-600">Response Rate</span>
+            <span class="text-[13px] font-bold text-slate-900">{{ responseRate }}%</span>
+          </div>
+          <div class="mt-1.5 h-1.5 w-full rounded bg-slate-100" />
+        </div>
+
+        <div class="flex items-center justify-between">
+          <span class="text-[13px] text-slate-600">Avg. Response Time</span>
+          <span class="text-[13px] font-bold text-slate-900">--</span>
+        </div>
+      </div>
+
+      <div class="h-24 w-px bg-slate-200" aria-hidden="true" />
+
+      <div class="flex w-[180px] flex-col items-center gap-1.5">
+        <div class="relative flex h-[72px] w-[72px] items-center justify-center text-emerald-500">
+          <svg viewBox="0 0 36 36" class="h-full w-full -rotate-90">
+            <circle
+              cx="18"
+              cy="18"
+              r="15.9155"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="3"
+              class="text-slate-200"
+            />
+            <circle
+              cx="18"
+              cy="18"
+              r="15.9155"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="3"
+              stroke-linecap="round"
+              :stroke-dasharray="gaugeDasharray"
+            />
+          </svg>
+          <div class="absolute inset-0 flex flex-col items-center justify-center">
+            <span data-testid="response-gauge-value" class="text-lg font-extrabold text-emerald-500">
+              {{ responseRate }}%
+            </span>
+            <span class="text-[8px] font-bold uppercase text-slate-400">Responded</span>
+          </div>
+        </div>
+        <p class="text-[11px] text-emerald-500">{{ progressCaption }}</p>
+      </div>
+    </div>
+  </section>
+</template>

--- a/components/Coach/detail/CoachDetailHeader.vue
+++ b/components/Coach/detail/CoachDetailHeader.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import type { Coach } from "~/types/models";
+import { getRoleLabel } from "~/utils/coachLabels";
+
+const props = defineProps<{
+  coach: Coach;
+  schoolName?: string | null;
+}>();
+
+const emit = defineEmits<{
+  edit: [];
+  delete: [];
+}>();
+
+const initials = computed(() => {
+  const first = props.coach.first_name?.[0] ?? "";
+  const last = props.coach.last_name?.[0] ?? "";
+  return `${first}${last}`.toUpperCase();
+});
+
+const fullName = computed(
+  () => `${props.coach.first_name} ${props.coach.last_name}`,
+);
+
+const subtitle = computed(() => {
+  const role = getRoleLabel(props.coach.role);
+  return props.schoolName ? `${role} · ${props.schoolName}` : role;
+});
+</script>
+
+<template>
+  <section
+    class="flex items-center justify-between rounded-xl border border-slate-200 bg-white px-5 py-3"
+  >
+    <div class="flex items-center gap-3">
+      <div
+        class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-100 text-[13px] font-semibold text-slate-500"
+        aria-hidden="true"
+      >
+        {{ initials }}
+      </div>
+      <div class="flex flex-col gap-0.5">
+        <p class="text-base font-bold text-slate-900">{{ fullName }}</p>
+        <p class="text-xs text-slate-600">{{ subtitle }}</p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-2.5">
+      <button
+        type="button"
+        data-testid="coach-header-edit"
+        class="flex items-center gap-1.5 rounded-lg bg-blue-50 px-4 py-2"
+        @click="emit('edit')"
+      >
+        <UIcon name="i-heroicons-pencil" class="h-3.5 w-3.5 text-blue-500" aria-hidden="true" />
+        <span class="text-[13px] font-semibold text-blue-500">Edit Profile</span>
+      </button>
+      <button
+        type="button"
+        data-testid="coach-header-delete"
+        class="flex items-center gap-1.5 rounded-lg border border-red-300 bg-red-50 px-4 py-2"
+        @click="emit('delete')"
+      >
+        <UIcon name="i-heroicons-trash" class="h-3.5 w-3.5 text-red-500" aria-hidden="true" />
+        <span class="text-[13px] font-semibold text-red-500">Delete Coach</span>
+      </button>
+    </div>
+  </section>
+</template>

--- a/components/Coach/detail/CoachStatCards.vue
+++ b/components/Coach/detail/CoachStatCards.vue
@@ -56,30 +56,31 @@ const preferredChannelIcon = computed(() =>
           OVERDUE
         </span>
       </div>
-      <svg viewBox="0 0 40 40" class="h-12 w-12 shrink-0">
-        <circle
-          cx="20"
-          cy="20"
-          r="16"
-          fill="none"
-          stroke-width="4"
-          class="text-slate-200"
-          stroke="currentColor"
-        />
-        <circle
-          cx="20"
-          cy="20"
-          r="16"
-          fill="none"
-          stroke-width="4"
-          stroke="currentColor"
-          :class="isOverdue ? 'text-red-500' : 'text-blue-500'"
-          :stroke-dasharray="RING_CIRCUMFERENCE"
-          stroke-dashoffset="0"
-          stroke-linecap="round"
-          transform="rotate(-90 20 20)"
-        />
-      </svg>
+      <div class="relative h-12 w-12 shrink-0">
+        <svg viewBox="0 0 40 40" class="h-12 w-12">
+          <circle
+            cx="20"
+            cy="20"
+            r="16"
+            fill="none"
+            stroke-width="4"
+            stroke="currentColor"
+            :class="isOverdue ? 'text-red-500' : 'text-slate-300'"
+            :stroke-dasharray="RING_CIRCUMFERENCE"
+            stroke-dashoffset="0"
+            stroke-linecap="round"
+            transform="rotate(-90 20 20)"
+          />
+        </svg>
+        <div class="absolute inset-0 flex items-center justify-center">
+          <UIcon
+            :name="isOverdue ? 'i-heroicons-exclamation-circle' : 'i-heroicons-clock'"
+            class="h-5 w-5"
+            :class="isOverdue ? 'text-red-500' : 'text-slate-400'"
+            aria-hidden="true"
+          />
+        </div>
+      </div>
     </div>
 
     <!-- Total Interactions -->
@@ -93,28 +94,26 @@ const preferredChannelIcon = computed(() =>
         </p>
         <p class="text-[11px] text-slate-600">{{ totalInteractions }} interactions logged</p>
       </div>
-      <svg viewBox="0 0 40 40" class="h-12 w-12 shrink-0">
-        <circle
-          cx="20"
-          cy="20"
-          r="16"
-          fill="none"
-          stroke-width="4"
-          class="text-slate-200"
-          stroke="currentColor"
-        />
-        <circle
-          cx="20"
-          cy="20"
-          r="16"
-          fill="none"
-          stroke-width="4"
-          stroke="currentColor"
-          class="text-blue-500"
-          stroke-linecap="round"
-          transform="rotate(-90 20 20)"
-        />
-      </svg>
+      <div class="relative h-12 w-12 shrink-0">
+        <svg viewBox="0 0 40 40" class="h-12 w-12">
+          <circle
+            cx="20"
+            cy="20"
+            r="16"
+            fill="none"
+            stroke-width="4"
+            stroke="currentColor"
+            class="text-blue-500"
+            :stroke-dasharray="RING_CIRCUMFERENCE"
+            stroke-dashoffset="0"
+            stroke-linecap="round"
+            transform="rotate(-90 20 20)"
+          />
+        </svg>
+        <div class="absolute inset-0 flex items-center justify-center">
+          <span class="text-[12px] font-bold text-blue-500">{{ totalInteractions }}</span>
+        </div>
+      </div>
     </div>
 
     <!-- Preferred Channel -->

--- a/pages/coaches/[id]/index.vue
+++ b/pages/coaches/[id]/index.vue
@@ -22,25 +22,6 @@
           <UIcon name="i-heroicons-arrow-left" class="h-4 w-4" />
           {{ backLink.text }}
         </NuxtLink>
-
-        <div v-if="coach" class="flex items-center gap-2">
-          <button
-            type="button"
-            data-test="edit-coach-btn"
-            class="rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 transition hover:bg-slate-50"
-            @click="editCoach"
-          >
-            Edit
-          </button>
-          <button
-            type="button"
-            data-test="coach-detail-delete-btn"
-            class="rounded-lg border border-red-200 px-3 py-1.5 text-sm font-medium text-red-600 transition hover:bg-red-50"
-            @click="openDeleteModal"
-          >
-            Delete
-          </button>
-        </div>
       </div>
     </div>
 
@@ -66,8 +47,16 @@
         <p class="text-slate-600">Coach not found</p>
       </div>
 
-      <!-- Coach Detail: two-column layout -->
-      <div v-if="!loading && coach" class="flex flex-col items-start gap-5 lg:flex-row">
+      <!-- Coach Detail: header toolbar + two-column layout -->
+      <div v-if="!loading && coach" class="space-y-5">
+        <CoachDetailHeader
+          :coach="coach"
+          :school-name="schoolName"
+          @edit="editCoach"
+          @delete="openDeleteModal"
+        />
+
+        <div class="flex flex-col items-start gap-5 lg:flex-row">
         <!-- Left rail -->
         <div class="w-full shrink-0 space-y-5 lg:w-[340px]">
           <CoachIdentityCard :coach="coach" />
@@ -103,15 +92,13 @@
             :preferred-channel="insights.preferredChannel.value"
             :response-rate="insights.responseRate.value"
           />
-          <div ref="communicationPanelEl">
-            <CommunicationPanel
-              :coach="coach"
-              :school="school"
-              :school-name="schoolName"
-              @interaction-logged="handleCoachInteractionLogged"
-            />
-          </div>
+          <CoachCommunicationAnalytics
+            :sent="insights.sentReceived.value.sent"
+            :received="insights.sentReceived.value.received"
+            :response-rate="insights.responseRate.value"
+          />
           <CoachInteractionsTable :interactions="recentInteractions" />
+        </div>
         </div>
       </div>
     </main>
@@ -146,12 +133,12 @@ import { useCoachStore } from "~/stores/coaches";
 import { useSchools } from "~/composables/useSchools";
 import { useInteractions } from "~/composables/useInteractions";
 import { useCoachInsights } from "~/composables/useCoachInsights";
-import { useCommunication } from "~/composables/useCommunication";
 import { useDeleteModal } from "~/composables/useDeleteModal";
 import { deriveBackLink } from "~/composables/useBackLink";
 import DeleteConfirmationModal from "~/components/DeleteConfirmationModal.vue";
 import EditCoachModal from "~/components/EditCoachModal.vue";
-import CommunicationPanel from "~/components/CommunicationPanel.vue";
+import CoachDetailHeader from "~/components/Coach/detail/CoachDetailHeader.vue";
+import CoachCommunicationAnalytics from "~/components/Coach/detail/CoachCommunicationAnalytics.vue";
 import CoachIdentityCard from "~/components/Coach/detail/CoachIdentityCard.vue";
 import CoachChannelActions from "~/components/Coach/detail/CoachChannelActions.vue";
 import CoachInternalNotes from "~/components/Coach/detail/CoachInternalNotes.vue";
@@ -188,12 +175,6 @@ const loading = ref(false);
 const error = ref<string | null>(null);
 const schoolName = ref("");
 const school = ref<School | undefined>(undefined);
-const communicationPanelEl = ref<HTMLElement | null>(null);
-
-// The inline CommunicationPanel composes+sends and emits interaction-logged;
-// this composable's handleInteractionLogged does the create-record +
-// last_contact_date bookkeeping that used to live behind a modal drawer.
-const { openCommunication, handleInteractionLogged } = useCommunication();
 
 // Delete modal management
 const {
@@ -222,13 +203,11 @@ const recentInteractions = computed<Interaction[]>(() => {
 
 const insights = useCoachInsights(coach, recentInteractions);
 
-// Communication handlers: the panel is embedded inline (not a modal), so
-// "Log Interaction" brings it into view rather than opening a drawer.
+// "Log Interaction" now routes to the interaction-create page, prefilling this
+// coach + school via query params (the inline composer was removed from the page).
 const openLogInteraction = () => {
-  communicationPanelEl.value?.scrollIntoView({
-    behavior: "smooth",
-    block: "start",
-  });
+  const schoolId = coach.value?.school_id ?? "";
+  navigateTo(`/interactions/add?coachId=${coachId}&schoolId=${schoolId}`);
 };
 
 // School-wide refresh (not coach-filtered): the interactions table filters by
@@ -258,32 +237,6 @@ async function logSocialDm(): Promise<void> {
 
 const handleOpenSocial = (_platform: "twitter" | "instagram") => {
   void logSocialDm();
-};
-
-const handleCoachInteractionLogged = async (interactionData: {
-  type: string;
-  direction: string;
-  content: string;
-}) => {
-  if (!coach.value) return;
-  try {
-    // Prime the composable's selectedCoach — CommunicationPanel is inline, so
-    // there's no separate "open" step to have set it already.
-    openCommunication(coach.value, "email");
-
-    const refreshData = async () => {
-      const updatedCoach = await getCoach(coachId);
-      if (updatedCoach) {
-        coach.value = updatedCoach;
-      }
-      await refreshSchoolInteractions();
-    };
-
-    await handleInteractionLogged(interactionData as any, refreshData);
-  } catch (err) {
-    error.value =
-      err instanceof Error ? err.message : "Failed to log interaction";
-  }
 };
 
 // Coach management handlers

--- a/pages/interactions/add.vue
+++ b/pages/interactions/add.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
 import { navigateTo } from "#app";
+import { useRoute } from "vue-router";
 import { useInteractions } from "~/composables/useInteractions";
 import { useUserStore } from "~/stores/user";
 import { useAppToast } from "~/composables/useAppToast";
@@ -13,9 +14,20 @@ definePageMeta({
 });
 
 const logger = createClientLogger("InteractionAdd");
+const route = useRoute();
 const userStore = useUserStore();
 const { createInteraction, loading } = useInteractions();
 const { showToast } = useAppToast();
+
+// Prefill coach/school when arriving from a coach's "Log Interaction" action.
+const initialData = computed<Partial<Interaction>>(() => {
+  const coachId = typeof route.query.coachId === "string" ? route.query.coachId : "";
+  const schoolId = typeof route.query.schoolId === "string" ? route.query.schoolId : "";
+  return {
+    ...(coachId ? { coach_id: coachId } : {}),
+    ...(schoolId ? { school_id: schoolId } : {}),
+  };
+});
 
 const pageTitle = computed(() => {
   return userStore.isAthlete ? "Log My Interaction" : "Log Interaction";
@@ -88,6 +100,7 @@ const handleCancel = () => {
   >
     <InteractionForm
       :loading="loading"
+      :initial-data="initialData"
       @submit="handleSubmit"
       @cancel="handleCancel"
     />

--- a/planning/coach-detail-followup-spec.md
+++ b/planning/coach-detail-followup-spec.md
@@ -1,0 +1,50 @@
+# Coach Detail follow-up — header bar + analytics card + KPI rings
+
+Follow-up to PR #475. Figma frame `4:4` (full) vs shipped `4:18` (content only). Three pieces to add/fix. Branch `feat/coach-detail-header-analytics` off develop.
+
+All Figma hex → standard Tailwind utilities (audit:tokens bans only raw hex in style/inline). No raw hex.
+
+## Piece 1 — Header toolbar (`components/Coach/detail/CoachDetailHeader.vue`) — NEW
+
+Full-width white card ABOVE the two-column grid. From Figma node 4:5.
+
+- Card: `bg-white border border-slate-200 rounded-xl px-5 py-3 flex items-center justify-between`.
+- Left `coach-identity-summary` (`flex gap-3 items-center`): avatar-tiny 36px `rounded-full` (initials, same initials logic as CoachIdentityCard — first_name[0]+last_name[0], `bg-slate-100 text-slate-500` centered) + name/role stack (`flex-col gap-0.5`): name `text-base font-bold text-slate-900`; subtitle `text-xs text-slate-600`.
+  - Subtitle text: render `{roleLabel} · {schoolName}` (e.g. "Head Coach · Wake Forest University"). NOTE: Figma literal was "Recruiting Candidate · Head Coach" — that "Recruiting Candidate" prefix is mockup filler for a coach; use role + school instead. roleLabel via existing role map (head→"Head Coach", assistant→"Assistant Coach", recruiting→"Recruiting Coordinator").
+- Right `actions` (`flex gap-2.5 items-center`):
+  - Edit Profile: `bg-blue-50 rounded-lg px-4 py-2 flex gap-1.5 items-center`; pencil icon 14px `text-blue-500`; label `text-[13px] font-semibold text-blue-500`. Emits `edit`.
+  - Delete Coach: `bg-red-50 border border-red-300 rounded-lg px-4 py-2 flex gap-1.5 items-center`; trash icon 14px `text-red-500`; label `text-[13px] font-semibold text-red-500`. Emits `delete`.
+- Props: `{ coach: Coach; schoolName?: string | null }`. Emits: `{ edit: []; delete: [] }`.
+- Icons: `i-heroicons-pencil` / `i-heroicons-trash`.
+
+Page wiring: render `<CoachDetailHeader :coach :school-name @edit=openEdit @delete=confirmDelete />` at the top of `pages/coaches/[id]/index.vue`, replacing the current plain Edit/Delete button strip. KEEP the "Back to All Coaches" link above it (app nav; not in the Figma component frame).
+
+## Piece 2 — Communication analytics card (`components/Coach/detail/CoachCommunicationAnalytics.vue`) — NEW; REPLACES the CommunicationPanel on this page
+
+From Figma node 4:104. Card: `bg-white border border-slate-200 rounded-xl p-4 flex flex-col gap-3`.
+- Header row (`flex items-center justify-between`): title "Communication History & Analytics" `text-sm font-bold text-slate-900`; "All Time" tag `bg-blue-50 text-blue-500 text-[11px] font-semibold rounded px-2 py-1`.
+- Split (`flex gap-5 items-center`):
+  - Metrics list (`flex-1 flex-col gap-3`):
+    - Sent / Received row: label `text-[13px] text-slate-600` "Sent / Received" + value `text-[13px] font-bold text-slate-900` "{sent} / {received}"; below a track `bg-slate-100 h-1.5 rounded w-full` with a `bg-blue-500 h-full` segment whose width % = sent/(sent+received)*100 (0 when none).
+    - Response Rate row: label "Response Rate" + value "{responseRate}%"; track `bg-slate-100 h-1.5 rounded w-full` (segment optional — design shows empty track, so just the track is fine).
+    - Avg. Response Time row (`flex justify-between`): label "Avg. Response Time" + value `--` (not computed yet; hardcode "--").
+  - Divider `w-px h-24 bg-slate-200`.
+  - Circular gauge (`w-[180px] flex-col gap-1.5 items-center`): 72px ring showing responseRate% — SVG `<circle>` track `stroke-slate-200` + progress `stroke-emerald-500` (`stroke-linecap-round`, dasharray from responseRate), center labels: `{responseRate}%` `text-lg font-extrabold text-emerald-500` + "RESPONDED" `text-[8px] font-bold text-slate-400 uppercase`; caption below `text-[11px] text-emerald-500` = responseRate>=75?"Great Progress":responseRate>=40?"Building Momentum":"Needs Attention".
+- Props: `{ sent: number; received: number; responseRate: number }`. Pure presentational.
+- Ring SVG: use `viewBox="0 0 36 36"` circle pattern with `stroke-dasharray="{responseRate} 100"` on the progress circle (standard technique). Use `stroke="currentColor"` + a `text-emerald-500` wrapper so no raw hex.
+
+Page wiring: REMOVE `<CommunicationPanel>` from `pages/coaches/[id]/index.vue` and its import/refs; place `<CoachCommunicationAnalytics :sent :received :response-rate>` where it was (between the KPI cards and the interactions section), fed from `insights.sentReceived.value` + `insights.responseRate.value`. Do NOT modify `components/CommunicationPanel.vue` (still used by other pages).
+
+Log Interaction rewire: the CoachChannelActions "Log Interaction" button previously scrolled to the composer. With the composer gone, `@log-interaction` now navigates to the interaction-create page prefilled: `navigateTo('/interactions/add?coachId=' + coach.id + '&schoolId=' + (coach.school_id||''))`. Add minimal query prefill to `pages/interactions/add.vue` (read `coachId`/`schoolId` from route.query and pass as InteractionForm initial values IF InteractionForm exposes an initial/prefill prop; if it does not, add a small `initial` prop to InteractionForm for coach_id/school_id only). Keep it minimal. Remove now-dead composer handlers (`openCommunication`, `handleCoachInteractionLogged`, `communicationPanelEl` scroll) from the page — but KEEP the social-DM auto-log path (`handleOpenSocial`/`logSocialDm`) and the `handleCoachInteractionLogged`→refresh only if still referenced; if fully dead after composer removal, remove cleanly and update the page spec.
+
+## Piece 3 — Encode KPI rings (`components/Coach/detail/CoachStatCards.vue`) — MODIFY
+
+From Figma nodes 4:81/4:92/4:102. Currently plain empty circles. Encode:
+- Days Since Contact card: 48px ring — when overdue, `stroke-red-500` track ring with a centered `i-heroicons-exclamation-circle` (or `-clock`) `text-red-500` icon (design shows an alert-circle in a red ring); when not overdue, `stroke-slate-300` ring, muted icon. Ring via SVG circle, decorative (full ring ok).
+- Total Interactions card: 48px ring `stroke-blue-500` with the count centered `text-[12px] font-bold text-blue-500`.
+- Preferred Channel card: KEEP existing 40px `bg-orange-500 rounded-full` badge with the channel icon (already correct).
+- Rings: `stroke="currentColor"` + text-color utility, `fill-none`. No raw hex. Keep it simple/decorative — no need to encode a precise arc %, just filled colored rings matching the design's look.
+
+## Constraints
+`<script setup lang="ts">`, typed props/emits, no `any` outside tests, no prop mutation, no raw hex/rgba. `npm run audit:tokens && npm run type-check` green. Add/adjust unit tests: CoachDetailHeader (edit/delete emits), CoachCommunicationAnalytics (renders sent/received, responseRate, gauge %), and update the page spec for the removed CommunicationPanel + new header/analytics + Log Interaction navigation. Full: `npm run test`.
+Commit trailer: `Claude-Session: https://claude.ai/code/session_01Bq11o1S44fVRH9kJWbfXgz`.

--- a/tests/unit/components/Coach/CoachCommunicationAnalytics.spec.ts
+++ b/tests/unit/components/Coach/CoachCommunicationAnalytics.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CoachCommunicationAnalytics from "~/components/Coach/detail/CoachCommunicationAnalytics.vue";
+
+describe("CoachCommunicationAnalytics", () => {
+  it("renders sent/received and response rate", () => {
+    const w = mount(CoachCommunicationAnalytics, {
+      props: { sent: 8, received: 5, responseRate: 100 },
+    });
+    expect(w.text()).toContain("8 / 5");
+    expect(w.text()).toContain("100%");
+  });
+
+  it("shows the response rate on the gauge", () => {
+    const w = mount(CoachCommunicationAnalytics, {
+      props: { sent: 3, received: 1, responseRate: 62 },
+    });
+    expect(w.get('[data-testid="response-gauge-value"]').text()).toContain("62%");
+  });
+
+  it("shows a Great Progress caption at or above the 75 threshold", () => {
+    const w = mount(CoachCommunicationAnalytics, {
+      props: { sent: 8, received: 5, responseRate: 100 },
+    });
+    expect(w.text()).toContain("Great Progress");
+  });
+
+  it("shows a Building Momentum caption between 40 and 74", () => {
+    const w = mount(CoachCommunicationAnalytics, {
+      props: { sent: 5, received: 2, responseRate: 50 },
+    });
+    expect(w.text()).toContain("Building Momentum");
+  });
+
+  it("shows a Needs Attention caption below 40", () => {
+    const w = mount(CoachCommunicationAnalytics, {
+      props: { sent: 5, received: 0, responseRate: 0 },
+    });
+    expect(w.text()).toContain("Needs Attention");
+  });
+});

--- a/tests/unit/components/Coach/CoachDetailHeader.spec.ts
+++ b/tests/unit/components/Coach/CoachDetailHeader.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { mount } from "@vue/test-utils";
+import CoachDetailHeader from "~/components/Coach/detail/CoachDetailHeader.vue";
+import type { Coach } from "~/types/models";
+
+const baseCoach: Coach = {
+  id: "coach-1",
+  school_id: "school-1",
+  role: "head",
+  first_name: "Jamie",
+  last_name: "Rivera",
+  email: null,
+  phone: null,
+  twitter_handle: null,
+  instagram_handle: null,
+  notes: null,
+  tags: [],
+  source: null,
+  last_contact_date: null,
+};
+
+describe("CoachDetailHeader", () => {
+  it("renders the coach name and a role · school subtitle", () => {
+    const w = mount(CoachDetailHeader, {
+      props: { coach: baseCoach, schoolName: "Wake Forest University" },
+    });
+    expect(w.text()).toContain("Jamie Rivera");
+    expect(w.text()).toContain("Head Coach · Wake Forest University");
+  });
+
+  it("emits edit when Edit Profile is clicked", async () => {
+    const w = mount(CoachDetailHeader, { props: { coach: baseCoach } });
+    await w.get('[data-testid="coach-header-edit"]').trigger("click");
+    expect(w.emitted("edit")).toBeTruthy();
+  });
+
+  it("emits delete when Delete Coach is clicked", async () => {
+    const w = mount(CoachDetailHeader, { props: { coach: baseCoach } });
+    await w.get('[data-testid="coach-header-delete"]').trigger("click");
+    expect(w.emitted("delete")).toBeTruthy();
+  });
+});

--- a/tests/unit/pages/coaches/[id].spec.ts
+++ b/tests/unit/pages/coaches/[id].spec.ts
@@ -4,6 +4,9 @@ import { createPinia, setActivePinia } from "pinia";
 import { ref } from "vue";
 import type { Coach } from "~/types/models";
 
+// Nuxt auto-imports navigateTo as a global; the page calls it bare.
+global.navigateTo = vi.fn();
+
 // Mock vue-router
 const mockPush = vi.fn();
 vi.mock("vue-router", () => ({
@@ -107,24 +110,8 @@ vi.mock("~/components/coaches/CoachProfileLink.vue", () => ({
   },
 }));
 
-// setup.ts registers a global name-matched CommunicationPanel stub
-// (`<div><slot /></div>`) that overrides any component import — override it
-// here with one that exposes the interaction-logged flow for assertions.
 const globalStubs = {
   NuxtLink: { template: "<a><slot /></a>" },
-  CommunicationPanel: {
-    name: "CommunicationPanel",
-    props: ["coach", "school", "schoolName"],
-    emits: ["interaction-logged"],
-    template: `
-      <div data-test="communication-panel">
-        <button @click="$emit('interaction-logged', { type: 'email', direction: 'outbound', content: 'Test' })"
-                data-test="log-interaction-btn">
-          Log Interaction
-        </button>
-      </div>
-    `,
-  },
 };
 
 describe("Coach Detail Page", () => {
@@ -248,7 +235,7 @@ describe("Coach Detail Page", () => {
         true,
       );
       expect(
-        wrapper.find('[data-test="communication-panel"]').exists(),
+        wrapper.findComponent({ name: "CoachCommunicationAnalytics" }).exists(),
       ).toBe(true);
       expect(
         wrapper.findComponent({ name: "CoachInteractionsTable" }).exists(),
@@ -303,17 +290,18 @@ describe("Coach Detail Page", () => {
   });
 
   describe("Interaction logging", () => {
-    it("routes CommunicationPanel's interaction-logged event through handleInteractionLogged", async () => {
+    it("navigates to the interaction-create page prefilled when CoachChannelActions emits log-interaction", async () => {
       const wrapper = await mountPage();
 
-      await wrapper.find('[data-test="log-interaction-btn"]').trigger("click");
+      const channelActions = wrapper.findComponent({
+        name: "CoachChannelActions",
+      });
+      channelActions.vm.$emit("log-interaction");
       await flushPromises();
 
-      expect(mockOpenCommunication).toHaveBeenCalledWith(
-        expect.objectContaining({ id: "coach-123" }),
-        "email",
+      expect(global.navigateTo).toHaveBeenCalledWith(
+        "/interactions/add?coachId=coach-123&schoolId=school-123",
       );
-      expect(mockHandleInteractionLogged).toHaveBeenCalled();
     });
   });
 
@@ -377,7 +365,7 @@ describe("Coach Detail Page", () => {
     it("opens edit modal when header edit button is clicked", async () => {
       const wrapper = await mountPage();
 
-      const editBtn = wrapper.find('[data-test="edit-coach-btn"]');
+      const editBtn = wrapper.find('[data-testid="coach-header-edit"]');
       expect(editBtn.exists()).toBe(true);
       await editBtn.trigger("click");
       await wrapper.vm.$nextTick();
@@ -402,7 +390,7 @@ describe("Coach Detail Page", () => {
     it("closes edit modal on close event", async () => {
       const wrapper = await mountPage();
 
-      await wrapper.find('[data-test="edit-coach-btn"]').trigger("click");
+      await wrapper.find('[data-testid="coach-header-edit"]').trigger("click");
       await wrapper.vm.$nextTick();
 
       await wrapper.find('[data-test="close-edit-btn"]').trigger("click");
@@ -416,7 +404,7 @@ describe("Coach Detail Page", () => {
     it("opens delete modal when delete is clicked", async () => {
       const wrapper = await mountPage();
 
-      const deleteBtn = wrapper.find('[data-test="coach-detail-delete-btn"]');
+      const deleteBtn = wrapper.find('[data-testid="coach-header-delete"]');
       await deleteBtn.trigger("click");
       await flushPromises();
 
@@ -428,7 +416,7 @@ describe("Coach Detail Page", () => {
 
       const wrapper = await mountPage();
 
-      await wrapper.find('[data-test="coach-detail-delete-btn"]').trigger("click");
+      await wrapper.find('[data-testid="coach-header-delete"]').trigger("click");
       await flushPromises();
 
       await wrapper.find('[data-test="confirm-delete-btn"]').trigger("click");
@@ -441,7 +429,7 @@ describe("Coach Detail Page", () => {
     it("closes delete modal when cancelled", async () => {
       const wrapper = await mountPage();
 
-      await wrapper.find('[data-test="coach-detail-delete-btn"]').trigger("click");
+      await wrapper.find('[data-testid="coach-header-delete"]').trigger("click");
       await flushPromises();
 
       const cancelBtn = wrapper.find('[data-test="cancel-delete-btn"]');
@@ -456,7 +444,7 @@ describe("Coach Detail Page", () => {
 
       const wrapper = await mountPage();
 
-      await wrapper.find('[data-test="coach-detail-delete-btn"]').trigger("click");
+      await wrapper.find('[data-testid="coach-header-delete"]').trigger("click");
       await flushPromises();
 
       await wrapper.find('[data-test="confirm-delete-btn"]').trigger("click");


### PR DESCRIPTION
## Summary

Follow-up to #475 (Coach Detail two-column redesign). Adds the header toolbar + communication-analytics card from Figma frame `4:4`, encodes the KPI rings, and wires it all into the page.

### Components (commit `c27b37ff`)
- **`CoachDetailHeader`** — full-width white toolbar above the grid: avatar/name/role·school + Edit Profile / Delete Coach actions (emits `edit`/`delete`).
- **`CoachCommunicationAnalytics`** — presentational card replacing the inline `CommunicationPanel` on this page: Sent/Received bar, Response Rate, and an emerald response-rate gauge (SVG, no raw hex).
- **`CoachStatCards`** — KPI rings encoded (days-since-contact alert ring, total-interactions blue ring).

### Page wiring (commit `fbebbb0f`)
- Replaced the plain top-bar Edit/Delete strip with `CoachDetailHeader` (kept "Back to All Coaches").
- Swapped `CommunicationPanel` → `CoachCommunicationAnalytics` (fed from `useCoachInsights` sent/received + responseRate). `CommunicationPanel.vue` untouched (still used elsewhere).
- Rewired Log Interaction → `navigateTo('/interactions/add?coachId=…&schoolId=…')`; added `initialData` query prefill to the interaction-create page.
- Removed now-dead composer handlers (`handleCoachInteractionLogged`, `useCommunication`, `communicationPanelEl` scroll). Kept social-DM auto-log path.

## Test plan
- [x] `type-check` 0 · `lint` 0 · `audit:tokens` 0 errors
- [x] Unit: coach detail specs 67 pass (page + header + analytics); full suite 7639 pass, identical to baseline
- [ ] Browser verify on QA (Chris) — coach detail header, analytics card, Log Interaction prefill
- [ ] iOS parity delta (header/analytics follow-up on top of existing coach-detail handoff spec)

https://claude.ai/code/session_016KpKsqXh9xkAZWg1FSDY8K
