### PR TITLE
feat(coach): school logo as coach avatar on detail page

### DIFF
--- a/components/Coach/detail/CoachDetailHeader.vue
+++ b/components/Coach/detail/CoachDetailHeader.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import type { Coach } from "~/types/models";
+import SchoolLogo from "~/components/School/SchoolLogo.vue";
+import type { Coach, School } from "~/types/models";
 import { getRoleLabel } from "~/utils/coachLabels";
 
 const props = defineProps<{
   coach: Coach;
+  school?: School | null;
   schoolName?: string | null;
 }>();
 
@@ -34,7 +36,14 @@ const subtitle = computed(() => {
     class="flex items-center justify-between rounded-xl border border-slate-200 bg-white px-5 py-3"
   >
     <div class="flex items-center gap-3">
+      <SchoolLogo
+        v-if="school"
+        :school="school"
+        size="sm"
+        class="shrink-0"
+      />
       <div
+        v-else
         class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-100 text-[13px] font-semibold text-slate-500"
         aria-hidden="true"
       >

--- a/components/Coach/detail/CoachIdentityCard.vue
+++ b/components/Coach/detail/CoachIdentityCard.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import type { Coach } from "~/types/models";
+import SchoolLogo from "~/components/School/SchoolLogo.vue";
+import type { Coach, School } from "~/types/models";
 
-const props = defineProps<{ coach: Coach }>();
+const props = defineProps<{ coach: Coach; school?: School | null }>();
 
 const initials = computed(() => {
   const first = props.coach.first_name?.[0] ?? "";
@@ -17,7 +18,11 @@ const fullName = computed(
 
 <template>
   <section class="rounded-xl border border-slate-200 bg-white p-5 text-center">
+    <div v-if="school" class="mb-3 flex justify-center">
+      <SchoolLogo :school="school" size="xl" />
+    </div>
     <div
+      v-else
       class="mx-auto mb-3 flex h-24 w-24 items-center justify-center rounded-full border-[3px] border-slate-200 bg-slate-100 text-lg font-semibold text-slate-600"
       aria-hidden="true"
     >

--- a/pages/coaches/[id]/index.vue
+++ b/pages/coaches/[id]/index.vue
@@ -51,6 +51,7 @@
       <div v-if="!loading && coach" class="space-y-5">
         <CoachDetailHeader
           :coach="coach"
+          :school="school"
           :school-name="schoolName"
           @edit="editCoach"
           @delete="openDeleteModal"
@@ -59,7 +60,7 @@
         <div class="flex flex-col items-start gap-5 lg:flex-row">
         <!-- Left rail -->
         <div class="w-full shrink-0 space-y-5 lg:w-[340px]">
-          <CoachIdentityCard :coach="coach" />
+          <CoachIdentityCard :coach="coach" :school="school" />
           <CoachChannelActions
             :coach="coach"
             @log-interaction="openLogInteraction"


### PR DESCRIPTION
The coach-detail redesign switched the coach avatar to initials. Coach contact records don't carry coach photos, so restore the established behavior of using the **school logo** as the coach's image (as `CoachCard` already does).

- `CoachIdentityCard` (96px / `xl`) and `CoachDetailHeader` (32px / `sm`) now render `SchoolLogo` when the school is known.
- Falls back to initials only when the coach has no school.

## Test plan
- [x] type-check 0 · audit:tokens 0 · coach specs 32 pass (fallback path — no school prop — still renders initials)
- [ ] Browser verify on QA — coach detail shows school logo in header + identity card

https://claude.ai/code/session_016KpKsqXh9xkAZWg1FSDY8K