### PR TITLE
style(coach): unify Direction filter label styling

### DIFF
--- a/components/Coach/detail/CoachInteractionsTable.vue
+++ b/components/Coach/detail/CoachInteractionsTable.vue
@@ -136,16 +136,20 @@ const sentimentBadgeClass = (sentiment: string): string =>
         </select>
       </div>
 
-      <DesignSystemFormSegmentedControl
-        v-model="selectedDirection"
-        label="Direction"
-        size="sm"
-        :options="[
-          { value: '', label: 'Both' },
-          { value: 'outbound', label: 'Sent' },
-          { value: 'inbound', label: 'Received' },
-        ]"
-      />
+      <div>
+        <label class="mb-1 block text-[11px] font-semibold text-slate-400">Direction</label>
+        <DesignSystemFormSegmentedControl
+          v-model="selectedDirection"
+          label="Direction"
+          hide-label
+          size="sm"
+          :options="[
+            { value: '', label: 'Both' },
+            { value: 'outbound', label: 'Sent' },
+            { value: 'inbound', label: 'Received' },
+          ]"
+        />
+      </div>
 
       <div>
         <label class="mb-1 block text-[11px] font-semibold text-slate-400">Date range</label>


### PR DESCRIPTION
Coach-detail Interactions filter bar: the segmented Direction control rendered its own larger, darker legend (`text-sm font-medium text-slate-700`), mismatched against the Type / Date range / Sentiment select labels (`text-[11px] font-semibold text-slate-400`).

Hide the segmented control's built-in legend (`hide-label`, kept for screen readers) and add a matching manual label above it, so all four filter labels are identical in size and color.

Class/markup-only change (`CoachInteractionsTable.vue`). `audit:tokens` 0 errors.

https://claude.ai/code/session_016KpKsqXh9xkAZWg1FSDY8K