### PR TITLE
test: cover invalid-refresh-token → login-redirect path

### DIFF
--- a/tests/unit/composables/useSupabase.spec.ts
+++ b/tests/unit/composables/useSupabase.spec.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
+// Captures the callback useSupabase() registers via onAuthStateChange, since
+// the client is a module-level singleton — it's only ever constructed (and
+// onAuthStateChange only ever called) once across this whole test file.
+let authStateCallback:
+  | ((event: string, session: unknown) => void)
+  | undefined;
+const mockSignOut = vi.fn();
+
+// useServiceStatus is a Nuxt auto-import in the source (no explicit import
+// statement) — inject as a global for the test environment.
+global.useServiceStatus = () => ({
+  markServiceUnavailable: vi.fn(),
+  markServiceAvailable: vi.fn(),
+});
+
 // Mock Supabase
 vi.mock("@supabase/supabase-js", () => ({
   createClient: vi.fn(() => ({
@@ -7,7 +22,10 @@ vi.mock("@supabase/supabase-js", () => ({
       getSession: vi.fn(),
       signUp: vi.fn(),
       signInWithPassword: vi.fn(),
-      signOut: vi.fn(),
+      signOut: mockSignOut,
+      onAuthStateChange: vi.fn((cb) => {
+        authStateCallback = cb;
+      }),
     },
     from: vi.fn(),
   })),
@@ -40,5 +58,29 @@ describe("useSupabase", () => {
     const client1 = useSupabase();
     const client2 = useSupabase();
     expect(client1).toBe(client2);
+  });
+
+  it("clears the local session when a token refresh comes back with no session", () => {
+    // Reproduces "AuthApiError: Invalid Refresh Token: Refresh Token Not
+    // Found" — Supabase reports TOKEN_REFRESHED with a null session when it
+    // can't recover the stored refresh token. The composable must sign the
+    // user out locally so the SIGNED_OUT listener (plugins/auth.client.ts)
+    // clears app state and middleware/auth.ts redirects to /login.
+    useSupabase();
+    expect(authStateCallback).toBeDefined();
+
+    authStateCallback?.("TOKEN_REFRESHED", null);
+
+    expect(mockSignOut).toHaveBeenCalledOnce();
+    expect(mockSignOut).toHaveBeenCalledWith({ scope: "local" });
+  });
+
+  it("does not sign out on a successful token refresh", () => {
+    useSupabase();
+    expect(authStateCallback).toBeDefined();
+
+    authStateCallback?.("TOKEN_REFRESHED", { access_token: "valid-token" });
+
+    expect(mockSignOut).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/plugins/auth.client.spec.ts
+++ b/tests/unit/plugins/auth.client.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// auth.client.ts registers a Supabase onAuthStateChange listener that must
+// route the user back to /login (via userStore.logout + resetAppState) when
+// the session ends — including when Supabase signs the user out locally
+// after failing to refresh an invalid/expired refresh token
+// ("AuthApiError: Invalid Refresh Token: Refresh Token Not Found").
+
+vi.mock("#app", () => ({
+  defineNuxtPlugin: (fn: (ctx: unknown) => unknown) => fn,
+}));
+
+let authStateCallback: (event: string) => void = () => {};
+const mockOnAuthStateChange = vi.fn((cb: (event: string) => void) => {
+  authStateCallback = cb;
+});
+
+// useSupabase and useUserStore are Nuxt auto-imports in the source (no
+// explicit import statements) — inject as globals for the test environment.
+global.useSupabase = () => ({
+  auth: { onAuthStateChange: mockOnAuthStateChange },
+});
+
+const mockLogout = vi.fn();
+const mockInitializeUser = vi.fn();
+global.useUserStore = () => ({
+  logout: mockLogout,
+  initializeUser: mockInitializeUser,
+});
+
+const mockResetAppState = vi.fn();
+vi.mock("~/composables/useAuthLifecycle", () => ({
+  resetAppState: mockResetAppState,
+}));
+
+describe("auth.client plugin", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const { default: plugin } = await import("~/plugins/auth.client");
+    plugin(undefined as never);
+  });
+
+  it("registers a single onAuthStateChange listener", () => {
+    expect(mockOnAuthStateChange).toHaveBeenCalledOnce();
+  });
+
+  it("logs the user out and resets app state on SIGNED_OUT", () => {
+    // This is the path an invalid/missing refresh token takes: Supabase
+    // emits SIGNED_OUT after failing to recover the session, which must
+    // clear local state so middleware/auth.ts redirects to /login.
+    authStateCallback("SIGNED_OUT");
+
+    expect(mockLogout).toHaveBeenCalledOnce();
+    expect(mockResetAppState).toHaveBeenCalledOnce();
+    expect(mockInitializeUser).not.toHaveBeenCalled();
+  });
+
+  it("initializes the user on SIGNED_IN without logging out", () => {
+    authStateCallback("SIGNED_IN");
+
+    expect(mockInitializeUser).toHaveBeenCalledOnce();
+    expect(mockLogout).not.toHaveBeenCalled();
+    expect(mockResetAppState).not.toHaveBeenCalled();
+  });
+
+  it("does nothing on unrelated auth events", () => {
+    authStateCallback("USER_UPDATED");
+
+    expect(mockLogout).not.toHaveBeenCalled();
+    expect(mockResetAppState).not.toHaveBeenCalled();
+    expect(mockInitializeUser).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Investigated #37 (`AuthApiError: Invalid Refresh Token: Refresh Token Not Found`) — confirmed the app already handles this gracefully: `useSupabase.ts` signs out locally on a failed refresh, `plugins/auth.client.ts` reacts to `SIGNED_OUT`, and `middleware/auth.ts` redirects to /login.
- Added missing regression tests for both of those paths; no production code changed.

Fixes #37.

Generated with [Claude Code](https://claude.ai/code)