### PR TITLE
feat(coach): show phone on coach detail

### DIFF
--- a/components/Coach/detail/CoachIdentityCard.vue
+++ b/components/Coach/detail/CoachIdentityCard.vue
@@ -38,6 +38,14 @@ const fullName = computed(
       {{ coach.email }}
     </a>
 
+    <a
+      v-if="coach.phone"
+      :href="`tel:${coach.phone}`"
+      class="mt-1 block truncate text-[13px] text-slate-600 hover:underline"
+    >
+      {{ coach.phone }}
+    </a>
+
     <div
       v-if="coach.twitter_handle || coach.instagram_handle"
       class="mt-3 space-y-2 border-t border-slate-200 pt-3"


### PR DESCRIPTION
Display the coach's phone number (as a `tel:` link) beneath the email on `CoachIdentityCard` when present. Hidden when the coach has no phone.

`type-check` 0 · `audit:tokens` 0 · coach specs 66 pass.

https://claude.ai/code/session_016KpKsqXh9xkAZWg1FSDY8K