### PR TITLE
fix(coach): Days Since Contact from interaction history

### DIFF
--- a/composables/useCoachInsights.ts
+++ b/composables/useCoachInsights.ts
@@ -4,8 +4,23 @@ import type { Coach, Interaction } from "~/types/models";
 export const OVERDUE_DAYS = 14;
 
 export function useCoachInsights(coach: Ref<Coach | null>, interactions: Ref<Interaction[]>) {
+  // Prefer the actual interaction history — the most recent interaction is the
+  // true "last contact". Fall back to the coach's stored last_contact_date only
+  // when no dated interactions are loaded (e.g. list views without the history).
+  const lastContactAt = computed<string | null>(() => {
+    let latest: number | null = null;
+    for (const i of interactions.value) {
+      if (!i.occurred_at) continue;
+      const t = new Date(i.occurred_at).getTime();
+      if (Number.isNaN(t)) continue;
+      if (latest === null || t > latest) latest = t;
+    }
+    if (latest !== null) return new Date(latest).toISOString();
+    return coach.value?.last_contact_date ?? null;
+  });
+
   const daysSinceContact = computed<number | null>(() => {
-    const d = coach.value?.last_contact_date;
+    const d = lastContactAt.value;
     if (!d) return null;
     return Math.floor((Date.now() - new Date(d).getTime()) / 864e5);
   });

--- a/tests/unit/composables/useCoachInsights.spec.ts
+++ b/tests/unit/composables/useCoachInsights.spec.ts
@@ -31,6 +31,31 @@ describe("useCoachInsights", () => {
     expect(i.isOverdue.value).toBe(false);
   });
 
+  it("derives daysSinceContact from the most recent interaction when last_contact_date is null", () => {
+    const i = useCoachInsights(
+      ref(coach()),
+      ref([ix({ occurred_at: daysAgo(60) }), ix({ occurred_at: daysAgo(90) })]),
+    );
+    expect(i.daysSinceContact.value).toBe(60);
+    expect(i.isOverdue.value).toBe(true);
+  });
+
+  it("prefers the most recent interaction over an older last_contact_date", () => {
+    const i = useCoachInsights(
+      ref(coach({ last_contact_date: daysAgo(100) })),
+      ref([ix({ occurred_at: daysAgo(5) })]),
+    );
+    expect(i.daysSinceContact.value).toBe(5);
+  });
+
+  it("falls back to last_contact_date when interactions have no dates", () => {
+    const i = useCoachInsights(
+      ref(coach({ last_contact_date: daysAgo(20) })),
+      ref([ix({ occurred_at: undefined })]),
+    );
+    expect(i.daysSinceContact.value).toBe(20);
+  });
+
   it("computes preferred channel as the mode of interaction types", () => {
     const i = useCoachInsights(ref(coach()), ref([ix({ type: "phone_call" }), ix({ type: "phone_call" }), ix({ type: "email" })]));
     expect(i.preferredChannel.value).toBe("phone_call");


### PR DESCRIPTION
## Bug
Coach detail "Days Since Contact" showed `—` even with a logged interaction (e.g. an email dated Jun 1). `useCoachInsights.daysSinceContact` read `coach.last_contact_date`, but that column is only written by the old inline-composer path (`useCommunication.ts`) that the detail redesign removed. Logging through `/interactions/add` never stamps it → null → dash.

## Fix
Derive the last-contact date from the most recent interaction's `occurred_at` (authoritative on the detail page, which loads the coach's interactions), falling back to `last_contact_date` only when no dated interactions are present. Fixes the card, `isOverdue`, and the overdue alert.

## Tests
Bug-driven TDD: added failing cases (derive from latest interaction; prefer interaction over older `last_contact_date`; fall back when undated) → RED → GREEN. `type-check` 0, coach specs 77 pass.

## Follow-up (not in this PR)
Coach **list** views (`useCoachListStats`, `useCoachFilters`, `useCoachPageFilters`) still read the stale `coach.last_contact_date` and don't load interactions. Logging an interaction should also stamp `coaches.last_contact_date` (on `createInteraction` or via a DB trigger) so those stay correct — flagging for a separate change.

https://claude.ai/code/session_016KpKsqXh9xkAZWg1FSDY8K