### PR TITLE
feat(db): stamp coach last_contact_date on interaction create

### DIFF
--- a/supabase/migrations/20260906000000_stamp_coach_last_contact_on_interaction.sql
+++ b/supabase/migrations/20260906000000_stamp_coach_last_contact_on_interaction.sql
@@ -1,0 +1,52 @@
+-- Stamp coaches.last_contact_date when an interaction is logged.
+--
+-- Background: coaches.last_contact_date was only written by the old inline
+-- coach-composer path. Interactions logged through /interactions/add (or iOS)
+-- never advanced it, so coach-list "days since contact", sorting, and filters
+-- went stale. This AFTER INSERT trigger stamps it for every write path.
+--
+-- Forward-only: uses GREATEST so a backdated older interaction never regresses
+-- a coach that already has more recent contact. SECURITY DEFINER so it can
+-- update coaches regardless of the caller's RLS (the trigger only ever touches
+-- the coach the interaction already references).
+--
+-- Scope: INSERT only, matching "stamp on interaction create". Edits/deletes of
+-- interactions do not recompute the field (rare; a follow-up could recompute).
+
+create or replace function public.stamp_coach_last_contact()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  if new.coach_id is not null and new.occurred_at is not null then
+    update public.coaches
+       set last_contact_date = greatest(
+             coalesce(last_contact_date, new.occurred_at),
+             new.occurred_at
+           )
+     where id = new.coach_id;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_stamp_coach_last_contact on public.interactions;
+
+create trigger trg_stamp_coach_last_contact
+  after insert on public.interactions
+  for each row
+  execute function public.stamp_coach_last_contact();
+
+-- Backfill existing coaches from their interaction history (forward-only).
+update public.coaches c
+   set last_contact_date = greatest(coalesce(c.last_contact_date, sub.mx), sub.mx)
+  from (
+    select coach_id, max(occurred_at) as mx
+      from public.interactions
+     where coach_id is not null
+       and occurred_at is not null
+     group by coach_id
+  ) sub
+ where c.id = sub.coach_id;


### PR DESCRIPTION
## What
`AFTER INSERT` trigger on `interactions` that advances `coaches.last_contact_date` (forward-only, `GREATEST`) whenever an interaction with a `coach_id` + `occurred_at` is logged — for every write path (web `/interactions/add`, iOS, etc.). Includes a one-time backfill from existing interaction history. `SECURITY DEFINER` so it updates the referenced coach regardless of caller RLS.

## Why
`last_contact_date` was only written by the old inline coach composer (removed in the detail redesign). Interactions logged elsewhere left it stale/null, so coach-**list** days-since, sorting, and filters were wrong. (The detail card was already fixed in #484 by deriving from interactions; this fixes the list views that don't load interaction history.)

## Applied live
Applied via Supabase MCP to `xpxzhqghxecsjhvklsqg` (single DB serves prod+QA). Verified: trigger present + enabled; backfill correct (Doug Adams → 2026-06-01, matching his only interaction). Migration file rides in this PR so the repo stays in sync.

## Scope / follow-up
INSERT only (matches "on interaction create"). Editing or deleting an interaction does not recompute the field — rare; a recompute-on-delete could follow if needed.

https://claude.ai/code/session_016KpKsqXh9xkAZWg1FSDY8K