### PR TITLE
style(coach): widen Direction filter column

### DIFF
--- a/components/Coach/detail/CoachInteractionsTable.vue
+++ b/components/Coach/detail/CoachInteractionsTable.vue
@@ -122,7 +122,9 @@ const sentimentBadgeClass = (sentiment: string): string =>
     </div>
 
     <!-- Filter bar -->
-    <div class="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+    <div
+      class="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.4fr)_minmax(0,1fr)_minmax(0,1fr)]"
+    >
       <div>
         <label class="mb-1 block text-[11px] font-semibold text-slate-400">Type</label>
         <select


### PR DESCRIPTION
Coach-detail Interactions filter bar: with 4 equal-width columns, the segmented Direction control's longest segment ("Received") sat cramped against the right border. Give Direction a wider column (`1.4fr` vs `1fr` for Type / Date range / Sentiment) so the active segment has symmetric breathing room.

Class-only change (`CoachInteractionsTable.vue`). `audit:tokens` 0 errors.

https://claude.ai/code/session_016KpKsqXh9xkAZWg1FSDY8K