### PR TITLE
style(coach): box the Send Recruiting Profile section

### DIFF
--- a/components/coaches/CoachProfileLink.vue
+++ b/components/coaches/CoachProfileLink.vue
@@ -140,7 +140,7 @@ function formatDate(iso: string | null): string {
 </script>
 
 <template>
-  <div class="space-y-3 rounded-xl border border-gray-100 p-4">
+  <div class="space-y-3 rounded-xl border border-slate-200 bg-white p-4">
     <h3 class="text-sm font-semibold text-gray-700">Send Recruiting Profile</h3>
 
     <div v-if="loading" class="text-sm text-gray-400">Loading…</div>


### PR DESCRIPTION
Wrap the "Send Recruiting Profile" section (`CoachProfileLink.vue`) in a white card matching the sibling coach-detail cards (`bg-white border-slate-200`), so it reads as a boxed section instead of blending into the page background.

Class-only change. `audit:tokens` 0 errors.

https://claude.ai/code/session_016KpKsqXh9xkAZWg1FSDY8K