### PR TITLE
security: finish Turnstile integration (action + hostname + token-length + client reset)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,12 @@ CRON_SECRET=your-cron-secret-here
 
 # Social media sync
 SYNC_API_KEY=your-sync-api-key-here
+# Cloudflare Turnstile (public player profile contact flow)
+# Site key is public (embedded in the client). Secret key is server-only.
+# Widget renders only when the site key is set; server verification no-ops
+# (passes) when the secret is absent. Optional NUXT_TURNSTILE_HOSTNAMES is a
+# comma-separated allowlist enforced only when set (e.g. myrecruitingcompass.com,qa.myrecruitingcompass.com).
+# (example uses Cloudflare's always-pass TEST site key; set your real site key in Vercel/.env)
+NUXT_PUBLIC_TURNSTILE_SITE_KEY=1x00000000000000000000AA
+NUXT_TURNSTILE_SECRET_KEY=your-turnstile-secret-key-here
+# NUXT_TURNSTILE_HOSTNAMES=myrecruitingcompass.com,qa.myrecruitingcompass.com

--- a/components/profile/public/ContactPlayerModal.vue
+++ b/components/profile/public/ContactPlayerModal.vue
@@ -83,6 +83,7 @@ const turnstileSiteKey = computed(
 const turnstileEnabled = computed(() => turnstileSiteKey.value.length > 0);
 const turnstileToken = ref<string | undefined>(undefined);
 const turnstileEl = ref<HTMLDivElement | null>(null);
+const turnstileWidgetId = ref<string | undefined>(undefined);
 
 const TURNSTILE_SCRIPT_SRC =
   "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
@@ -90,8 +91,13 @@ const TURNSTILE_SCRIPT_SRC =
 type TurnstileGlobal = {
   render: (
     el: HTMLElement,
-    options: { sitekey: string; callback: (token: string) => void },
-  ) => void;
+    options: {
+      sitekey: string;
+      action?: string;
+      callback: (token: string) => void;
+    },
+  ) => string;
+  reset: (widgetId?: string) => void;
 };
 
 function loadTurnstileScript(): Promise<void> {
@@ -127,8 +133,9 @@ onMounted(async () => {
     await loadTurnstileScript();
     const w = window as unknown as { turnstile?: TurnstileGlobal };
     if (w.turnstile && turnstileEl.value) {
-      w.turnstile.render(turnstileEl.value, {
+      turnstileWidgetId.value = w.turnstile.render(turnstileEl.value, {
         sitekey: turnstileSiteKey.value,
+        action: "contact",
         callback: (token: string) => {
           turnstileToken.value = token;
         },
@@ -178,9 +185,21 @@ async function handleSubmit() {
     emit("submitted");
   } catch (err) {
     submitError.value = friendlyErrorMessage(err);
+    resetTurnstile();
   } finally {
     submitting.value = false;
   }
+}
+
+// A Turnstile token is single-use — Cloudflare redeems it at siteverify, so
+// replaying the same token after a failed submit always fails. Resetting
+// the widget mints a fresh token for the retry instead of 403-looping.
+function resetTurnstile() {
+  const w = window as unknown as { turnstile?: TurnstileGlobal };
+  if (w.turnstile) {
+    w.turnstile.reset(turnstileWidgetId.value);
+  }
+  turnstileToken.value = undefined;
 }
 
 function handleClose() {

--- a/server/api/public/profile/[slug]/contact.post.ts
+++ b/server/api/public/profile/[slug]/contact.post.ts
@@ -117,10 +117,10 @@ export default defineEventHandler(async (event) => {
     }
     const data = parsed.data;
 
-    const turnstileResult = await verifyTurnstile(
-      data.turnstileToken,
-      clientIp,
-    );
+    const turnstileResult = await verifyTurnstile(data.turnstileToken, {
+      ip: clientIp,
+      expectedAction: "contact",
+    });
     if (turnstileResult.reason === "disabled") {
       logger.warn(
         "Turnstile verification disabled (no secret key configured) — relying on honeypot + rate limit only",

--- a/server/utils/turnstile.ts
+++ b/server/utils/turnstile.ts
@@ -4,12 +4,24 @@
  * configured, verification is a silent no-op PASS (mirrors the
  * RESEND_API_KEY guard in server/utils/emailService.ts) so the flow works
  * before Turnstile is provisioned.
+ *
+ * Verifies the full siteverify contract, not just `success`: the response
+ * `action` must match the caller's `expectedAction` (defends against a
+ * token minted for a different widget/flow being replayed here), and when
+ * `NUXT_TURNSTILE_HOSTNAMES` is configured, `hostname` must be in that
+ * allowlist (defends against a token minted on an attacker-controlled page
+ * embedding the same site key). The hostname check is opt-in — unset env
+ * means skip it, not fail open on success/action.
  */
 
 const VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+const MAX_TOKEN_LENGTH = 2048;
 
 interface TurnstileVerifyResponse {
   success: boolean;
+  action?: string;
+  hostname?: string;
+  "error-codes"?: string[];
 }
 
 export interface TurnstileResult {
@@ -17,15 +29,25 @@ export interface TurnstileResult {
   reason?: string;
 }
 
+function allowedHostnames(): string[] | null {
+  const raw = process.env.NUXT_TURNSTILE_HOSTNAMES;
+  if (!raw) return null;
+  const hosts = raw
+    .split(",")
+    .map((h) => h.trim())
+    .filter((h) => h.length > 0);
+  return hosts.length > 0 ? hosts : null;
+}
+
 /**
  * Verifies a Turnstile response token against Cloudflare's siteverify API.
- * Never throws: network errors and non-2xx responses resolve to a failed
- * result rather than propagating, so callers can treat this as a plain
- * boolean gate.
+ * Never throws: network errors, non-2xx responses, and contract violations
+ * (action/hostname mismatch) all resolve to a failed result rather than
+ * propagating, so callers can treat this as a plain boolean gate.
  */
 export async function verifyTurnstile(
   token: string | undefined,
-  ip?: string,
+  opts?: { ip?: string; expectedAction?: string },
 ): Promise<TurnstileResult> {
   const secretKey = process.env.NUXT_TURNSTILE_SECRET_KEY;
 
@@ -33,13 +55,17 @@ export async function verifyTurnstile(
     return { ok: true, reason: "disabled" };
   }
 
+  if (!token || token.length === 0 || token.length > MAX_TOKEN_LENGTH) {
+    return { ok: false, reason: "missing_token" };
+  }
+
   try {
     const body = new URLSearchParams({
       secret: secretKey,
-      response: token ?? "",
+      response: token,
     });
-    if (ip) {
-      body.set("remoteip", ip);
+    if (opts?.ip) {
+      body.set("remoteip", opts.ip);
     }
 
     const response = await fetch(VERIFY_URL, {
@@ -53,7 +79,20 @@ export async function verifyTurnstile(
     }
 
     const data = (await response.json()) as TurnstileVerifyResponse;
-    return { ok: data.success === true };
+    if (data.success !== true) {
+      return { ok: false };
+    }
+
+    if (opts?.expectedAction && data.action !== opts.expectedAction) {
+      return { ok: false, reason: "action_mismatch" };
+    }
+
+    const hosts = allowedHostnames();
+    if (hosts && (!data.hostname || !hosts.includes(data.hostname))) {
+      return { ok: false, reason: "hostname_mismatch" };
+    }
+
+    return { ok: true };
   } catch {
     return { ok: false, reason: "verify_failed" };
   }

--- a/tests/unit/components/profile/ContactPlayerModal.spec.ts
+++ b/tests/unit/components/profile/ContactPlayerModal.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { mount } from "@vue/test-utils";
 
 let turnstileSiteKey = "";
@@ -154,5 +154,67 @@ describe("ContactPlayerModal", () => {
     const w = mount(ContactPlayerModal, { props: baseProps });
     await w.find("[data-test='modal-close']").trigger("click");
     expect(w.emitted().close).toBeTruthy();
+  });
+
+  describe("Turnstile widget render + reset", () => {
+    afterEach(() => {
+      delete (window as unknown as { turnstile?: unknown }).turnstile;
+    });
+
+    it("renders the widget with action: 'contact' when a site key is configured", async () => {
+      turnstileSiteKey = "test-site-key";
+      const renderMock = vi.fn().mockReturnValue("widget-1");
+      (window as unknown as { turnstile: unknown }).turnstile = {
+        render: renderMock,
+        reset: vi.fn(),
+      };
+
+      mount(ContactPlayerModal, { props: baseProps });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(renderMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          sitekey: "test-site-key",
+          action: "contact",
+        }),
+      );
+    });
+
+    it("resets the widget and clears the token when a submit fails", async () => {
+      turnstileSiteKey = "test-site-key";
+      const resetMock = vi.fn();
+      let capturedCallback: ((token: string) => void) | undefined;
+      const renderMock = vi.fn((_el, options) => {
+        capturedCallback = options.callback;
+        return "widget-1";
+      });
+      (window as unknown as { turnstile: unknown }).turnstile = {
+        render: renderMock,
+        reset: resetMock,
+      };
+
+      const fetchMock = vi.fn().mockRejectedValue(new Error("boom"));
+      vi.stubGlobal("$fetch", fetchMock);
+
+      const w = mount(ContactPlayerModal, { props: baseProps });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      capturedCallback?.("spent-token");
+      await w.vm.$nextTick();
+
+      await w.find("[data-test='coach-name']").setValue("Coach Smith");
+      await w.find("[data-test='note']").setValue("Note text here.");
+      await w.find("form").trigger("submit");
+      await w.vm.$nextTick();
+      await w.vm.$nextTick();
+
+      expect(resetMock).toHaveBeenCalledWith("widget-1");
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          body: expect.objectContaining({ turnstileToken: "spent-token" }),
+        }),
+      );
+    });
   });
 });

--- a/tests/unit/server/api/public/contact.spec.ts
+++ b/tests/unit/server/api/public/contact.spec.ts
@@ -376,7 +376,10 @@ describe("POST /api/public/profile/[slug]/contact", () => {
         expect.objectContaining({ ip: "9.9.9.9" }),
       );
       expect(mockState.insertedContact).toMatchObject({ ip: "9.9.9.9" });
-      expect(verifyTurnstileMock).toHaveBeenCalledWith(undefined, "9.9.9.9");
+      expect(verifyTurnstileMock).toHaveBeenCalledWith(undefined, {
+        ip: "9.9.9.9",
+        expectedAction: "contact",
+      });
     });
 
     it("ignores a spoofed leftmost X-Forwarded-For when x-vercel-forwarded-for is present", async () => {

--- a/tests/unit/server/utils/turnstile.spec.ts
+++ b/tests/unit/server/utils/turnstile.spec.ts
@@ -4,9 +4,11 @@ import { verifyTurnstile, isHoneypotTripped } from "~/server/utils/turnstile";
 describe("turnstile", () => {
   const originalFetch = global.fetch;
   const originalKey = process.env.NUXT_TURNSTILE_SECRET_KEY;
+  const originalHostnames = process.env.NUXT_TURNSTILE_HOSTNAMES;
 
   beforeEach(() => {
     delete process.env.NUXT_TURNSTILE_SECRET_KEY;
+    delete process.env.NUXT_TURNSTILE_HOSTNAMES;
   });
 
   afterEach(() => {
@@ -15,6 +17,11 @@ describe("turnstile", () => {
       delete process.env.NUXT_TURNSTILE_SECRET_KEY;
     } else {
       process.env.NUXT_TURNSTILE_SECRET_KEY = originalKey;
+    }
+    if (originalHostnames === undefined) {
+      delete process.env.NUXT_TURNSTILE_HOSTNAMES;
+    } else {
+      process.env.NUXT_TURNSTILE_HOSTNAMES = originalHostnames;
     }
   });
 
@@ -28,20 +35,56 @@ describe("turnstile", () => {
       expect(global.fetch).not.toHaveBeenCalled();
     });
 
-    it("resolves ok:true when secret set and Cloudflare reports success", async () => {
+    it("resolves ok:true when secret set, success true, and action matches expectedAction", async () => {
       process.env.NUXT_TURNSTILE_SECRET_KEY = "test-secret";
       global.fetch = vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve({ success: true }),
+        json: () =>
+          Promise.resolve({
+            success: true,
+            action: "contact",
+            hostname: "example.com",
+          }),
       });
 
-      const result = await verifyTurnstile("token-123", "1.2.3.4");
+      const result = await verifyTurnstile("token-123", {
+        ip: "1.2.3.4",
+        expectedAction: "contact",
+      });
 
       expect(result).toEqual({ ok: true });
       expect(global.fetch).toHaveBeenCalledWith(
         "https://challenges.cloudflare.com/turnstile/v0/siteverify",
         expect.objectContaining({ method: "POST" }),
       );
+    });
+
+    it("resolves ok:true when no expectedAction is passed (action not checked)", async () => {
+      process.env.NUXT_TURNSTILE_SECRET_KEY = "test-secret";
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ success: true, action: "whatever" }),
+      });
+
+      const result = await verifyTurnstile("token-123");
+
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("resolves ok:false reason:action_mismatch when action does not match expectedAction", async () => {
+      process.env.NUXT_TURNSTILE_SECRET_KEY = "test-secret";
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ success: true, action: "login" }),
+      });
+
+      const result = await verifyTurnstile("token-123", {
+        expectedAction: "contact",
+      });
+
+      expect(result).toEqual({ ok: false, reason: "action_mismatch" });
     });
 
     it("resolves ok:false when Cloudflare reports success:false", async () => {
@@ -54,6 +97,77 @@ describe("turnstile", () => {
       const result = await verifyTurnstile("token-123");
 
       expect(result).toEqual({ ok: false });
+    });
+
+    it("resolves ok:true when NUXT_TURNSTILE_HOSTNAMES is set and hostname matches", async () => {
+      process.env.NUXT_TURNSTILE_SECRET_KEY = "test-secret";
+      process.env.NUXT_TURNSTILE_HOSTNAMES = "example.com, other.com";
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ success: true, hostname: "example.com" }),
+      });
+
+      const result = await verifyTurnstile("token-123");
+
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("resolves ok:false reason:hostname_mismatch when NUXT_TURNSTILE_HOSTNAMES is set and hostname does not match", async () => {
+      process.env.NUXT_TURNSTILE_SECRET_KEY = "test-secret";
+      process.env.NUXT_TURNSTILE_HOSTNAMES = "example.com";
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ success: true, hostname: "evil.com" }),
+      });
+
+      const result = await verifyTurnstile("token-123");
+
+      expect(result).toEqual({ ok: false, reason: "hostname_mismatch" });
+    });
+
+    it("ignores hostname when NUXT_TURNSTILE_HOSTNAMES is unset", async () => {
+      process.env.NUXT_TURNSTILE_SECRET_KEY = "test-secret";
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ success: true, hostname: "anything-at-all.com" }),
+      });
+
+      const result = await verifyTurnstile("token-123");
+
+      expect(result).toEqual({ ok: true });
+    });
+
+    it("resolves ok:false reason:missing_token and never calls fetch when token is undefined", async () => {
+      process.env.NUXT_TURNSTILE_SECRET_KEY = "test-secret";
+      global.fetch = vi.fn();
+
+      const result = await verifyTurnstile(undefined);
+
+      expect(result).toEqual({ ok: false, reason: "missing_token" });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("resolves ok:false reason:missing_token and never calls fetch when token is empty string", async () => {
+      process.env.NUXT_TURNSTILE_SECRET_KEY = "test-secret";
+      global.fetch = vi.fn();
+
+      const result = await verifyTurnstile("");
+
+      expect(result).toEqual({ ok: false, reason: "missing_token" });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("resolves ok:false reason:missing_token and never calls fetch when token exceeds 2048 chars", async () => {
+      process.env.NUXT_TURNSTILE_SECRET_KEY = "test-secret";
+      global.fetch = vi.fn();
+
+      const result = await verifyTurnstile("a".repeat(2049));
+
+      expect(result).toEqual({ ok: false, reason: "missing_token" });
+      expect(global.fetch).not.toHaveBeenCalled();
     });
 
     it("resolves ok:false reason:verify_failed and never throws when fetch rejects", async () => {


### PR DESCRIPTION
## Turnstile integration — finish the Phase 3 launch gate

Completes the Cloudflare Turnstile integration for the Contact Player flow (Phase 3, #491), following Cloudflare's existing-widget hardening flow. Widget is provisioned (site key `0x4AAAAAAEc9xAHjjO-Jv5pg`).

### What changed
- **`server/utils/turnstile.ts`** — `verifyTurnstile` now enforces Cloudflare's full siteverify contract, not just `success`:
  - token-length guard (missing/empty/>2048 → reject **before** any network call),
  - `action` must equal the expected action (`"contact"`),
  - `hostname` allowlist enforced **only when `NUXT_TURNSTILE_HOSTNAMES` is set** (opt-in; unset → skipped, so QA/prod don't break before it's configured); a missing hostname fails closed when the list is set,
  - still a **no-op PASS when the secret is absent** (flag-off), still **never throws** (network/parse → reject).
- **`contact.post.ts`** — passes `expectedAction: "contact"`; 403-on-fail + disabled-warn unchanged.
- **`ContactPlayerModal.vue`** — renders the widget with `action: "contact"`, captures the `widgetId`, and **resets the widget + clears the token on a failed submit** (Turnstile tokens are single-use — without reset a retry replays a spent token and 403-loops).
- **`.env.example`** — documents `NUXT_PUBLIC_TURNSTILE_SITE_KEY` (public), `NUXT_TURNSTILE_SECRET_KEY` (server, placeholder), and the optional `NUXT_TURNSTILE_HOSTNAMES` allowlist. Uses Cloudflare's always-pass test site key as the placeholder.

### To arm it (env only — no further code)
1. Set in **Vercel Production** (and Preview for QA if wanted): `NUXT_PUBLIC_TURNSTILE_SITE_KEY=0x4AAAAAAEc9xAHjjO-Jv5pg` + `NUXT_TURNSTILE_SECRET_KEY=<secret from the Cloudflare widget>`.
2. **Redeploy** (the app is `ssr:false`, so `NUXT_PUBLIC_*` is baked at build).
3. Optionally set `NUXT_TURNSTILE_HOSTNAMES=myrecruitingcompass.com,qa.myrecruitingcompass.com` to enforce the server hostname check.
Behavior: site key present → widget renders + server verifies (fail-closed); absent → verifier no-ops. Nothing breaks in between.

### Test plan
Unit **8123 pass / 0 fail** · type-check 0 · lint 0 · audit:tokens 0. New tests cover: action mismatch, hostname enforce/skip, token-length no-fetch guard, reset-on-failed-submit, and the unchanged secret-absent no-op.

Closes the Turnstile half of the Phase-3 public-launch gate (Upstash rate-limit env still to confirm).

https://claude.ai/code/session_0171A2GPq5iCs5X9ciXwBFqJ
