### PR TITLE
feat: Public Player Profile Phase 4 — Express Interest + inbound inbox

### DIFF
--- a/components/profile/ProfileInbox.vue
+++ b/components/profile/ProfileInbox.vue
@@ -1,0 +1,92 @@
+<template>
+  <div class="space-y-6">
+    <StatsTiles :stats="inboxStats" aria-label="Inbound Leads Statistics" />
+
+    <DesignSystemLoadingState
+      v-if="loading"
+      message="Loading your inbox..."
+    />
+    <DesignSystemErrorState
+      v-else-if="error"
+      :error="error"
+      @retry="fetchContacts"
+    />
+    <DesignSystemEmptyState
+      v-else-if="leads.length === 0"
+      title="No leads yet"
+      description="Coach interest and messages from your public profile will show up here."
+    />
+    <ul v-else class="space-y-3">
+      <li
+        v-for="lead in leads"
+        :key="lead.id"
+        class="rounded-xl border border-slate-200 bg-white p-4 shadow-xs"
+      >
+        <div class="flex items-start justify-between gap-3">
+          <div class="min-w-0">
+            <div class="mb-1 flex items-center gap-2">
+              <DesignSystemBadge
+                :color="lead.type === 'interest' ? 'purple' : 'blue'"
+                variant="light"
+                size="sm"
+              >
+                {{ lead.type === "interest" ? "Interest" : "Contact" }}
+              </DesignSystemBadge>
+              <span class="truncate font-semibold text-slate-900">{{
+                lead.coach_name
+              }}</span>
+            </div>
+            <p class="text-sm text-slate-600">
+              <span v-if="lead.program">{{ lead.program }}</span>
+              <span v-if="lead.program && lead.school_name"> &middot; </span>
+              <span v-if="lead.school_name">{{ lead.school_name }}</span>
+            </p>
+            <p v-if="lead.note" class="mt-2 line-clamp-2 text-sm text-slate-500">
+              {{ lead.note }}
+            </p>
+          </div>
+          <span class="shrink-0 text-xs whitespace-nowrap text-slate-400">
+            {{ formatLeadDate(lead.created_at) }}
+          </span>
+        </div>
+      </li>
+    </ul>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import StatsTiles from "~/components/shared/StatsTiles.vue";
+import { useProfileContacts } from "~/composables/useProfileContacts";
+
+const { leads, counts, loading, error, fetchContacts } = useProfileContacts();
+
+const inboxStats = computed(() => [
+  {
+    label: "Interest this month",
+    value: counts.value.interestThisMonth,
+    icon: "i-heroicons-hand-raised",
+    color: "purple" as const,
+    testId: "stat-interest-this-month",
+  },
+  {
+    label: "Contact this month",
+    value: counts.value.contactThisMonth,
+    icon: "i-heroicons-envelope",
+    color: "blue" as const,
+    testId: "stat-contact-this-month",
+  },
+]);
+
+function formatLeadDate(dateString: string): string {
+  const date = new Date(dateString);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffDays < 1) return "Today";
+  if (diffDays < 7) return `${diffDays}d ago`;
+
+  return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+}
+</script>

--- a/components/profile/PublicProfileCard.vue
+++ b/components/profile/PublicProfileCard.vue
@@ -1,6 +1,6 @@
 <!-- components/profile/PublicProfileCard.vue -->
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, onMounted } from "vue";
 import type { PublicProfileData } from "~/types/models";
 import ProfileHero from "~/components/profile/public/ProfileHero.vue";
 import MetricsGrid from "~/components/profile/public/MetricsGrid.vue";
@@ -10,6 +10,7 @@ import TargetProgramValues from "~/components/profile/public/TargetProgramValues
 import TeamHistoryPanel from "~/components/profile/public/TeamHistoryPanel.vue";
 import AwardsHonors from "~/components/profile/public/AwardsHonors.vue";
 import ContactPlayerModal from "~/components/profile/public/ContactPlayerModal.vue";
+import ExpressInterestPopover from "~/components/profile/public/ExpressInterestPopover.vue";
 
 // `slug` is optional because the owner-side live preview (ProfileLivePreview)
 // renders this card before the profile has a real public URL.
@@ -39,6 +40,58 @@ function handleContact() {
 function closeContactModal() {
   showContactModal.value = false;
 }
+
+// Express Interest mirrors the Contact flow above, plus a persisted "sent"
+// state so the hero button reflects a prior submission across reloads.
+const showInterestPopover = ref(false);
+const interestSent = ref(false);
+
+function interestSentKey(slug: string): string {
+  return `interest-sent:${slug}`;
+}
+
+onMounted(() => {
+  if (!props.slug) return;
+  try {
+    interestSent.value =
+      window.localStorage.getItem(interestSentKey(props.slug)) === "true";
+  } catch {
+    // Storage unavailable (private mode, SSR hydration edge case) — the
+    // server remains the source of truth, so just skip the UX shortcut.
+  }
+});
+
+// Programs offered to the popover derive from the athlete's public sport +
+// positions — null-safe since `athletic` is null when that section is
+// hidden, in which case the popover falls back to its free-text input.
+const interestPrograms = computed(() => {
+  const a = props.data.athletic;
+  const values = [a?.primary_sport, ...(a?.positions ?? [])].filter(
+    (v): v is string => !!v,
+  );
+  return [...new Set(values)];
+});
+
+function handleInterest() {
+  emit("interest");
+  if (!props.slug) return;
+  showInterestPopover.value = true;
+}
+
+function closeInterestPopover() {
+  showInterestPopover.value = false;
+}
+
+function onInterestSubmitted() {
+  interestSent.value = true;
+  if (!props.slug) return;
+  try {
+    window.localStorage.setItem(interestSentKey(props.slug), "true");
+  } catch {
+    // Best-effort persistence only — a failed write just means the button
+    // re-enables on the next visit; it doesn't block the confirmation UX.
+  }
+}
 </script>
 
 <template>
@@ -47,8 +100,9 @@ function closeContactModal() {
   >
     <ProfileHero
       :data="data"
+      :interest-sent="interestSent"
       @contact="handleContact"
-      @interest="$emit('interest')"
+      @interest="handleInterest"
     />
 
     <div class="space-y-6 px-6 py-6">
@@ -92,6 +146,15 @@ function closeContactModal() {
       :slug="slug"
       :player-name="data.playerName"
       @close="closeContactModal"
+    />
+
+    <ExpressInterestPopover
+      v-if="showInterestPopover && slug"
+      :slug="slug"
+      :player-name="data.playerName"
+      :programs="interestPrograms"
+      @close="closeInterestPopover"
+      @submitted="onInterestSubmitted"
     />
   </article>
 </template>

--- a/components/profile/public/ExpressInterestPopover.vue
+++ b/components/profile/public/ExpressInterestPopover.vue
@@ -9,7 +9,7 @@
   configured, so the flow works unchanged before Turnstile is provisioned.
 -->
 <script setup lang="ts">
-import { ref, computed, onMounted } from "vue";
+import { ref, computed, onMounted, onBeforeUnmount, nextTick } from "vue";
 import { useRuntimeConfig } from "#app";
 
 const props = defineProps<{
@@ -22,6 +22,17 @@ const emit = defineEmits<{
   close: [];
   submitted: [];
 }>();
+
+const dialogRef = ref<HTMLDialogElement | null>(null);
+
+onMounted(async () => {
+  await nextTick();
+  dialogRef.value?.showModal?.();
+});
+
+onBeforeUnmount(() => {
+  dialogRef.value?.close?.();
+});
 
 const program = ref("");
 const note = ref("");
@@ -183,10 +194,11 @@ function handleClose() {
 </script>
 
 <template>
-  <div
-    class="w-full max-w-sm rounded-xl border-2 border-brand-slate-200 bg-white p-0 shadow-2xl"
-    role="dialog"
+  <dialog
+    ref="dialogRef"
+    class="w-full max-w-sm rounded-xl border-2 border-brand-slate-200 bg-white p-0 shadow-2xl backdrop:bg-black/50"
     aria-labelledby="express-interest-title"
+    @cancel.prevent="handleClose"
   >
     <div class="flex items-center justify-between border-b border-brand-slate-200 px-5 py-3">
       <h2 id="express-interest-title" class="text-base font-semibold text-brand-slate-900">
@@ -332,5 +344,5 @@ function handleClose() {
         </DesignSystemButton>
       </div>
     </form>
-  </div>
+  </dialog>
 </template>

--- a/components/profile/public/ExpressInterestPopover.vue
+++ b/components/profile/public/ExpressInterestPopover.vue
@@ -1,0 +1,336 @@
+<!-- components/profile/public/ExpressInterestPopover.vue -->
+<!--
+  Public-page "Express Interest" popover — the one-tap sibling of
+  Contact Player. Submits POST /api/public/profile/[slug]/interest — see
+  that endpoint for the source-of-truth Zod schema this mirrors client-side.
+  Same anti-abuse layers as ContactPlayerModal: a hidden honeypot field
+  (`hp`) and an optional Turnstile widget (action: "interest", vs
+  ContactPlayerModal's "contact") that only mounts when a site key is
+  configured, so the flow works unchanged before Turnstile is provisioned.
+-->
+<script setup lang="ts">
+import { ref, computed, onMounted } from "vue";
+import { useRuntimeConfig } from "#app";
+
+const props = defineProps<{
+  slug: string;
+  playerName: string;
+  programs?: string[];
+}>();
+
+const emit = defineEmits<{
+  close: [];
+  submitted: [];
+}>();
+
+const program = ref("");
+const note = ref("");
+const coachName = ref("");
+const coachEmail = ref("");
+const hp = ref("");
+
+const hasProgramOptions = computed(() => !!props.programs?.length);
+
+const fieldErrors = ref<{ program?: string; coachEmail?: string; note?: string }>({});
+const submitError = ref("");
+const submitting = ref(false);
+const submitted = ref(false);
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function validate(): boolean {
+  const errors: typeof fieldErrors.value = {};
+  const trimmedProgram = program.value.trim();
+  if (!trimmedProgram) {
+    errors.program = "Please select or enter a program.";
+  } else if (trimmedProgram.length > 80) {
+    errors.program = "Keep the program under 80 characters.";
+  }
+  if (note.value.trim().length > 1000) {
+    errors.note = "Keep the note under 1000 characters.";
+  }
+  if (coachEmail.value.trim() && !EMAIL_RE.test(coachEmail.value.trim())) {
+    errors.coachEmail = "Enter a valid email address.";
+  }
+  fieldErrors.value = errors;
+  return Object.keys(errors).length === 0;
+}
+
+// --- Turnstile (optional, flag-gated) -------------------------------------
+const runtimeConfig = useRuntimeConfig();
+const turnstileSiteKey = computed(
+  () => runtimeConfig.public?.turnstileSiteKey ?? "",
+);
+const turnstileEnabled = computed(() => turnstileSiteKey.value.length > 0);
+const turnstileToken = ref<string | undefined>(undefined);
+const turnstileEl = ref<HTMLDivElement | null>(null);
+const turnstileWidgetId = ref<string | undefined>(undefined);
+
+const TURNSTILE_SCRIPT_SRC =
+  "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+
+type TurnstileGlobal = {
+  render: (
+    el: HTMLElement,
+    options: {
+      sitekey: string;
+      action?: string;
+      callback: (token: string) => void;
+    },
+  ) => string;
+  reset: (widgetId?: string) => void;
+};
+
+function loadTurnstileScript(): Promise<void> {
+  return new Promise((resolve) => {
+    const w = window as unknown as { turnstile?: TurnstileGlobal };
+    if (w.turnstile) {
+      resolve();
+      return;
+    }
+    const existing = document.querySelector<HTMLScriptElement>(
+      `script[src="${TURNSTILE_SCRIPT_SRC}"]`,
+    );
+    const script = existing ?? document.createElement("script");
+    script.addEventListener("load", () => resolve());
+    // Never crash the form: a blocked/failed script just means the widget
+    // never renders and the server no-ops verification when the flag is off.
+    script.addEventListener("error", () => resolve());
+    if (!existing) {
+      try {
+        script.src = TURNSTILE_SCRIPT_SRC;
+        script.async = true;
+        document.head.appendChild(script);
+      } catch {
+        resolve();
+      }
+    }
+  });
+}
+
+onMounted(async () => {
+  if (!turnstileEnabled.value) return;
+  try {
+    await loadTurnstileScript();
+    const w = window as unknown as { turnstile?: TurnstileGlobal };
+    if (w.turnstile && turnstileEl.value) {
+      turnstileWidgetId.value = w.turnstile.render(turnstileEl.value, {
+        sitekey: turnstileSiteKey.value,
+        action: "interest",
+        callback: (token: string) => {
+          turnstileToken.value = token;
+        },
+      });
+    }
+  } catch {
+    // Guarded above; nothing to do — submit still works without a token.
+  }
+});
+// ---------------------------------------------------------------------------
+
+function friendlyErrorMessage(err: unknown): string {
+  const statusCode =
+    err && typeof err === "object" && "statusCode" in err
+      ? (err as { statusCode?: number }).statusCode
+      : undefined;
+  if (statusCode === 429) {
+    return "You've sent a few already — try again shortly.";
+  }
+  return "Couldn't send your interest. Please try again.";
+}
+
+async function handleSubmit() {
+  submitError.value = "";
+  if (!validate()) return;
+
+  submitting.value = true;
+  try {
+    await $fetch(`/api/public/profile/${props.slug}/interest`, {
+      method: "POST",
+      body: {
+        program: program.value.trim(),
+        note: note.value.trim() || undefined,
+        coachName: coachName.value.trim() || undefined,
+        coachEmail: coachEmail.value.trim() || undefined,
+        turnstileToken: turnstileToken.value,
+        hp: hp.value,
+      },
+    });
+    submitted.value = true;
+    emit("submitted");
+  } catch (err) {
+    submitError.value = friendlyErrorMessage(err);
+    resetTurnstile();
+  } finally {
+    submitting.value = false;
+  }
+}
+
+// A Turnstile token is single-use — Cloudflare redeems it at siteverify, so
+// replaying the same token after a failed submit always fails. Resetting
+// the widget mints a fresh token for the retry instead of 403-looping.
+function resetTurnstile() {
+  const w = window as unknown as { turnstile?: TurnstileGlobal };
+  if (w.turnstile) {
+    w.turnstile.reset(turnstileWidgetId.value);
+  }
+  turnstileToken.value = undefined;
+}
+
+function handleClose() {
+  emit("close");
+}
+</script>
+
+<template>
+  <div
+    class="w-full max-w-sm rounded-xl border-2 border-brand-slate-200 bg-white p-0 shadow-2xl"
+    role="dialog"
+    aria-labelledby="express-interest-title"
+  >
+    <div class="flex items-center justify-between border-b border-brand-slate-200 px-5 py-3">
+      <h2 id="express-interest-title" class="text-base font-semibold text-brand-slate-900">
+        Express interest in {{ playerName }}
+      </h2>
+      <button
+        type="button"
+        data-test="popover-close"
+        aria-label="Close"
+        class="rounded-full p-1 text-brand-slate-400 hover:bg-brand-slate-100 hover:text-brand-slate-600"
+        @click="handleClose"
+      >
+        &times;
+      </button>
+    </div>
+
+    <div v-if="submitted" class="px-5 py-6 text-center">
+      <p class="text-base font-medium text-brand-slate-900">
+        Interest sent.
+      </p>
+      <p class="mt-2 text-sm text-brand-slate-600">
+        The player has been notified of your interest.
+      </p>
+      <DesignSystemButton
+        class="mt-6"
+        color="blue"
+        variant="solid"
+        @click="handleClose"
+      >
+        Close
+      </DesignSystemButton>
+    </div>
+
+    <form v-else class="flex flex-col gap-4 px-5 py-4" @submit.prevent="handleSubmit">
+      <div>
+        <label class="mb-1 block text-sm font-medium text-brand-slate-700" for="interest-program">
+          Program
+          <span aria-hidden="true" class="text-red-500">*</span>
+        </label>
+        <select
+          v-if="hasProgramOptions"
+          id="interest-program"
+          data-test="program-select"
+          v-model="program"
+          required
+          class="w-full rounded-xl border-2 bg-white px-3 py-2 focus:border-transparent focus:ring-2 focus:ring-brand-blue-500"
+          :class="fieldErrors.program ? 'border-red-500' : 'border-brand-slate-300'"
+        >
+          <option value="" disabled>Select a program</option>
+          <option v-for="p in programs" :key="p" :value="p">{{ p }}</option>
+        </select>
+        <input
+          v-else
+          id="interest-program"
+          data-test="program-input"
+          type="text"
+          v-model="program"
+          required
+          maxlength="80"
+          placeholder="e.g. Baseball - SS"
+          class="w-full rounded-xl border-2 bg-white px-3 py-2 focus:border-transparent focus:ring-2 focus:ring-brand-blue-500"
+          :class="fieldErrors.program ? 'border-red-500' : 'border-brand-slate-300'"
+        />
+        <p v-if="fieldErrors.program" class="mt-1 text-sm text-red-600">
+          {{ fieldErrors.program }}
+        </p>
+      </div>
+
+      <div>
+        <label class="mb-1 block text-sm font-medium text-brand-slate-700" for="interest-note">
+          Note (optional)
+        </label>
+        <textarea
+          id="interest-note"
+          data-test="note"
+          v-model="note"
+          rows="3"
+          maxlength="1000"
+          class="w-full resize-none rounded-xl border-2 bg-white px-3 py-2 focus:border-transparent focus:ring-2 focus:ring-brand-blue-500"
+          :class="fieldErrors.note ? 'border-red-500' : 'border-brand-slate-300'"
+        />
+        <p v-if="fieldErrors.note" class="mt-1 text-sm text-red-600">
+          {{ fieldErrors.note }}
+        </p>
+      </div>
+
+      <div>
+        <label class="mb-1 block text-sm font-medium text-brand-slate-700" for="interest-coach-name">
+          Your name (optional)
+        </label>
+        <input
+          id="interest-coach-name"
+          data-test="coach-name"
+          type="text"
+          v-model="coachName"
+          maxlength="120"
+          class="w-full rounded-xl border-2 border-brand-slate-300 bg-white px-3 py-2 focus:border-transparent focus:ring-2 focus:ring-brand-blue-500"
+        />
+      </div>
+
+      <div>
+        <label class="mb-1 block text-sm font-medium text-brand-slate-700" for="interest-coach-email">
+          Your email (optional)
+        </label>
+        <input
+          id="interest-coach-email"
+          data-test="coach-email"
+          type="email"
+          v-model="coachEmail"
+          class="w-full rounded-xl border-2 bg-white px-3 py-2 focus:border-transparent focus:ring-2 focus:ring-brand-blue-500"
+          :class="fieldErrors.coachEmail ? 'border-red-500' : 'border-brand-slate-300'"
+        />
+        <p v-if="fieldErrors.coachEmail" class="mt-1 text-sm text-red-600">
+          {{ fieldErrors.coachEmail }}
+        </p>
+      </div>
+
+      <!-- Honeypot: never shown to a human. A filled value silently no-ops
+           the submission server-side. -->
+      <input
+        type="text"
+        name="hp"
+        v-model="hp"
+        autocomplete="off"
+        tabindex="-1"
+        aria-hidden="true"
+        class="absolute h-px w-px overflow-hidden opacity-0"
+        style="clip: rect(0, 0, 0, 0)"
+      />
+
+      <div v-if="turnstileEnabled" data-test="turnstile-widget" ref="turnstileEl"></div>
+
+      <p v-if="submitError" data-test="submit-error" role="alert" class="text-sm text-red-600">
+        {{ submitError }}
+      </p>
+
+      <div class="mt-1 flex justify-end gap-3">
+        <DesignSystemButton type="button" variant="outline" color="slate" @click="handleClose">
+          Cancel
+        </DesignSystemButton>
+        <DesignSystemButton type="submit" variant="solid" color="blue" :disabled="submitting" :loading="submitting">
+          Express interest
+        </DesignSystemButton>
+      </div>
+    </form>
+  </div>
+</template>

--- a/components/profile/public/ProfileHero.vue
+++ b/components/profile/public/ProfileHero.vue
@@ -4,7 +4,10 @@ import { computed } from "vue";
 import type { PublicProfileData } from "~/types/models";
 import { buildSocialLinks } from "~/utils/profile/socialLinks";
 
-const props = defineProps<{ data: PublicProfileData }>();
+const props = withDefaults(
+  defineProps<{ data: PublicProfileData; interestSent?: boolean }>(),
+  { interestSent: false },
+);
 
 defineEmits<{ contact: []; interest: [] }>();
 
@@ -112,8 +115,13 @@ const socialLinks = computed(() => buildSocialLinks(props.data.social));
           <DesignSystemButton color="blue" variant="solid" @click="$emit('contact')">
             Contact Player
           </DesignSystemButton>
-          <DesignSystemButton color="slate" variant="outline" @click="$emit('interest')">
-            Express Interest
+          <DesignSystemButton
+            color="slate"
+            variant="outline"
+            :disabled="interestSent"
+            @click="$emit('interest')"
+          >
+            {{ interestSent ? "Interest Sent" : "Express Interest" }}
           </DesignSystemButton>
           <span
             class="inline-flex items-center gap-1.5 rounded-full bg-brand-emerald-900/40 px-3 py-1 text-xs font-medium text-brand-emerald-300 ring-1 ring-brand-emerald-700/50"

--- a/composables/useProfileContacts.ts
+++ b/composables/useProfileContacts.ts
@@ -1,0 +1,63 @@
+// composables/useProfileContacts.ts
+import { ref, onMounted } from "vue";
+import { createClientLogger } from "~/utils/logger";
+
+const logger = createClientLogger("profile-contacts");
+
+export type ProfileLeadType = "contact" | "interest";
+
+export interface ProfileLead {
+  id: string;
+  type: ProfileLeadType;
+  coach_name: string;
+  coach_email: string | null;
+  coach_title: string | null;
+  school_name: string | null;
+  program: string | null;
+  note: string | null;
+  matched_coach_id: string | null;
+  created_at: string;
+}
+
+export interface ProfileContactCounts {
+  interestThisMonth: number;
+  contactThisMonth: number;
+  totalThisMonth: number;
+}
+
+interface ProfileContactsResponse {
+  leads: ProfileLead[];
+  counts: ProfileContactCounts;
+}
+
+export function useProfileContacts() {
+  const leads = ref<ProfileLead[]>([]);
+  const counts = ref<ProfileContactCounts>({
+    interestThisMonth: 0,
+    contactThisMonth: 0,
+    totalThisMonth: 0,
+  });
+  const loading = ref(false);
+  const error = ref<string | null>(null);
+
+  async function fetchContacts(): Promise<void> {
+    loading.value = true;
+    error.value = null;
+    try {
+      const data = await $fetch<ProfileContactsResponse>(
+        "/api/player/profile/contacts",
+      );
+      leads.value = data.leads;
+      counts.value = data.counts;
+    } catch (err) {
+      logger.error("Failed to load inbound leads", err);
+      error.value = "Failed to load your inbox. Please try again.";
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  onMounted(() => fetchContacts());
+
+  return { leads, counts, loading, error, fetchContacts };
+}

--- a/pages/settings/player-details.vue
+++ b/pages/settings/player-details.vue
@@ -188,6 +188,14 @@
           </div>
         </div>
 
+        <!-- TAB: INBOX -->
+        <div
+          v-show="currentTab === 'inbox'"
+          class="animate-in fade-in slide-in-from-bottom-2 space-y-6 duration-300"
+        >
+          <ProfileInbox />
+        </div>
+
         <!-- TAB: HISTORY -->
         <div
           v-show="currentTab === 'history'"
@@ -366,6 +374,7 @@ const validTabs = [
   "academics",
   "history",
   "public-profile",
+  "inbox",
 ];
 const currentTab = ref(
   validTabs.includes(route.query.tab as string)
@@ -382,6 +391,7 @@ const tabs = [
   },
   { id: "history", name: "History", icon: "i-heroicons-clock" },
   { id: "public-profile", name: "Public Profile", icon: "i-heroicons-share" },
+  { id: "inbox", name: "Inbox", icon: "i-heroicons-inbox-arrow-down" },
 ];
 
 const { loading: profileLoading } = usePlayerProfile();

--- a/planning/2026-08-26-public-player-profile-phase4-plan.md
+++ b/planning/2026-08-26-public-player-profile-phase4-plan.md
@@ -1,0 +1,177 @@
+# Public Player Profile — Phase 4 (Express Interest) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) tracking.
+
+**Goal:** Add the second inbound flow to the public profile — **Express Interest**: a low-friction, one-tap "I'm interested" from a coach on `/p/<slug>`. Server hardens it with the **same guard stack as Phase 3** (honeypot → per-IP rate-limit → **per-slug rate-limit** → Zod → Turnstile → slug-404), inserts a `profile_contacts` row with **`type='interest'`**, optionally links a CRM coach via `matchCoachByEmail`, and notifies the player. Plus: the athlete's **inbound inbox** (view Contact + Interest leads) and **thin monthly analytics**. Returns `{ ok: true }` only — never PII.
+
+**Spec:** `planning/2026-08-25-public-player-profile-spec.md` (§Phase 4 line ~125, §Public endpoints line ~96, §Interaction modals line ~118). **Handoff:** `planning/handoff-2026-08-26-public-player-profile-phase4.md`.
+
+## Decisions (Chris, 2026-08-26 — bind this phase)
+
+- **Coach identity on Express Interest = OPTIONAL email.** Form = `program` (required) + optional `note` + optional `coachName` + optional `coachEmail`. Truly one-tap still allowed (program only). When `coachEmail` present → `matchCoachByEmail` links an existing CRM coach (same match-only rail as Phase 3, **never creates** a coach). Anonymous interest is a valid lead.
+- **`program` field = select over the athlete's own sport(s)/positions**, with **free-text fallback**. Source is the PUBLIC payload's `athletic` block (`primary_sport` + `positions`). ⚠️ `athletic` is **`null` when `show_athletic` is false** (`types/models.ts:538`) → when null OR empty, the popover renders a free-text `program` input. No new PII exposure (sport is already public when shown).
+- **Inbox home = a new "Inbox" tab in `pages/settings/player-details.vue`** (beside the existing `public-profile` tab that renders `ProfileSetup`). Co-located with the profile that generates the leads. Shows BOTH `type='contact'` (Phase 3) and `type='interest'` leads.
+- **Analytics = thin.** Monthly count tiles ("N interest / N contact this month") + a small over-time count, above the inbox list. One aggregate query. No funnel/breakdown this phase.
+- **Per-slug rate limit = build it this phase.** One-tap = higher spam surface than Contact. Add exported `rateLimitByKey(event, key, opts)` to `rateLimit.ts` and apply `interest:<slug>` on the interest endpoint AND retrofit `contact:<slug>` on the Phase-3 contact endpoint (closes its deferred TODO at `contact.post.ts:104`).
+
+## Reuse map (Phase 3 built the rails — Phase 4 mostly reuses)
+
+| Need | Reuse | Location |
+|---|---|---|
+| Guard stack template (honeypot→rate-limit→Zod→Turnstile→slug-404→match→insert→notify→`{ok:true}`) | clone the whole handler | `server/api/public/profile/[slug]/contact.post.ts` |
+| Turnstile verify (flag-gated, no-op pass when keyless) | `verifyTurnstile(token,{ip,expectedAction})` + `isHoneypotTripped` | `server/utils/turnstile.ts` |
+| Per-IP rate limit (trusted `x-vercel-forwarded-for`) | `rateLimitByIp(event,{requests,window,ip})` + `throwIfRateLimited` | `server/utils/rateLimit.ts:61` |
+| Coach match (match-only, family-scoped, never creates) | `matchCoachByEmail(admin,{familyUnitId,email})` | `server/utils/matchCoachByEmail.ts` |
+| Trusted client IP + IP→inet coercion | `x-vercel-forwarded-for` chain + `toValidInetOrNull` | `contact.post.ts:83`, `:43` |
+| Slug→player resolve (hash then vanity, unpublished→404) | inline resolver | `contact.post.ts:139` |
+| Player notification + email (fire-and-forget-safe) | notifications insert (`type:'inbound_interaction'`, `related_entity_type:'profile_contact'`) + `sendNotificationEmail` | `contact.post.ts:239` |
+| Lead sink table (`type` in contact/interest, `program`, family-read RLS) | `profile_contacts` (already live) | migration `20260909000000_profile_contacts.sql` |
+| Hero button emits (`contact`/`interest`, `interest` inert) | `@interest` handler is net-new; `@contact` is the pattern | `components/profile/public/ProfileHero.vue:9,115` |
+| Modal wiring host (owns ProfileHero + ContactPlayerModal) | add ExpressInterestPopover + `@interest` here | `components/profile/PublicProfileCard.vue` |
+| Turnstile widget (conditional/flag-gated client pattern) | mirror the widget mount + token capture | `components/profile/public/ContactPlayerModal.vue` |
+| Settings tab pattern (`tabs`, `currentTab`, `v-show`) | add `inbox` tab entry | `pages/settings/player-details.vue:57` |
+| Public sport/positions for the program select | `data.athletic?.primary_sport` + `data.athletic?.positions` (null-safe) | `types/models.ts:538` |
+
+**Net-new:** `rateLimitByKey`; the interest POST endpoint; `ExpressInterestPopover.vue`; `@interest` wiring + "Interest Sent" localStorage state; `GET /api/player/profile/contacts` (authed inbox endpoint + monthly counts); `useProfileContacts` composable; `ProfileInbox.vue` (tab content + stat tiles).
+
+## Global Constraints
+
+- TS strict, no `any` outside tests; `as const` enums; immutability. Zod for ALL body input.
+- **Security (unauth write endpoint — primary risk surface):** honeypot `hp` non-empty → `{ ok:true }` silent no-op; per-IP AND **per-slug** rate limit; Turnstile verify server-side (flag-gated, loud `warn` when disabled); **service-role inserts only** (no client RLS insert — `profile_contacts` has NO insert policy); **no player/coach PII in any response** (`{ ok:true }` only); capture `ip`/`ua`; Zod-validate every field.
+- Inbox endpoint (authed) = **read-only**, family-scoped via the existing `profile_contacts` family-read RLS (`auth.uid()` through `family_members`). Resolve the family athlete the same way other authed player endpoints do — do NOT trust a client-supplied family id.
+- No secret in client bundle. UI: no raw hex/rgba — brand tokens; `DesignSystem*` (never `DS*`); DS empty/loading/error states; `npm run audit:tokens` clean.
+- **NO migration this phase.** `profile_contacts` already has `type` + `program` + coach fields + family-read RLS (verified live, `20260909000000`). If any schema need emerges → **STOP and ask Chris**.
+- Local E2E blocked by dev-server EMFILE (Phases 1–3 all hit it) → E2E lands + runs in CI, not locally. Node ≥22 (`nvm use`).
+- Gates before "done": `npm run type-check`, `npm run lint`, `npm run test`, `npm run audit:tokens`.
+
+---
+
+### Task 1: `rateLimitByKey` + per-slug limiting (retrofit Contact)
+
+**Files:** Modify `server/utils/rateLimit.ts`; Modify `server/api/public/profile/[slug]/contact.post.ts` (apply per-slug + drop the TODO); Test `tests/unit/server/utils/rateLimit.spec.ts` (extend if present, else create).
+
+**Interface:** `rateLimitByKey(event: H3Event, key: string, options: RateLimitOptions): Promise<RateLimitResult>` — mirrors `rateLimitByUser` but limits on the caller-supplied `key` verbatim (the caller namespaces it, e.g. `interest:<slug>`). No limiter configured (missing Upstash env) → `BYPASS_RESULT` (graceful degrade, unchanged precedent). Never throws.
+
+- [ ] **Step 1 (TDD RED):** test — with a mocked limiter, `rateLimitByKey(event,'interest:abc123',{requests:20,window:'1 h'})` calls `limiter.limit('interest:abc123')`; missing env → `BYPASS_RESULT`; limiter throw → `BYPASS_RESULT` (safeLimit). Run → FAIL.
+- [ ] **Step 2:** Implement `rateLimitByKey` (reuse `createLimiter`/`safeLimit`). In `contact.post.ts`, after the per-IP limit add `throwIfRateLimited(await rateLimitByKey(event, \`contact:${slug}\`, { requests: 20, window: "1 h" }))` and delete the `TODO(per-slug rate limit)` comment block.
+- [ ] **Step 3:** GREEN + type-check + lint. Commit `feat(security): per-slug rate limiter + retrofit Contact endpoint`.
+
+---
+
+### Task 2: `POST /api/public/profile/[slug]/interest` endpoint
+
+**Files:** Create `server/api/public/profile/[slug]/interest.post.ts`; Test `tests/unit/server/api/public/interest.spec.ts` (model on `contact.spec.ts`).
+
+**Zod body:** `{ program: string(1..80), note?: string(1..1000), coachName?: string(1..120), coachEmail?: email, turnstileToken?: string, hp?: string }`. **Guard order (identical to contact, fail-fast):**
+1. Slug shape check (`HASH_SLUG_RE`/`VANITY_SLUG_RE`) → 404. Resolve trusted `clientIp` + `userAgent` (reuse the exact chain from `contact.post.ts`).
+2. `isHoneypotTripped(body.hp)` → `{ ok:true }` silent (no insert, no notify).
+3. `throwIfRateLimited(rateLimitByIp(event,{requests:5,window:"10 m",ip:clientIp}))`.
+4. `throwIfRateLimited(rateLimitByKey(event,\`interest:${slug}\`,{requests:20,window:"1 h"}))`.
+5. Zod `safeParse` → 422 `.issues[0]?.message`.
+6. `verifyTurnstile(body.turnstileToken,{ip:clientIp,expectedAction:"interest"})` → `reason:'disabled'` → `logger.warn`; `!ok` → 403.
+7. Resolve player by slug (hash then vanity); `!profile || !is_published` → 404.
+8. `matchCoachByEmail(admin,{familyUnitId:profile.family_unit_id,email:data.coachEmail})` → `matchedCoachId | null` (only when email present; NEVER creates).
+9. Insert `profile_contacts`: `family_unit_id`, `player_user_id: profile.user_id`, **`type:'interest'`**, `coach_name: data.coachName ?? "A coach"` (column is NOT NULL — default a placeholder for anonymous), `coach_email: data.coachEmail ?? null`, `matched_coach_id: matchedCoachId`, **`program: data.program`**, `note: data.note ?? null`, `ip: toValidInetOrNull(clientIp)`, `user_agent`. (No school fields on interest.)
+10. Notify player (fire-and-forget-safe, mirror contact): notification `type:'inbound_interaction'`, title **"New interest from a coach"**, message `\`${coachLabel} expressed interest in your ${data.program} profile.\`` (`coachLabel = data.coachName ?? "A coach"`), `related_entity_type:'profile_contact'`, `related_entity_id: inserted.id`; + `sendNotificationEmail` to the player when `users.email` present. A notify failure must NOT fail the response.
+11. Return `{ ok:true }`.
+
+> **NOTE — `coach_name` is NOT NULL** (`profile_contacts.coach_name text not null`). Anonymous interest supplies no name → insert a placeholder (`"A coach"`). Confirm the column constraint before implementing; if Chris prefers a nullable name for interest, that's a migration → STOP and ask.
+
+- [ ] **Step 1 (TDD RED):** unit over mocked admin + mocked deps: honeypot → `{ok:true}`, NO insert, NO notify; bad body (missing `program`) → 422; Turnstile `{ok:false}` → 403; per-slug limit exceeded → 429; unknown/unpublished slug → 404; happy anonymous (program only) → insert `type:'interest'` + `program` + placeholder name + `matched_coach_id:null` + notification minted + `{ok:true}`; happy with matching `coachEmail` → `matched_coach_id` set; response never contains player/coach PII. Run → FAIL.
+- [ ] **Step 2:** Implement by cloning `contact.post.ts` structure (keep the trusted-IP + inet-coercion + slug-resolver + notify-safe patterns verbatim). Reuse Task-1 `rateLimitByKey`.
+- [ ] **Step 3:** GREEN + type-check + lint. `npm run dev` + `curl` the endpoint (honeypot, missing program → 422, happy path → confirm a `type='interest'` row + a notification land). Commit `feat(api): public Express Interest endpoint (hardened, profile_contacts type=interest)`.
+
+---
+
+### Task 3: `ExpressInterestPopover.vue`
+
+**Files:** Create `components/profile/public/ExpressInterestPopover.vue`; Test `tests/unit/components/profile/ExpressInterestPopover.spec.ts`.
+
+**Interface:** props `{ slug: string; playerName: string; programs?: string[] }` (programs = the athlete's public sport/positions from the card; may be empty), emits `close`, `submitted`. Fields: **program** — a `DesignSystem*` select when `programs?.length`, else a free-text input; optional **note**; optional **coach name** + **coach email**; hidden honeypot `hp` (visually hidden, `autocomplete="off"`, `tabindex="-1"`). Turnstile widget mounts ONLY when `runtimeConfig.public.turnstileSiteKey` is set (mirror `ContactPlayerModal.vue`'s script inject + token capture, `action:"interest"`). Submit → `$fetch(\`/api/public/profile/${slug}/interest\`, { method:"POST", body })`. Success → emit `submitted` + show confirmation ("The player has been notified of your interest"). Error → inline message; 429 → friendly "try again shortly". `<script setup>`, DS primitives, brand tokens, no raw hex.
+
+- [ ] **Step 1 (TDD RED):** test — renders program select when `programs` provided, free-text when empty; renders honeypot; fill + submit → `$fetch` called with `{program, hp:""}`; success → confirmation + `submitted` emitted; Turnstile widget absent when no site key (mock runtimeConfig). Run → FAIL.
+- [ ] **Step 2:** Implement. Turnstile script guarded + cleaned on unmount; submit still works if the script fails to load (server no-ops verification when flag off). Client-mirror the Zod min/max for UX (server is source of truth).
+- [ ] **Step 3:** GREEN + type-check + audit:tokens. Commit `feat(profile): Express Interest popover (program select + honeypot + optional Turnstile)`.
+
+---
+
+### Task 4: Wire hero `@interest` + "Interest Sent" state
+
+**Files:** Modify `components/profile/PublicProfileCard.vue`; Test extend `tests/unit/components/profile/PublicProfileCard.spec.ts` (or the card's existing spec).
+
+**Interface:** In `PublicProfileCard.vue` (owns `ProfileHero` + `ContactPlayerModal`), add popover open/close state and handle `@interest` → open `ExpressInterestPopover`, passing `slug`, `playerName`, and `programs` derived null-safely from the public payload: `[data.athletic?.primary_sport, ...(data.athletic?.positions ?? [])].filter(Boolean)` deduped. On `@submitted`: set an **"Interest Sent" button state**, persisted per-session in `localStorage` keyed by slug (e.g. `interest-sent:<slug>`), and reflect it on the hero button (disabled + "Interest Sent" label). Server is source of truth; localStorage only suppresses re-submit UX within the session. Heed the **teleport-backdrop-isolate-root** lesson (don't teleport the backdrop over the popover). Close popover only on `@close` (Phase-3 lesson: don't close on `@submitted` before the confirmation paints).
+
+> The hero button label/disabled state needs a prop. Either pass an `interestSent` prop into `ProfileHero` (preferred — keep hero presentational) or read localStorage in the card and swap the emitted button. Keep `ProfileHero` dumb; card owns state.
+
+- [ ] **Step 1 (TDD RED):** test — clicking "Express Interest" opens the popover; `@submitted` sets the "Interest Sent" state + writes localStorage; on remount with the localStorage key set, the hero shows "Interest Sent" disabled; `@close` hides the popover. Run → FAIL.
+- [ ] **Step 2:** Implement. Guard localStorage access (SSR-safe / try-catch). No raw hex.
+- [ ] **Step 3:** GREEN + type-check + audit:tokens. Commit `feat(profile): wire hero Express Interest + Interest Sent state`.
+
+---
+
+### Task 5: `GET /api/player/profile/contacts` — inbox + monthly counts
+
+**Files:** Create `server/api/player/profile/contacts.get.ts`; Test `tests/unit/server/api/player/profile-contacts.spec.ts`.
+
+**Interface:** authed GET. Resolve the requesting user's family athlete (reuse the repo's existing authed player-context resolver — grep how `server/api/player/**` or `server/api/user/preferences/**` resolves the family/athlete; do NOT trust a client family id). Query `profile_contacts` for that `family_unit_id`, newest-first, with a sane cap (e.g. `limit 100`; add optional `?limit`/`?before` cursor if trivial, else fixed cap). Response:
+```ts
+{
+  leads: Array<{ id; type: "contact" | "interest"; coach_name; coach_email; coach_title; school_name; program; note; matched_coach_id; created_at }>;
+  counts: { interestThisMonth: number; contactThisMonth: number; totalThisMonth: number };
+}
+```
+`counts` = rows where `created_at >= start-of-current-month` grouped by `type` (compute in-handler from the fetched set only if the cap safely covers a month; otherwise a small separate `count` query per type — prefer the explicit count query to stay correct under high volume). Never expose `ip`/`user_agent`/`family_unit_id` in the response. Read-only (no mutation).
+
+- [ ] **Step 1 (TDD RED):** unit over mocked admin/context: returns family-scoped leads newest-first; `counts` splits interest vs contact for the current month; unauth/no-athlete → 401/appropriate; `ip`/`ua` never in payload. Run → FAIL.
+- [ ] **Step 2:** Implement. Family scope via the existing authed resolver + service-role read (or user-client read that rides the family-read RLS — match how sibling authed player endpoints read family data). Month boundary in UTC (note the web TZ `getFullYear` lesson — use explicit UTC month start).
+- [ ] **Step 3:** GREEN + type-check + lint. `npm run dev` + `curl` with an authed session (or document the manual check). Commit `feat(api): player inbound-leads inbox endpoint + monthly counts`.
+
+---
+
+### Task 6: `useProfileContacts` + `ProfileInbox.vue` tab
+
+**Files:** Create `composables/useProfileContacts.ts`; Create `components/profile/ProfileInbox.vue`; Modify `pages/settings/player-details.vue` (add the `inbox` tab entry + `v-show` panel); Tests `tests/unit/composables/useProfileContacts.spec.ts` + `tests/unit/components/profile/ProfileInbox.spec.ts`.
+
+**Interfaces:**
+- `useProfileContacts()` → `{ leads, counts, loading, error, fetchContacts }` (standard composable shape; `$fetch('/api/player/profile/contacts')`; try/catch → user-friendly error; `onMounted` auto-fetch).
+- `ProfileInbox.vue` — renders: monthly **stat tiles** ("N interest this month" / "N contact this month") using the existing DS stat/tile primitive (grep `docs/design/components.md` + admin `AdminStatTile` for the right web primitive — use the public-app equivalent, NOT the Admin-namespaced one); then a **leads list** (each: contact-vs-interest badge, coach_name, program, school_name, note excerpt, relative date). DS empty state ("No leads yet"), loading skeleton, error state. No raw hex.
+- `player-details.vue` — add `{ id: "inbox", name: "Inbox", icon: <UIcon name> }` to `tabs`, and a `<div v-show="currentTab === 'inbox'"><ProfileInbox /></div>` panel mirroring the existing tab panels.
+
+- [ ] **Step 1 (TDD RED):** composable test (mock `$fetch` → leads/counts populate; error path sets `error`); component test (renders tiles from counts, a row per lead with the correct badge, empty state when no leads). Run → FAIL.
+- [ ] **Step 2:** Implement. Reuse DS list/badge/tile primitives; badge color: interest vs contact via brand tokens.
+- [ ] **Step 3:** GREEN + type-check + lint + audit:tokens. Commit `feat(profile): inbound-leads inbox tab + monthly stat tiles`.
+
+---
+
+### Task 7: E2E — express interest → Interest Sent + lead visible in inbox
+
+**Files:** Create `tests/e2e/profile-interest.spec.ts`.
+
+- [ ] **Step 1:** E2E — anonymous context opens `/p/<slug>` (self-published), clicks Express Interest, selects/enters a program, submits (honeypot empty), asserts the "Interest Sent" state. Turnstile off in test env (no site key) so no widget blocks. Then an authed second context (the player) opens the Public Profile → Inbox tab and asserts the new interest lead + the month count. Follow repo Playwright conventions (storageState, separate anon context, `data-test` selectors, RUN_ID-unique data).
+- [ ] **Step 2:** `--list` parses + typecheck/lint clean; run locally if possible, else CI-defer (document the EMFILE block). Do NOT weaken assertions.
+- [ ] **Step 3:** Commit `test(e2e): express interest → Interest Sent + inbox lead`.
+
+---
+
+### Task 8: Full gate + phase wrap
+
+- [ ] `npm run type-check && npm run lint && npm run test && npm run audit:tokens` — all pass.
+- [ ] `npm run dev` — open a public profile logged-out, submit Express Interest (anonymous AND with a coach email), confirm: `{ ok:true }` with NO PII in the network payload; the player gets an in-app notification; the lead appears in the Inbox tab with the right badge + month count; honeypot + rapid-fire rate-limit behave; "Interest Sent" persists across reload.
+- [ ] Confirm the carried **launch gate** is still noted (Turnstile keys + Upstash env before ANY public prod promote of Contact/Interest — Chris's env work, separate). Update `CLAUDE.local.md` + write a Phase-4 handoff.
+
+---
+
+## Self-Review
+
+**Spec coverage (Phase 4 slice):** public interest endpoint hardened (T2) with honeypot+per-IP+**per-slug**+Zod+Turnstile+service-role+no-PII (T1+T2, Global Constraints); one-tap popover with program select + optional coach email (T3); "Interest Sent" state persisted per-session (T4); athlete inbound inbox reading both lead types (T5+T6); thin monthly analytics (T5 counts + T6 tiles); E2E (T7); gates (T8). ✓
+
+**Chris decisions honored:** optional coach email (match-only, never creates); program = select-over-own-sports + free-text fallback (athletic-null-safe); inbox = new tab in player-details; analytics = monthly counts only; per-slug limiter built + Contact retrofitted. ✓
+
+**No migration:** `profile_contacts` already carries `type` + `program` + coach fields + family-read RLS (live `20260909000000`). Verified. ✓
+
+**Deferred / carried:** provisioning real Turnstile keys + Upstash env (launch gate, Chris's env). Phase-3 fast-follows (notification-preference gating for inbound leads, dup-email `maybeSingle`, IPv6 regex). Phase-2 fast-follows (brand social icons, banner host allowlist, committed_school_id ownership). Richer analytics (funnel/breakdown) = future.
+
+**Open items to confirm at build:**
+- `profile_contacts.coach_name` is NOT NULL → anonymous interest inserts a `"A coach"` placeholder. If Chris wants a nullable interest name, that's a migration → STOP and ask.
+- The authed family-athlete resolver for the inbox endpoint (T5) — grep the exact pattern sibling `server/api/player/**` endpoints use; do not invent.
+- The public-app stat-tile primitive (T6) — use the non-Admin DS equivalent; confirm the component name in `docs/design/components.md` before building.

--- a/server/api/player/profile/contacts.get.ts
+++ b/server/api/player/profile/contacts.get.ts
@@ -1,0 +1,110 @@
+/**
+ * GET /api/player/profile/contacts
+ *
+ * Authed family inbox for inbound leads captured by the public profile's
+ * Contact/Express Interest flows (`profile_contacts`). Family scope is
+ * resolved server-side from the requesting user's `family_members` row —
+ * never from a client-supplied id. Read-only; never exposes `ip`,
+ * `user_agent`, or `family_unit_id`.
+ */
+import { defineEventHandler, createError } from "h3";
+import { requireAuth } from "~/server/utils/auth";
+import { useSupabaseAdmin } from "~/server/utils/supabase";
+import { useLogger } from "~/server/utils/logger";
+
+const LEADS_LIMIT = 100;
+
+type LeadType = "contact" | "interest";
+
+interface ProfileContactLead {
+  id: string;
+  type: LeadType;
+  coach_name: string;
+  coach_email: string | null;
+  coach_title: string | null;
+  school_name: string | null;
+  program: string | null;
+  note: string | null;
+  matched_coach_id: string | null;
+  created_at: string;
+}
+
+export default defineEventHandler(async (event) => {
+  const logger = useLogger(event, "player/profile/contacts");
+  try {
+    const { id: userId } = await requireAuth(event);
+    const supabase = useSupabaseAdmin();
+
+    const { data: membership } = await supabase
+      .from("family_members")
+      .select("family_unit_id")
+      .eq("user_id", userId)
+      .single();
+
+    if (!membership) {
+      throw createError({
+        statusCode: 403,
+        statusMessage: "Not a family member",
+      });
+    }
+    const familyUnitId = membership.family_unit_id;
+
+    const { data: leads, error: leadsError } = await supabase
+      .from("profile_contacts")
+      .select(
+        "id, type, coach_name, coach_email, coach_title, school_name, program, note, matched_coach_id, created_at",
+      )
+      .eq("family_unit_id", familyUnitId)
+      .order("created_at", { ascending: false })
+      .limit(LEADS_LIMIT);
+
+    if (leadsError) {
+      logger.error("Failed to fetch profile_contacts leads", leadsError);
+      throw createError({
+        statusCode: 500,
+        statusMessage: "Failed to load inbound leads",
+      });
+    }
+
+    // UTC month boundary — local getFullYear() has bitten us before (see
+    // MEMORY: web TZ bugs) and would silently shift the window near midnight.
+    const now = new Date();
+    const monthStartIso = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1),
+    ).toISOString();
+
+    // Explicit per-type count query rather than deriving from `leads` — stays
+    // correct once inbound volume exceeds the fixed LEADS_LIMIT cap.
+    const [{ count: interestThisMonth }, { count: contactThisMonth }] =
+      await Promise.all([
+        supabase
+          .from("profile_contacts")
+          .select("*", { count: "exact", head: true })
+          .eq("family_unit_id", familyUnitId)
+          .eq("type", "interest")
+          .gte("created_at", monthStartIso),
+        supabase
+          .from("profile_contacts")
+          .select("*", { count: "exact", head: true })
+          .eq("family_unit_id", familyUnitId)
+          .eq("type", "contact")
+          .gte("created_at", monthStartIso),
+      ]);
+
+    return {
+      leads: (leads ?? []) as ProfileContactLead[],
+      counts: {
+        interestThisMonth: interestThisMonth ?? 0,
+        contactThisMonth: contactThisMonth ?? 0,
+        totalThisMonth: (interestThisMonth ?? 0) + (contactThisMonth ?? 0),
+      },
+    };
+  } catch (err) {
+    if (err instanceof Error && "statusCode" in err) throw err;
+    logger.error("Failed to load inbound leads", err);
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Failed to load inbound leads",
+    });
+  }
+});

--- a/server/api/public/profile/[slug]/contact.post.ts
+++ b/server/api/public/profile/[slug]/contact.post.ts
@@ -22,7 +22,11 @@ import {
 import { z } from "zod";
 import { useSupabaseAdmin } from "~/server/utils/supabase";
 import { useLogger } from "~/server/utils/logger";
-import { rateLimitByIp, throwIfRateLimited } from "~/server/utils/rateLimit";
+import {
+  rateLimitByIp,
+  rateLimitByKey,
+  throwIfRateLimited,
+} from "~/server/utils/rateLimit";
 import { verifyTurnstile, isHoneypotTripped } from "~/server/utils/turnstile";
 import { matchCoachByEmail } from "~/server/utils/matchCoachByEmail";
 import { sendNotificationEmail } from "~/server/utils/emailService";
@@ -101,12 +105,14 @@ export default defineEventHandler(async (event) => {
       window: "10 m",
       ip: clientIp,
     });
-    // TODO(per-slug rate limit): rateLimit.ts only exports rateLimitByIp/
-    // rateLimitByUser (keyed internally). A per-slug limiter (key
-    // `contact:<slug>`) would blunt targeting a single athlete but needs a
-    // small addition to rateLimit.ts (exported rateLimitByKey) — deferring;
-    // per-IP is the must-have guard and is in place.
     throwIfRateLimited(rateLimitResult);
+
+    throwIfRateLimited(
+      await rateLimitByKey(event, `contact:${slug}`, {
+        requests: 20,
+        window: "1 h",
+      }),
+    );
 
     const parsed = contactSchema.safeParse(body);
     if (!parsed.success) {

--- a/server/api/public/profile/[slug]/interest.post.ts
+++ b/server/api/public/profile/[slug]/interest.post.ts
@@ -1,0 +1,277 @@
+/**
+ * POST /api/public/profile/[slug]/interest
+ *
+ * Unauthenticated "Express Interest" lead-capture on the public player
+ * profile — a lighter one-tap sibling of Contact Player. Stores the lead in
+ * `profile_contacts` (service-role write, no RLS INSERT policy) as
+ * `type: 'interest'` and notifies the player in-app + by email. NEVER
+ * creates/mutates a coach row from unauthenticated input —
+ * `matchCoachByEmail` only matches. The response is always `{ ok: true }` —
+ * no player/coach PII ever leaves this endpoint.
+ */
+import {
+  defineEventHandler,
+  getRouterParam,
+  getRequestIP,
+  getRequestHeader,
+  getHeader,
+  readBody,
+  createError,
+} from "h3";
+import { z } from "zod";
+import { useSupabaseAdmin } from "~/server/utils/supabase";
+import { useLogger } from "~/server/utils/logger";
+import {
+  rateLimitByIp,
+  rateLimitByKey,
+  throwIfRateLimited,
+} from "~/server/utils/rateLimit";
+import { verifyTurnstile, isHoneypotTripped } from "~/server/utils/turnstile";
+import { matchCoachByEmail } from "~/server/utils/matchCoachByEmail";
+import { sendNotificationEmail } from "~/server/utils/emailService";
+import type { Database } from "~/types/database";
+
+const HASH_SLUG_RE = /^[a-z0-9]{6}$/;
+const VANITY_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,28}[a-z0-9]$/;
+
+// Loose-but-sufficient IPv4/IPv6 validators for the `profile_contacts.ip`
+// `inet` column — a malformed header value must degrade to `null`, never
+// fail the insert (a dropped lead is worse than a missing IP).
+const IPV4_RE =
+  /^(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}$/;
+const IPV6_RE = /^[0-9a-fA-F:]{2,}$/;
+
+function toValidInetOrNull(ip: string | null | undefined): string | null {
+  if (!ip) return null;
+  const trimmed = ip.trim();
+  if (IPV4_RE.test(trimmed)) return trimmed;
+  if (trimmed.includes(":") && IPV6_RE.test(trimmed)) return trimmed;
+  return null;
+}
+
+const interestSchema = z.object({
+  program: z.string().trim().min(1).max(80),
+  note: z.string().trim().min(1).max(1000).optional(),
+  coachName: z.string().trim().min(1).max(120).optional(),
+  coachEmail: z.string().trim().email().optional(),
+  turnstileToken: z.string().optional(),
+  hp: z.string().optional(),
+});
+
+type ProfileContactInsert =
+  Database["public"]["Tables"]["profile_contacts"]["Insert"];
+type NotificationInsert =
+  Database["public"]["Tables"]["notifications"]["Insert"];
+
+export default defineEventHandler(async (event) => {
+  const logger = useLogger(event, "public/profile/interest");
+
+  try {
+    const slug = getRouterParam(event, "slug")!;
+    if (!HASH_SLUG_RE.test(slug) && !VANITY_SLUG_RE.test(slug)) {
+      throw createError({
+        statusCode: 404,
+        statusMessage: "Profile not found",
+      });
+    }
+    // The trusted client IP — Vercel's `x-vercel-forwarded-for` is
+    // platform-set and cannot be spoofed by the client, unlike the leftmost
+    // value of `X-Forwarded-For`, which h3's `xForwardedFor: true` reads and
+    // an attacker can rotate to evade per-IP rate limiting. Falls back to
+    // `x-real-ip`, then h3's resolution, for local/non-Vercel environments.
+    const clientIp =
+      getHeader(event, "x-vercel-forwarded-for") ||
+      getHeader(event, "x-real-ip") ||
+      getRequestIP(event, { xForwardedFor: true }) ||
+      undefined;
+    const rawUserAgent = getRequestHeader(event, "user-agent") ?? null;
+    const userAgent = rawUserAgent ? rawUserAgent.slice(0, 512) : null;
+
+    const body = await readBody(event);
+
+    // Honeypot: silent success, no insert, no notify. Cheapest check first.
+    if (isHoneypotTripped((body as { hp?: unknown })?.hp)) {
+      logger.info("Honeypot tripped, silently discarding", { slug });
+      return { ok: true };
+    }
+
+    const rateLimitResult = await rateLimitByIp(event, {
+      requests: 5,
+      window: "10 m",
+      ip: clientIp,
+    });
+    throwIfRateLimited(rateLimitResult);
+
+    throwIfRateLimited(
+      await rateLimitByKey(event, `interest:${slug}`, {
+        requests: 20,
+        window: "1 h",
+      }),
+    );
+
+    const parsed = interestSchema.safeParse(body);
+    if (!parsed.success) {
+      throw createError({
+        statusCode: 422,
+        statusMessage: parsed.error.issues[0]?.message ?? "Invalid request",
+      });
+    }
+    const data = parsed.data;
+
+    const turnstileResult = await verifyTurnstile(data.turnstileToken, {
+      ip: clientIp,
+      expectedAction: "interest",
+    });
+    if (turnstileResult.reason === "disabled") {
+      logger.warn(
+        "Turnstile verification disabled (no secret key configured) — relying on honeypot + rate limit only",
+      );
+    }
+    if (!turnstileResult.ok) {
+      throw createError({
+        statusCode: 403,
+        statusMessage: "Verification failed",
+      });
+    }
+
+    const admin = useSupabaseAdmin();
+
+    // Resolve by hash_slug first, then vanity_slug — mirrors [slug].get.ts.
+    let profileResult = await admin
+      .from("player_profiles")
+      .select("id, family_unit_id, user_id, is_published")
+      .eq("hash_slug", slug)
+      .maybeSingle();
+    if (profileResult.error) {
+      logger.error(
+        "Failed to query player_profiles by hash_slug",
+        profileResult.error,
+      );
+      throw createError({
+        statusCode: 500,
+        statusMessage: "Failed to submit interest",
+      });
+    }
+    if (!profileResult.data) {
+      profileResult = await admin
+        .from("player_profiles")
+        .select("id, family_unit_id, user_id, is_published")
+        .eq("vanity_slug", slug)
+        .maybeSingle();
+      if (profileResult.error) {
+        logger.error(
+          "Failed to query player_profiles by vanity_slug",
+          profileResult.error,
+        );
+        throw createError({
+          statusCode: 500,
+          statusMessage: "Failed to submit interest",
+        });
+      }
+    }
+    const profile = profileResult.data;
+
+    if (!profile || !profile.is_published) {
+      // Never distinguish "not found" from "unpublished" — both look like a
+      // 404 to an unauthenticated caller.
+      logger.warn("Interest submitted for unknown/unpublished slug", {
+        slug,
+      });
+      throw createError({
+        statusCode: 404,
+        statusMessage: "Profile not found",
+      });
+    }
+
+    const { coachId: matchedCoachId } = await matchCoachByEmail(admin, {
+      familyUnitId: profile.family_unit_id,
+      email: data.coachEmail,
+    });
+
+    // `coach_name` is NOT NULL — anonymous interest gets a placeholder.
+    const coachLabel = data.coachName ?? "A coach";
+
+    const insertRow: ProfileContactInsert = {
+      family_unit_id: profile.family_unit_id,
+      player_user_id: profile.user_id,
+      type: "interest",
+      coach_name: coachLabel,
+      coach_email: data.coachEmail ?? null,
+      matched_coach_id: matchedCoachId,
+      program: data.program,
+      note: data.note ?? null,
+      ip: toValidInetOrNull(clientIp),
+      user_agent: userAgent,
+    };
+
+    const { data: inserted, error: insertError } = await admin
+      .from("profile_contacts")
+      .insert(insertRow)
+      .select("id")
+      .single();
+
+    if (insertError || !inserted) {
+      logger.error("Failed to insert profile_contacts row", insertError);
+      throw createError({
+        statusCode: 500,
+        statusMessage: "Failed to submit interest",
+      });
+    }
+
+    // Notify the player — fire-and-forget-safe: a failure here must never
+    // fail the response, since the lead is already durably stored.
+    try {
+      const { data: user } = await admin
+        .from("users")
+        .select("email, full_name")
+        .eq("id", profile.user_id)
+        .maybeSingle();
+
+      const title = "New interest from a coach";
+      const message = `${coachLabel} expressed interest in your ${data.program} profile.`;
+
+      const notificationRow: NotificationInsert = {
+        user_id: profile.user_id,
+        type: "inbound_interaction",
+        title,
+        message,
+        related_entity_type: "profile_contact",
+        related_entity_id: inserted.id,
+        scheduled_for: new Date().toISOString(),
+      };
+      const { error: notifyError } = await admin
+        .from("notifications")
+        .insert(notificationRow);
+      if (notifyError) {
+        logger.warn("Failed to insert notification row", notifyError);
+      }
+
+      if (user?.email) {
+        await sendNotificationEmail({
+          to: user.email,
+          subject: title,
+          title,
+          message,
+          priority: "normal",
+        });
+      }
+    } catch (notifyErr) {
+      logger.warn("Failed to notify player of inbound interest", notifyErr);
+    }
+
+    logger.info("Public interest submitted", {
+      slug,
+      ip: clientIp,
+      matched: !!matchedCoachId,
+    });
+
+    return { ok: true };
+  } catch (err) {
+    if (err instanceof Error && "statusCode" in err) throw err;
+    logger.error("Failed to submit public interest", err);
+    throw createError({
+      statusCode: 500,
+      statusMessage: "Failed to submit interest",
+    });
+  }
+});

--- a/server/utils/rateLimit.ts
+++ b/server/utils/rateLimit.ts
@@ -79,6 +79,16 @@ export async function rateLimitByUser(
   return safeLimit(() => limiter.limit(userId));
 }
 
+export async function rateLimitByKey(
+  event: H3Event,
+  key: string,
+  options: RateLimitOptions,
+): Promise<RateLimitResult> {
+  const limiter = createLimiter(options);
+  if (!limiter) return BYPASS_RESULT;
+  return safeLimit(() => limiter.limit(key));
+}
+
 export function throwIfRateLimited(
   result: Pick<RateLimitResult, "success" | "reset">,
 ): void {

--- a/tests/e2e/profile-interest.spec.ts
+++ b/tests/e2e/profile-interest.spec.ts
@@ -112,8 +112,12 @@ test.describe("Public profile — Express Interest", () => {
       ).toBeVisible();
 
       // Close the confirmation — the popover only closes on this explicit
-      // action (not on submit), same fix as the sibling Contact modal.
-      await anonPage.getByRole("button", { name: "Close" }).click();
+      // action (not on submit), same fix as the sibling Contact modal. The
+      // header's icon-close button is always rendered (even pre-submit) and
+      // shares the same "Close" aria-label as the confirmation's button, so
+      // a role-based lookup would hit both — use its stable data-test
+      // instead of asserting on a strict-mode-ambiguous accessible name.
+      await anonPage.locator('[data-test="popover-close"]').click();
 
       // Hero button is disabled and now reads "Interest Sent" — persisted
       // client-side (per-slug localStorage) so a repeat visitor can't spam.

--- a/tests/e2e/profile-interest.spec.ts
+++ b/tests/e2e/profile-interest.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect, type Browser, type Page } from "@playwright/test";
+
+/**
+ * Public visitor submits "Express Interest" on `/p/<slug>` → the hero button
+ * flips to "Interest Sent" → the lead is visible in the player's own Inbox
+ * tab.
+ *
+ * Mirrors profile-contact.spec.ts: Playwright's default `page` fixture is
+ * pre-authenticated as the shared `player.json` account (see
+ * playwright.config.ts). This spec self-publishes that account's own
+ * profile and reads its slug off the setup page's share panel — the demo
+ * compassdemo account/slug only exists in the live prod DB, not the
+ * dedicated test Supabase project CI runs against. The public-page half of
+ * the flow needs a genuinely anonymous context (no cookies/localStorage),
+ * since a real coach visiting the page has no account.
+ *
+ * Turnstile is off in the test env (no NUXT_PUBLIC_TURNSTILE_SITE_KEY), so
+ * the widget never mounts and never blocks submission.
+ */
+const RUN_ID = Date.now();
+const COACH_NAME = `E2E Interest Coach ${RUN_ID}`;
+const COACH_NOTE = `E2E interest note ${RUN_ID} — would love to talk about your future.`;
+const PROFILE_PUT_PATTERN = (res: { url(): string; request(): { method(): string } }) =>
+  res.url().includes("/api/player/profile") && res.request().method() === "PUT";
+
+async function waitForProfileSave(page: Page, action: () => Promise<void>) {
+  await Promise.all([page.waitForResponse(PROFILE_PUT_PATTERN), action()]);
+}
+
+async function ensurePublishedAndGetSlug(page: Page): Promise<string> {
+  await page.goto("/settings/player-details");
+  await page.waitForLoadState("domcontentloaded");
+
+  await page
+    .locator("button", { hasText: "Public Profile" })
+    .first()
+    .click();
+
+  const publishToggle = page.locator('[data-test="publish-toggle"]');
+  await publishToggle.waitFor({ state: "visible", timeout: 15000 });
+
+  // Ensure published — an unpublished profile 410s on /p/:slug, which would
+  // make the anonymous-visitor flow below unreachable.
+  if (!(await page.getByText("Profile is live").isVisible().catch(() => false))) {
+    await waitForProfileSave(page, () => publishToggle.click());
+  }
+  await expect(page.getByText("Profile is live")).toBeVisible();
+
+  // Read the published slug directly off the share panel — never hardcode a
+  // slug, this account's profile may already exist from a prior run.
+  const shareUrl = page.locator("span.font-mono", { hasText: "/p/" });
+  await expect(shareUrl).toBeVisible();
+  const urlText = (await shareUrl.textContent())?.trim() ?? "";
+  const slug = urlText.split("/p/")[1];
+  expect(slug, `could not parse a slug out of share URL "${urlText}"`).toBeTruthy();
+  return slug;
+}
+
+test.describe("Public profile — Express Interest", () => {
+  test("anonymous visitor expresses interest, hero flips to Interest Sent, and the lead lands in the player's inbox", async ({
+    page,
+    browser,
+  }: {
+    page: Page;
+    browser: Browser;
+  }) => {
+    const slug = await ensurePublishedAndGetSlug(page);
+
+    const anonContext = await browser.newContext({
+      storageState: { cookies: [], origins: [] },
+    });
+    try {
+      const anonPage = await anonContext.newPage();
+      await anonPage.goto(`/p/${slug}`);
+
+      const interestButton = anonPage.getByRole("button", {
+        name: "Express Interest",
+      });
+      await interestButton.click();
+
+      // The popover is a native <dialog> — assert its heading is up before
+      // touching fields, so a slow mount can't produce a flaky fill.
+      await expect(
+        anonPage.getByRole("heading", { name: /^Express interest in/ }),
+      ).toBeVisible();
+
+      // Program renders as a <select> when the profile has athletic
+      // sport/position data, or a free-text input otherwise — handle both
+      // rather than assuming the shared test account's data shape.
+      const programSelect = anonPage.locator('[data-test="program-select"]');
+      const programInput = anonPage.locator('[data-test="program-input"]');
+      if (await programSelect.isVisible().catch(() => false)) {
+        await programSelect.selectOption({ index: 1 });
+      } else {
+        await programInput.fill(`E2E Program ${RUN_ID}`);
+      }
+
+      await anonPage.locator('[data-test="coach-name"]').fill(COACH_NAME);
+      await anonPage
+        .locator('[data-test="coach-email"]')
+        .fill(`e2e-interest-coach-${RUN_ID}@example.com`);
+      await anonPage.locator('[data-test="note"]').fill(COACH_NOTE);
+
+      // Honeypot (`hp`) intentionally left untouched — a real coach never
+      // sees or fills it; a filled value would silently no-op the submit.
+
+      await anonPage.getByRole("button", { name: "Express interest" }).click();
+
+      await expect(anonPage.getByText("Interest sent.")).toBeVisible();
+      await expect(
+        anonPage.getByText("The player has been notified of your interest."),
+      ).toBeVisible();
+
+      // Close the confirmation — the popover only closes on this explicit
+      // action (not on submit), same fix as the sibling Contact modal.
+      await anonPage.getByRole("button", { name: "Close" }).click();
+
+      // Hero button is disabled and now reads "Interest Sent" — persisted
+      // client-side (per-slug localStorage) so a repeat visitor can't spam.
+      await expect(
+        anonPage.getByRole("button", { name: "Interest Sent" }),
+      ).toBeDisabled();
+    } finally {
+      await anonContext.close();
+    }
+
+    // Player-side: the lead is visible in the Public Profile → Inbox tab.
+    await page.goto("/settings/player-details");
+    await page.waitForLoadState("domcontentloaded");
+    await page.locator("button", { hasText: "Inbox" }).first().click();
+
+    const leadRow = page.getByText(COACH_NAME).first();
+    await expect(leadRow).toBeVisible({ timeout: 10000 });
+
+    const interestBadge = page
+      .locator("li", { hasText: COACH_NAME })
+      .getByText("Interest", { exact: true });
+    await expect(interestBadge).toBeVisible();
+
+    // Month-count tile reflects at least this run's lead.
+    const interestStat = page.locator('[data-testid="stat-interest-this-month"]');
+    await expect(interestStat).toBeVisible();
+  });
+});

--- a/tests/unit/components/profile/ExpressInterestPopover.spec.ts
+++ b/tests/unit/components/profile/ExpressInterestPopover.spec.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mount } from "@vue/test-utils";
+
+let turnstileSiteKey = "";
+vi.mock("#app", () => ({
+  useRuntimeConfig: () => ({
+    public: { turnstileSiteKey },
+  }),
+}));
+
+vi.stubGlobal("$fetch", vi.fn());
+
+import ExpressInterestPopover from "~/components/profile/public/ExpressInterestPopover.vue";
+
+const baseProps = {
+  slug: "owen-a",
+  playerName: "Owen A",
+};
+
+describe("ExpressInterestPopover", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    turnstileSiteKey = "";
+  });
+
+  it("renders a program select when programs are provided", () => {
+    const w = mount(ExpressInterestPopover, {
+      props: { ...baseProps, programs: ["Baseball - SS", "Baseball - OF"] },
+    });
+    expect(w.find("[data-test='program-select']").exists()).toBe(true);
+    expect(w.find("[data-test='program-input']").exists()).toBe(false);
+  });
+
+  it("renders a free-text program input when programs is empty", () => {
+    const w = mount(ExpressInterestPopover, { props: baseProps });
+    expect(w.find("[data-test='program-input']").exists()).toBe(true);
+    expect(w.find("[data-test='program-select']").exists()).toBe(false);
+  });
+
+  it("renders a visually-hidden honeypot input named hp", () => {
+    const w = mount(ExpressInterestPopover, { props: baseProps });
+    const hp = w.find("input[name='hp']");
+    expect(hp.exists()).toBe(true);
+    expect(hp.attributes("autocomplete")).toBe("off");
+    expect(hp.attributes("tabindex")).toBe("-1");
+    expect(hp.attributes("aria-hidden")).toBe("true");
+  });
+
+  it("does not render a Turnstile widget when no site key is configured", () => {
+    const w = mount(ExpressInterestPopover, { props: baseProps });
+    expect(w.find("[data-test='turnstile-widget']").exists()).toBe(false);
+  });
+
+  it("renders a Turnstile widget container when a site key is configured", () => {
+    turnstileSiteKey = "test-site-key";
+    const w = mount(ExpressInterestPopover, { props: baseProps });
+    expect(w.find("[data-test='turnstile-widget']").exists()).toBe(true);
+  });
+
+  it("submits the expected body with an empty honeypot and shows the confirmation state", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("$fetch", fetchMock);
+
+    const w = mount(ExpressInterestPopover, { props: baseProps });
+
+    await w.find("[data-test='program-input']").setValue("Baseball - SS");
+    await w.find("[data-test='note']").setValue("Loved your film.");
+    await w.find("[data-test='coach-name']").setValue("Coach Smith");
+    await w.find("[data-test='coach-email']").setValue("coach@state.edu");
+
+    await w.find("form").trigger("submit");
+    await w.vm.$nextTick();
+    await w.vm.$nextTick();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/public/profile/owen-a/interest",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.objectContaining({
+          program: "Baseball - SS",
+          note: "Loved your film.",
+          coachName: "Coach Smith",
+          coachEmail: "coach@state.edu",
+          hp: "",
+        }),
+      }),
+    );
+
+    expect(w.text()).toContain(
+      "The player has been notified of your interest",
+    );
+    expect(w.emitted().submitted).toBeTruthy();
+  });
+
+  it("requires a program value before submitting", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("$fetch", fetchMock);
+
+    const w = mount(ExpressInterestPopover, { props: baseProps });
+    await w.find("form").trigger("submit");
+    await w.vm.$nextTick();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("shows an inline error when submission fails", async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error("boom"));
+    vi.stubGlobal("$fetch", fetchMock);
+
+    const w = mount(ExpressInterestPopover, { props: baseProps });
+    await w.find("[data-test='program-input']").setValue("Baseball - SS");
+    await w.find("form").trigger("submit");
+    await w.vm.$nextTick();
+    await w.vm.$nextTick();
+
+    expect(w.find("[data-test='submit-error']").exists()).toBe(true);
+  });
+
+  it("shows a friendly rate-limit message on a 429 response", async () => {
+    const fetchMock = vi.fn().mockRejectedValue({ statusCode: 429 });
+    vi.stubGlobal("$fetch", fetchMock);
+
+    const w = mount(ExpressInterestPopover, { props: baseProps });
+    await w.find("[data-test='program-input']").setValue("Baseball - SS");
+    await w.find("form").trigger("submit");
+    await w.vm.$nextTick();
+    await w.vm.$nextTick();
+
+    expect(w.find("[data-test='submit-error']").text()).toContain(
+      "try again shortly",
+    );
+  });
+
+  it("emits close when the close button is clicked", async () => {
+    const w = mount(ExpressInterestPopover, { props: baseProps });
+    await w.find("[data-test='popover-close']").trigger("click");
+    expect(w.emitted().close).toBeTruthy();
+  });
+
+  describe("Turnstile widget render + reset", () => {
+    afterEach(() => {
+      delete (window as unknown as { turnstile?: unknown }).turnstile;
+    });
+
+    it("renders the widget with action: 'interest' when a site key is configured", async () => {
+      turnstileSiteKey = "test-site-key";
+      const renderMock = vi.fn().mockReturnValue("widget-1");
+      (window as unknown as { turnstile: unknown }).turnstile = {
+        render: renderMock,
+        reset: vi.fn(),
+      };
+
+      mount(ExpressInterestPopover, { props: baseProps });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(renderMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          sitekey: "test-site-key",
+          action: "interest",
+        }),
+      );
+    });
+
+    it("resets the widget and clears the token when a submit fails", async () => {
+      turnstileSiteKey = "test-site-key";
+      const resetMock = vi.fn();
+      let capturedCallback: ((token: string) => void) | undefined;
+      const renderMock = vi.fn((_el, options) => {
+        capturedCallback = options.callback;
+        return "widget-1";
+      });
+      (window as unknown as { turnstile: unknown }).turnstile = {
+        render: renderMock,
+        reset: resetMock,
+      };
+
+      const fetchMock = vi.fn().mockRejectedValue(new Error("boom"));
+      vi.stubGlobal("$fetch", fetchMock);
+
+      const w = mount(ExpressInterestPopover, { props: baseProps });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      capturedCallback?.("spent-token");
+      await w.vm.$nextTick();
+
+      await w.find("[data-test='program-input']").setValue("Baseball - SS");
+      await w.find("form").trigger("submit");
+      await w.vm.$nextTick();
+      await w.vm.$nextTick();
+
+      expect(resetMock).toHaveBeenCalledWith("widget-1");
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          body: expect.objectContaining({ turnstileToken: "spent-token" }),
+        }),
+      );
+    });
+  });
+});

--- a/tests/unit/components/profile/ExpressInterestPopover.spec.ts
+++ b/tests/unit/components/profile/ExpressInterestPopover.spec.ts
@@ -137,6 +137,13 @@ describe("ExpressInterestPopover", () => {
     expect(w.emitted().close).toBeTruthy();
   });
 
+  it("renders a native <dialog> and emits close on Escape (cancel event)", async () => {
+    const w = mount(ExpressInterestPopover, { props: baseProps });
+    expect(w.find("dialog").exists()).toBe(true);
+    await w.find("dialog").trigger("cancel");
+    expect(w.emitted().close).toBeTruthy();
+  });
+
   describe("Turnstile widget render + reset", () => {
     afterEach(() => {
       delete (window as unknown as { turnstile?: unknown }).turnstile;

--- a/tests/unit/components/profile/ProfileInbox.spec.ts
+++ b/tests/unit/components/profile/ProfileInbox.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ref } from "vue";
+import { mount } from "@vue/test-utils";
+import ProfileInbox from "~/components/profile/ProfileInbox.vue";
+import type {
+  ProfileLead,
+  ProfileContactCounts,
+} from "~/composables/useProfileContacts";
+
+const mockFetchContacts = vi.fn();
+const state = {
+  leads: ref<ProfileLead[]>([]),
+  counts: ref<ProfileContactCounts>({
+    interestThisMonth: 0,
+    contactThisMonth: 0,
+    totalThisMonth: 0,
+  }),
+  loading: ref(false),
+  error: ref<string | null>(null),
+};
+
+vi.mock("~/composables/useProfileContacts", () => ({
+  useProfileContacts: () => ({
+    leads: state.leads,
+    counts: state.counts,
+    loading: state.loading,
+    error: state.error,
+    fetchContacts: mockFetchContacts,
+  }),
+}));
+
+const stubs = {
+  DesignSystemEmptyState: { template: "<div>EMPTY: {{ title }}</div>", props: ["title", "description"] },
+  DesignSystemLoadingState: { template: "<div>LOADING</div>" },
+  DesignSystemErrorState: {
+    template: "<div>ERROR: {{ error }}</div>",
+    props: ["error"],
+  },
+  DesignSystemBadge: { template: "<span><slot /></span>", props: ["color", "variant", "size"] },
+};
+
+const sampleLead: ProfileLead = {
+  id: "lead-1",
+  type: "interest",
+  coach_name: "Coach Smith",
+  coach_email: "coach@school.edu",
+  coach_title: "Head Coach",
+  school_name: "State University",
+  program: "Baseball",
+  note: "Loved your highlight film and would like to schedule a call.",
+  matched_coach_id: null,
+  created_at: "2026-08-01T00:00:00.000Z",
+};
+
+describe("ProfileInbox", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.leads.value = [];
+    state.counts.value = {
+      interestThisMonth: 0,
+      contactThisMonth: 0,
+      totalThisMonth: 0,
+    };
+    state.loading.value = false;
+    state.error.value = null;
+  });
+
+  it("renders monthly stat tiles from counts", () => {
+    state.counts.value = {
+      interestThisMonth: 4,
+      contactThisMonth: 2,
+      totalThisMonth: 6,
+    };
+    const w = mount(ProfileInbox, { global: { stubs } });
+    expect(w.text()).toContain("4");
+    expect(w.text()).toContain("2");
+  });
+
+  it("renders a row per lead with coach name, program, school, and note excerpt", () => {
+    state.leads.value = [sampleLead];
+    const w = mount(ProfileInbox, { global: { stubs } });
+    expect(w.text()).toContain("Coach Smith");
+    expect(w.text()).toContain("Baseball");
+    expect(w.text()).toContain("State University");
+    expect(w.text()).toContain("Loved your highlight film");
+  });
+
+  it("shows the loading state while loading", () => {
+    state.loading.value = true;
+    const w = mount(ProfileInbox, { global: { stubs } });
+    expect(w.text()).toContain("LOADING");
+  });
+
+  it("shows the error state and retries via fetchContacts", async () => {
+    state.error.value = "Failed to load your inbox. Please try again.";
+    const w = mount(ProfileInbox, { global: { stubs } });
+    expect(w.text()).toContain("Failed to load your inbox");
+  });
+
+  it("shows an empty state when not loading and there are no leads", () => {
+    const w = mount(ProfileInbox, { global: { stubs } });
+    expect(w.text()).toContain("EMPTY");
+    expect(w.text()).toContain("No leads yet");
+  });
+});

--- a/tests/unit/components/profile/PublicProfileCard.spec.ts
+++ b/tests/unit/components/profile/PublicProfileCard.spec.ts
@@ -1,8 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { mount } from "@vue/test-utils";
 import PublicProfileCard from "~/components/profile/PublicProfileCard.vue";
 import ProfileHero from "~/components/profile/public/ProfileHero.vue";
 import ContactPlayerModal from "~/components/profile/public/ContactPlayerModal.vue";
+import ExpressInterestPopover from "~/components/profile/public/ExpressInterestPopover.vue";
+
+vi.mock("#app", () => ({
+  useRuntimeConfig: () => ({ public: { turnstileSiteKey: "" } }),
+}));
+vi.stubGlobal("$fetch", vi.fn());
 
 const baseData = {
   playerName: "Owen A",
@@ -44,6 +50,10 @@ const dataAwardsVisible = {
 } as never;
 
 describe("PublicProfileCard", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
   it("hides a section marked visible:false, even with non-empty data", () => {
     const w = mount(PublicProfileCard, {
       props: { data: dataAwardsHidden, slug: "owen-a" },
@@ -124,5 +134,90 @@ describe("PublicProfileCard", () => {
 
     await modal.vm.$emit("close");
     expect(w.findComponent(ContactPlayerModal).exists()).toBe(false);
+  });
+
+  it("opens the interest popover when Express Interest is clicked, and closes on close", async () => {
+    const w = mount(PublicProfileCard, {
+      props: { data: dataAwardsHidden, slug: "owen-a" },
+    });
+    const hero = w.findComponent(ProfileHero);
+    await hero.vm.$emit("interest");
+
+    const popover = w.findComponent(ExpressInterestPopover);
+    expect(popover.exists()).toBe(true);
+
+    await popover.vm.$emit("close");
+    expect(w.findComponent(ExpressInterestPopover).exists()).toBe(false);
+  });
+
+  it("derives programs from primary_sport + positions, deduped", async () => {
+    const dataWithPositions = {
+      ...dataAwardsHidden,
+      athletic: { primary_sport: "Baseball", positions: ["SS", "Baseball"] },
+    };
+    const w = mount(PublicProfileCard, {
+      props: { data: dataWithPositions, slug: "owen-a" },
+    });
+    const hero = w.findComponent(ProfileHero);
+    await hero.vm.$emit("interest");
+
+    const popover = w.findComponent(ExpressInterestPopover);
+    expect(popover.props("programs")).toEqual(["Baseball", "SS"]);
+  });
+
+  it("passes empty programs when athletic is null (hidden section)", async () => {
+    const dataNoAthletic = { ...dataAwardsHidden, athletic: null };
+    const w = mount(PublicProfileCard, {
+      props: { data: dataNoAthletic, slug: "owen-a" },
+    });
+    const hero = w.findComponent(ProfileHero);
+    await hero.vm.$emit("interest");
+
+    const popover = w.findComponent(ExpressInterestPopover);
+    expect(popover.props("programs")).toEqual([]);
+  });
+
+  it("keeps the popover mounted (showing its confirmation) on submitted, and only unmounts on close", async () => {
+    const w = mount(PublicProfileCard, {
+      props: { data: dataAwardsHidden, slug: "owen-a" },
+    });
+    const hero = w.findComponent(ProfileHero);
+    await hero.vm.$emit("interest");
+
+    const popover = w.findComponent(ExpressInterestPopover);
+    await popover.vm.$emit("submitted");
+    expect(w.findComponent(ExpressInterestPopover).exists()).toBe(true);
+
+    await popover.vm.$emit("close");
+    expect(w.findComponent(ExpressInterestPopover).exists()).toBe(false);
+  });
+
+  it("sets Interest Sent + persists to localStorage on submitted, and restores it on remount", async () => {
+    const w = mount(PublicProfileCard, {
+      props: { data: dataAwardsHidden, slug: "owen-a" },
+    });
+    const hero = w.findComponent(ProfileHero);
+    await hero.vm.$emit("interest");
+    const popover = w.findComponent(ExpressInterestPopover);
+    await popover.vm.$emit("submitted");
+
+    expect(w.findComponent(ProfileHero).props("interestSent")).toBe(true);
+    expect(localStorage.getItem("interest-sent:owen-a")).toBe("true");
+
+    const w2 = mount(PublicProfileCard, {
+      props: { data: dataAwardsHidden, slug: "owen-a" },
+    });
+    await w2.vm.$nextTick();
+    expect(w2.findComponent(ProfileHero).props("interestSent")).toBe(true);
+  });
+
+  it("does not open the interest popover without a real slug", async () => {
+    const w = mount(PublicProfileCard, {
+      props: { data: dataAwardsHidden },
+    });
+    const hero = w.findComponent(ProfileHero);
+    await hero.vm.$emit("interest");
+    expect(w.findComponent(ExpressInterestPopover).exists()).toBe(false);
+    expect(w.emitted("interest")).toBeTruthy();
   });
 });

--- a/tests/unit/components/profile/public/ProfileHero.spec.ts
+++ b/tests/unit/components/profile/public/ProfileHero.spec.ts
@@ -47,6 +47,51 @@ describe("ProfileHero", () => {
     expect(w.text()).toContain("@owen.a");
   });
 
+  it("labels the interest button 'Express Interest' and emits interest when not yet sent", async () => {
+    const w = mount(ProfileHero, {
+      props: {
+        data: {
+          playerName: "Owen A",
+          photoUrl: null,
+          headerColor: "slate",
+          bannerUrl: null,
+          jerseyNumber: 7,
+          commitmentStatus: "uncommitted",
+          committedSchoolName: null,
+          bio: "x",
+          athletic: { primary_sport: "Baseball" },
+        } as never,
+      },
+    });
+    const btn = w.findAll("button")[1];
+    expect(btn.text()).toBe("Express Interest");
+    expect(btn.attributes("disabled")).toBeUndefined();
+    await btn.trigger("click");
+    expect(w.emitted().interest).toBeTruthy();
+  });
+
+  it("shows a disabled 'Interest Sent' button and does not emit interest when interestSent is true", async () => {
+    const w = mount(ProfileHero, {
+      props: {
+        data: {
+          playerName: "Owen A",
+          photoUrl: null,
+          headerColor: "slate",
+          bannerUrl: null,
+          jerseyNumber: 7,
+          commitmentStatus: "uncommitted",
+          committedSchoolName: null,
+          bio: "x",
+          athletic: { primary_sport: "Baseball" },
+        } as never,
+        interestSent: true,
+      },
+    });
+    const btn = w.findAll("button")[1];
+    expect(btn.text()).toBe("Interest Sent");
+    expect(btn.attributes("disabled")).toBeDefined();
+  });
+
   it("renders no social row when social is absent", () => {
     const w = mount(ProfileHero, {
       props: {

--- a/tests/unit/composables/useProfileContacts.spec.ts
+++ b/tests/unit/composables/useProfileContacts.spec.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.stubGlobal("$fetch", vi.fn());
+
+const mockLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+};
+vi.mock("~/utils/logger", () => ({
+  createClientLogger: () => mockLogger,
+}));
+
+const sampleLead = {
+  id: "lead-1",
+  type: "interest" as const,
+  coach_name: "Coach Smith",
+  coach_email: "coach@school.edu",
+  coach_title: "Head Coach",
+  school_name: "State University",
+  program: "Baseball",
+  note: "Loved your highlight film.",
+  matched_coach_id: null,
+  created_at: "2026-08-01T00:00:00.000Z",
+};
+
+const sampleCounts = {
+  interestThisMonth: 2,
+  contactThisMonth: 1,
+  totalThisMonth: 3,
+};
+
+describe("useProfileContacts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("initializes with empty leads and zeroed counts", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ leads: [], counts: null });
+    vi.stubGlobal("$fetch", mockFetch);
+    const { useProfileContacts } = await import(
+      "~/composables/useProfileContacts"
+    );
+    const { leads, counts } = useProfileContacts();
+    expect(leads.value).toEqual([]);
+    expect(counts.value).toEqual({
+      interestThisMonth: 0,
+      contactThisMonth: 0,
+      totalThisMonth: 0,
+    });
+  });
+
+  it("fetchContacts populates leads and counts from GET /api/player/profile/contacts", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      leads: [sampleLead],
+      counts: sampleCounts,
+    });
+    vi.stubGlobal("$fetch", mockFetch);
+    const { useProfileContacts } = await import(
+      "~/composables/useProfileContacts"
+    );
+    const { leads, counts, fetchContacts, loading } = useProfileContacts();
+    const promise = fetchContacts();
+    expect(loading.value).toBe(true);
+    await promise;
+    expect(mockFetch).toHaveBeenCalledWith("/api/player/profile/contacts");
+    expect(leads.value).toEqual([sampleLead]);
+    expect(counts.value).toEqual(sampleCounts);
+    expect(loading.value).toBe(false);
+  });
+
+  it("fetchContacts sets a user-friendly error and resets loading when $fetch rejects", async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error("Network error"));
+    vi.stubGlobal("$fetch", mockFetch);
+    const { useProfileContacts } = await import(
+      "~/composables/useProfileContacts"
+    );
+    const { fetchContacts, error, loading, leads } = useProfileContacts();
+    await fetchContacts();
+    expect(error.value).toBe("Failed to load your inbox. Please try again.");
+    expect(loading.value).toBe(false);
+    expect(leads.value).toEqual([]);
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/server/api/player/profile-contacts.spec.ts
+++ b/tests/unit/server/api/player/profile-contacts.spec.ts
@@ -1,0 +1,219 @@
+/**
+ * GET /api/player/profile/contacts — behavioral tests.
+ *
+ * The authed family inbox for inbound leads written by the public profile's
+ * Contact/Express Interest flows (`profile_contacts`). Verifies family scope
+ * (never a client-supplied id), newest-first ordering, monthly count split
+ * by type, and that raw `ip`/`user_agent`/`family_unit_id` never leak into
+ * the response.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { H3Event } from "h3";
+
+vi.mock("~/server/utils/auth", () => ({
+  requireAuth: vi.fn(),
+}));
+
+vi.mock("~/server/utils/logger", () => ({
+  useLogger: () => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock("~/server/utils/supabase", () => ({ useSupabaseAdmin: vi.fn() }));
+
+function fakeEvent(): H3Event {
+  return { context: {} } as unknown as H3Event;
+}
+
+const LEAD_ROWS = [
+  {
+    id: "lead-2",
+    type: "interest",
+    coach_name: "Coach Newer",
+    coach_email: "newer@example.com",
+    coach_title: "Head Coach",
+    school_name: "Newer State",
+    program: "Baseball",
+    note: "Interested",
+    matched_coach_id: null,
+    created_at: "2026-08-20T00:00:00.000Z",
+  },
+  {
+    id: "lead-1",
+    type: "contact",
+    coach_name: "Coach Older",
+    coach_email: "older@example.com",
+    coach_title: null,
+    school_name: "Older State",
+    program: null,
+    note: "Reaching out",
+    matched_coach_id: "coach-123",
+    created_at: "2026-07-01T00:00:00.000Z",
+  },
+];
+
+/**
+ * Builds a mocked admin client matching this endpoint's exact call shape:
+ * - `family_members` select().eq().single() → membership
+ * - `profile_contacts` select().eq().order().limit() → leads
+ * - `profile_contacts` select("*", {count}).eq().eq().gte() → per-type count
+ */
+function buildAdminMock(opts: {
+  membership: { family_unit_id: string } | null;
+  leads: typeof LEAD_ROWS;
+  interestCount: number;
+  contactCount: number;
+}) {
+  const from = vi.fn((table: string) => {
+    if (table === "family_members") {
+      return {
+        select: () => ({
+          eq: () => ({
+            single: () =>
+              Promise.resolve({ data: opts.membership, error: null }),
+          }),
+        }),
+      };
+    }
+    if (table === "profile_contacts") {
+      return {
+        select: (_cols: string, countOpts?: { count?: string }) => {
+          if (countOpts?.count) {
+            // Count query: select(...).eq(family).eq(type).gte(month) → { count }
+            const chain = {
+              eq: (col: string, val: string) => {
+                if (col === "type") {
+                  const count =
+                    val === "interest" ? opts.interestCount : opts.contactCount;
+                  return {
+                    gte: () => Promise.resolve({ count, error: null }),
+                  };
+                }
+                return chain;
+              },
+            };
+            return chain;
+          }
+          // Leads listing: select().eq(family).order().limit()
+          return {
+            eq: () => ({
+              order: () => ({
+                limit: () =>
+                  Promise.resolve({ data: opts.leads, error: null }),
+              }),
+            }),
+          };
+        },
+      };
+    }
+    throw new Error(`Unexpected table: ${table}`);
+  });
+  return { from } as never;
+}
+
+describe("GET /api/player/profile/contacts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  async function loadHandler() {
+    return (await import("~/server/api/player/profile/contacts.get")).default;
+  }
+
+  async function mockAuth(user: { id: string; email: string } | null) {
+    const { requireAuth } = await import("~/server/utils/auth");
+    if (user) {
+      vi.mocked(requireAuth).mockResolvedValue(user);
+    } else {
+      vi.mocked(requireAuth).mockRejectedValue(
+        Object.assign(new Error("Unauthorized"), { statusCode: 401 }),
+      );
+    }
+  }
+
+  it("returns family-scoped leads newest-first with monthly counts split by type", async () => {
+    await mockAuth({ id: "user-1", email: "user@example.com" });
+    const { useSupabaseAdmin } = await import("~/server/utils/supabase");
+    vi.mocked(useSupabaseAdmin).mockReturnValue(
+      buildAdminMock({
+        membership: { family_unit_id: "family-1" },
+        leads: LEAD_ROWS,
+        interestCount: 1,
+        contactCount: 1,
+      }),
+    );
+    const handler = await loadHandler();
+
+    const result = await handler(fakeEvent());
+
+    expect(result).toMatchObject({
+      leads: [
+        expect.objectContaining({ id: "lead-2", type: "interest" }),
+        expect.objectContaining({ id: "lead-1", type: "contact" }),
+      ],
+      counts: {
+        interestThisMonth: 1,
+        contactThisMonth: 1,
+        totalThisMonth: 2,
+      },
+    });
+  });
+
+  it("never exposes ip, user_agent, or family_unit_id in the payload", async () => {
+    await mockAuth({ id: "user-1", email: "user@example.com" });
+    const { useSupabaseAdmin } = await import("~/server/utils/supabase");
+    vi.mocked(useSupabaseAdmin).mockReturnValue(
+      buildAdminMock({
+        membership: { family_unit_id: "family-1" },
+        leads: LEAD_ROWS,
+        interestCount: 1,
+        contactCount: 1,
+      }),
+    );
+    const handler = await loadHandler();
+
+    const result = (await handler(fakeEvent())) as {
+      leads: Record<string, unknown>[];
+    };
+
+    for (const lead of result.leads) {
+      expect(lead).not.toHaveProperty("ip");
+      expect(lead).not.toHaveProperty("user_agent");
+      expect(lead).not.toHaveProperty("family_unit_id");
+    }
+  });
+
+  it("propagates an unauthenticated request's rejection", async () => {
+    await mockAuth(null);
+    const { useSupabaseAdmin } = await import("~/server/utils/supabase");
+    vi.mocked(useSupabaseAdmin).mockReturnValue({ from: vi.fn() } as never);
+    const handler = await loadHandler();
+
+    await expect(handler(fakeEvent())).rejects.toMatchObject({
+      statusCode: 401,
+    });
+  });
+
+  it("returns 403 when the user has no family membership", async () => {
+    await mockAuth({ id: "user-1", email: "user@example.com" });
+    const { useSupabaseAdmin } = await import("~/server/utils/supabase");
+    vi.mocked(useSupabaseAdmin).mockReturnValue(
+      buildAdminMock({
+        membership: null,
+        leads: [],
+        interestCount: 0,
+        contactCount: 0,
+      }),
+    );
+    const handler = await loadHandler();
+
+    await expect(handler(fakeEvent())).rejects.toMatchObject({
+      statusCode: 403,
+    });
+  });
+});

--- a/tests/unit/server/api/public/contact.spec.ts
+++ b/tests/unit/server/api/public/contact.spec.ts
@@ -20,12 +20,19 @@ const rateLimitByIpMock = vi.fn(async () => ({
   remaining: 4,
   reset: 0,
 }));
+const rateLimitByKeyMock = vi.fn(async () => ({
+  success: true,
+  limit: 20,
+  remaining: 19,
+  reset: 0,
+}));
 const verifyTurnstileMock = vi.fn(async () => ({ ok: true }));
 const matchCoachByEmailMock = vi.fn(async () => ({ coachId: null as string | null }));
 const sendNotificationEmailMock = vi.fn(async () => ({ success: true }));
 
 vi.mock("~/server/utils/rateLimit", () => ({
   rateLimitByIp: (...args: unknown[]) => rateLimitByIpMock(...args),
+  rateLimitByKey: (...args: unknown[]) => rateLimitByKeyMock(...args),
   throwIfRateLimited: (result: { success: boolean }) => {
     if (!result.success) {
       const err = new Error("Too many requests") as Error & {
@@ -192,6 +199,13 @@ describe("POST /api/public/profile/[slug]/contact", () => {
       success: true,
       limit: 5,
       remaining: 4,
+      reset: 0,
+    });
+    rateLimitByKeyMock.mockClear();
+    rateLimitByKeyMock.mockResolvedValue({
+      success: true,
+      limit: 20,
+      remaining: 19,
       reset: 0,
     });
     verifyTurnstileMock.mockClear();

--- a/tests/unit/server/api/public/interest.spec.ts
+++ b/tests/unit/server/api/public/interest.spec.ts
@@ -1,0 +1,360 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockState = {
+  profileRow: null as {
+    id: string;
+    family_unit_id: string;
+    user_id: string;
+    is_published: boolean;
+  } | null,
+  userRow: null as { email: string; full_name: string | null } | null,
+  insertedContact: null as Record<string, unknown> | null,
+  contactInsertError: null as object | null,
+  notificationInserts: [] as Record<string, unknown>[],
+};
+
+const rateLimitByIpMock = vi.fn(async () => ({
+  success: true,
+  limit: 5,
+  remaining: 4,
+  reset: 0,
+}));
+const rateLimitByKeyMock = vi.fn(async () => ({
+  success: true,
+  limit: 20,
+  remaining: 19,
+  reset: 0,
+}));
+const verifyTurnstileMock = vi.fn(async () => ({ ok: true }));
+const matchCoachByEmailMock = vi.fn(async () => ({ coachId: null as string | null }));
+const sendNotificationEmailMock = vi.fn(async () => ({ success: true }));
+
+vi.mock("~/server/utils/rateLimit", () => ({
+  rateLimitByIp: (...args: unknown[]) => rateLimitByIpMock(...args),
+  rateLimitByKey: (...args: unknown[]) => rateLimitByKeyMock(...args),
+  throwIfRateLimited: (result: { success: boolean }) => {
+    if (!result.success) {
+      const err = new Error("Too many requests") as Error & {
+        statusCode: number;
+      };
+      err.statusCode = 429;
+      throw err;
+    }
+  },
+}));
+
+vi.mock("~/server/utils/turnstile", () => ({
+  verifyTurnstile: (...args: unknown[]) => verifyTurnstileMock(...args),
+  isHoneypotTripped: (hp: unknown) =>
+    typeof hp === "string" && hp.trim().length > 0,
+}));
+
+vi.mock("~/server/utils/matchCoachByEmail", () => ({
+  matchCoachByEmail: (...args: unknown[]) => matchCoachByEmailMock(...args),
+}));
+
+vi.mock("~/server/utils/emailService", () => ({
+  sendNotificationEmail: (...args: unknown[]) =>
+    sendNotificationEmailMock(...args),
+}));
+
+vi.mock("~/server/utils/supabase", () => ({
+  useSupabaseAdmin: vi.fn(() => ({
+    from: (table: string) => {
+      if (table === "player_profiles") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () =>
+                Promise.resolve({ data: mockState.profileRow, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === "users") {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: () =>
+                Promise.resolve({ data: mockState.userRow, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === "profile_contacts") {
+        return {
+          insert: (row: Record<string, unknown>) => {
+            mockState.insertedContact = row;
+            return {
+              select: () => ({
+                single: () =>
+                  Promise.resolve({
+                    data: mockState.contactInsertError
+                      ? null
+                      : { id: "contact-1" },
+                    error: mockState.contactInsertError,
+                  }),
+              }),
+            };
+          },
+        };
+      }
+      if (table === "notifications") {
+        return {
+          insert: (row: Record<string, unknown>) => {
+            mockState.notificationInserts.push(row);
+            return Promise.resolve({ error: null });
+          },
+        };
+      }
+      return {};
+    },
+  })),
+}));
+
+vi.mock("~/server/utils/logger", () => ({
+  useLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  }),
+}));
+
+vi.mock("h3", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("h3")>();
+  return {
+    ...actual,
+    defineEventHandler: (fn: (event: unknown) => unknown) => fn,
+    getRouterParam: vi.fn(() => "abc123"),
+    getRequestIP: vi.fn(() => "1.2.3.4"),
+    getRequestHeader: vi.fn(() => "Mozilla/5.0"),
+    getHeader: vi.fn(
+      (
+        event: { _headers?: Record<string, string> },
+        name: string,
+      ) => event._headers?.[name.toLowerCase()],
+    ),
+    readBody: vi.fn(async (event: { _body?: unknown }) => event._body ?? {}),
+    createError: (cfg: { statusCode: number; statusMessage?: string }) => {
+      const err = new Error(cfg.statusMessage) as Error & {
+        statusCode: number;
+      };
+      err.statusCode = cfg.statusCode;
+      return err;
+    },
+  };
+});
+
+const { default: handler } = await import(
+  "~/server/api/public/profile/[slug]/interest.post"
+);
+
+function makeEvent(
+  body: Record<string, unknown>,
+  headers: Record<string, string> = {},
+) {
+  return {
+    _body: body,
+    _headers: headers,
+  } as unknown as Parameters<typeof handler>[0];
+}
+
+const validBody = {
+  program: "2027 Baseball Camp",
+};
+
+describe("POST /api/public/profile/[slug]/interest", () => {
+  beforeEach(() => {
+    mockState.profileRow = {
+      id: "profile-1",
+      family_unit_id: "family-1",
+      user_id: "player-1",
+      is_published: true,
+    };
+    mockState.userRow = { email: "player@example.com", full_name: "Player One" };
+    mockState.insertedContact = null;
+    mockState.contactInsertError = null;
+    mockState.notificationInserts = [];
+    rateLimitByIpMock.mockClear();
+    rateLimitByIpMock.mockResolvedValue({
+      success: true,
+      limit: 5,
+      remaining: 4,
+      reset: 0,
+    });
+    rateLimitByKeyMock.mockClear();
+    rateLimitByKeyMock.mockResolvedValue({
+      success: true,
+      limit: 20,
+      remaining: 19,
+      reset: 0,
+    });
+    verifyTurnstileMock.mockClear();
+    verifyTurnstileMock.mockResolvedValue({ ok: true });
+    matchCoachByEmailMock.mockClear();
+    matchCoachByEmailMock.mockResolvedValue({ coachId: null });
+    sendNotificationEmailMock.mockClear();
+    sendNotificationEmailMock.mockResolvedValue({ success: true });
+  });
+
+  it("silently returns ok when honeypot is tripped, with no insert or notify", async () => {
+    const result = await handler(makeEvent({ ...validBody, hp: "im-a-bot" }));
+    expect(result).toEqual({ ok: true });
+    expect(mockState.insertedContact).toBeNull();
+    expect(sendNotificationEmailMock).not.toHaveBeenCalled();
+    expect(mockState.notificationInserts).toHaveLength(0);
+  });
+
+  it("returns 429 when per-IP rate limited", async () => {
+    rateLimitByIpMock.mockResolvedValueOnce({
+      success: false,
+      limit: 5,
+      remaining: 0,
+      reset: Date.now() + 60_000,
+    });
+    await expect(handler(makeEvent(validBody))).rejects.toMatchObject({
+      statusCode: 429,
+    });
+  });
+
+  it("returns 429 when per-slug rate limited, using an interest-namespaced key", async () => {
+    rateLimitByKeyMock.mockResolvedValueOnce({
+      success: false,
+      limit: 20,
+      remaining: 0,
+      reset: Date.now() + 60_000,
+    });
+    await expect(handler(makeEvent(validBody))).rejects.toMatchObject({
+      statusCode: 429,
+    });
+    expect(rateLimitByKeyMock).toHaveBeenCalledWith(
+      expect.anything(),
+      "interest:abc123",
+      expect.objectContaining({ requests: 20, window: "1 h" }),
+    );
+  });
+
+  it("returns 422 when program is missing", async () => {
+    await expect(handler(makeEvent({}))).rejects.toMatchObject({
+      statusCode: 422,
+    });
+  });
+
+  it("returns 403 when Turnstile verification fails", async () => {
+    verifyTurnstileMock.mockResolvedValueOnce({ ok: false, reason: "invalid" });
+    await expect(
+      handler(makeEvent({ ...validBody, turnstileToken: "bad" })),
+    ).rejects.toMatchObject({ statusCode: 403 });
+    expect(mockState.insertedContact).toBeNull();
+  });
+
+  it("calls verifyTurnstile with expectedAction 'interest'", async () => {
+    await handler(makeEvent(validBody));
+    expect(verifyTurnstileMock).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ expectedAction: "interest" }),
+    );
+  });
+
+  it("returns 404 when the slug does not resolve to a profile", async () => {
+    mockState.profileRow = null;
+    await expect(handler(makeEvent(validBody))).rejects.toMatchObject({
+      statusCode: 404,
+    });
+  });
+
+  it("returns 404 when the profile is unpublished", async () => {
+    mockState.profileRow = {
+      id: "profile-1",
+      family_unit_id: "family-1",
+      user_id: "player-1",
+      is_published: false,
+    };
+    await expect(handler(makeEvent(validBody))).rejects.toMatchObject({
+      statusCode: 404,
+    });
+  });
+
+  it("inserts an anonymous interest with a placeholder coach name, no match, and notifies", async () => {
+    const result = await handler(makeEvent(validBody));
+
+    expect(result).toEqual({ ok: true });
+    expect(mockState.insertedContact).toMatchObject({
+      family_unit_id: "family-1",
+      player_user_id: "player-1",
+      type: "interest",
+      program: "2027 Baseball Camp",
+      coach_name: "A coach",
+      coach_email: null,
+      matched_coach_id: null,
+      ip: "1.2.3.4",
+      user_agent: "Mozilla/5.0",
+    });
+    expect(mockState.notificationInserts).toHaveLength(1);
+    expect(mockState.notificationInserts[0]).toMatchObject({
+      user_id: "player-1",
+      type: "inbound_interaction",
+      title: "New interest from a coach",
+      related_entity_type: "profile_contact",
+      related_entity_id: "contact-1",
+    });
+    expect(sendNotificationEmailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets matched_coach_id when coachEmail matches an existing coach", async () => {
+    matchCoachByEmailMock.mockResolvedValueOnce({ coachId: "coach-42" });
+    const result = await handler(
+      makeEvent({
+        ...validBody,
+        coachName: "Coach Smith",
+        coachEmail: "coach@example.edu",
+      }),
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(mockState.insertedContact).toMatchObject({
+      coach_name: "Coach Smith",
+      coach_email: "coach@example.edu",
+      matched_coach_id: "coach-42",
+    });
+  });
+
+  it("never leaks player/coach PII in the response body", async () => {
+    const result = await handler(
+      makeEvent({ ...validBody, coachName: "Coach Smith" }),
+    );
+    const serialized = JSON.stringify(result);
+    expect(serialized).not.toContain("player@example.com");
+    expect(serialized).not.toContain("Coach Smith");
+    expect(Object.keys(result as object).sort()).toEqual(["ok"]);
+  });
+
+  it("does not fail the response when notification insert fails", async () => {
+    sendNotificationEmailMock.mockRejectedValueOnce(new Error("resend down"));
+    const result = await handler(makeEvent(validBody));
+    expect(result).toEqual({ ok: true });
+  });
+
+  describe("trusted client IP", () => {
+    it("uses x-vercel-forwarded-for for the rate-limit key and stored ip", async () => {
+      const result = await handler(
+        makeEvent(validBody, { "x-vercel-forwarded-for": "9.9.9.9" }),
+      );
+      expect(result).toEqual({ ok: true });
+      expect(rateLimitByIpMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ ip: "9.9.9.9" }),
+      );
+      expect(mockState.insertedContact).toMatchObject({ ip: "9.9.9.9" });
+    });
+
+    it("inserts with ip null instead of 500ing when the resolved IP is malformed", async () => {
+      const result = await handler(
+        makeEvent(validBody, { "x-vercel-forwarded-for": "garbage" }),
+      );
+      expect(result).toEqual({ ok: true });
+      expect(mockState.insertedContact).toMatchObject({ ip: null });
+    });
+  });
+});

--- a/tests/unit/server/utils/rateLimit.spec.ts
+++ b/tests/unit/server/utils/rateLimit.spec.ts
@@ -34,6 +34,7 @@ vi.mock("h3", async (importOriginal) => {
 import {
   rateLimitByIp,
   rateLimitByUser,
+  rateLimitByKey,
   throwIfRateLimited,
 } from "~/server/utils/rateLimit";
 import { getRequestIP, createError } from "h3";
@@ -113,6 +114,78 @@ describe("rateLimitByUser", () => {
     });
 
     expect(mockLimit).toHaveBeenCalledWith("user-abc");
+  });
+});
+
+describe("rateLimitByKey", () => {
+  beforeEach(() => {
+    mockLimit.mockClear();
+    process.env.UPSTASH_REDIS_REST_URL = "https://test.upstash.io";
+    process.env.UPSTASH_REDIS_REST_TOKEN = "test-token";
+  });
+
+  it("uses caller-supplied key as rate limit key", async () => {
+    mockLimit.mockResolvedValue({
+      success: true,
+      limit: 20,
+      remaining: 19,
+      reset: Date.now(),
+    });
+
+    await rateLimitByKey({} as never, "contact:abc123", {
+      requests: 20,
+      window: "1 h",
+    });
+
+    expect(mockLimit).toHaveBeenCalledWith("contact:abc123");
+  });
+
+  it("returns success result when under limit", async () => {
+    const now = Date.now();
+    mockLimit.mockResolvedValue({
+      success: true,
+      limit: 20,
+      remaining: 19,
+      reset: now + 3600000,
+    });
+
+    const result = await rateLimitByKey({} as never, "interest:xyz789", {
+      requests: 20,
+      window: "1 h",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.remaining).toBe(19);
+  });
+
+  it("returns BYPASS_RESULT when Upstash env is missing", async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    const result = await rateLimitByKey({} as never, "contact:abc123", {
+      requests: 20,
+      window: "1 h",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.limit).toBe(0);
+    expect(result.remaining).toBe(0);
+    expect(result.reset).toBe(0);
+    expect(mockLimit).not.toHaveBeenCalled();
+  });
+
+  it("returns BYPASS_RESULT when limiter throws", async () => {
+    mockLimit.mockRejectedValue(new Error("Redis connection failed"));
+
+    const result = await rateLimitByKey({} as never, "contact:abc123", {
+      requests: 20,
+      window: "1 h",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.limit).toBe(0);
+    expect(result.remaining).toBe(0);
+    expect(result.reset).toBe(0);
   });
 });
 


### PR DESCRIPTION
## Phase 4 — Express Interest (final spec phase)

Adds the one-tap **Express Interest** inbound flow to the public player profile, the athlete's **inbound-leads inbox**, and thin **monthly analytics**. Built via subagent-driven-development — 8 tasks, every task reviewed + fix-looped, whole-branch opus final review = **Ready to merge**.

**No migration** — `profile_contacts` (Phase 3, live) already has `type` + `program` + family-read RLS.

### What's in it
- **Per-slug rate limiter** — `rateLimitByKey(event,key,opts)`; Contact endpoint retrofitted `contact:<slug>` (closes Phase-3 TODO); Interest uses `interest:<slug>`.
- **`POST /api/public/profile/[slug]/interest`** — verbatim clone of the hardened Contact guard chain: honeypot → per-IP → per-slug → Zod → Turnstile (`action:"interest"`) → slug-404 → `matchCoachByEmail` (match-only, never creates) → service-role insert `type:'interest'`+`program` → notify (in-app + email) → `{ ok:true }` only (no PII). Anonymous interest allowed (`coach_name` NOT NULL → placeholder "A coach").
- **`ExpressInterestPopover.vue`** — native `<dialog>` (focus-trap + Escape + aria-modal, mirrors ContactPlayerModal), program-select over the athlete's own sports with free-text fallback (athletic-section-null-safe), honeypot, conditional Turnstile widget.
- **Hero wiring + "Interest Sent" state** — `PublicProfileCard` owns popover state + `localStorage` `interest-sent:<slug>` (SSR-guarded); `ProfileHero` gets `interestSent` prop → disabled "Interest Sent" button.
- **Authed inbox** — `GET /api/player/profile/contacts` (family-scoped via `requireAuth` + `family_members`, never a client id; excludes `ip`/`user_agent`/`family_unit_id`; per-type UTC-month exact counts) + `useProfileContacts` + `ProfileInbox.vue` (StatsTiles + lead rows w/ contact/interest badge, DS empty/loading/error) + new **Inbox** tab in `pages/settings/player-details.vue`.
- **E2E** `tests/e2e/profile-interest.spec.ts` — public submit → Interest Sent → authed inbox assert.

### Test plan
- ✅ type-check 0 · lint 0 · audit:tokens 0 err (5 pre-existing chart warnings)
- ✅ unit **8174 pass / 0 fail** / 63 skip
- ⏳ E2E `profile-interest.spec.ts` CI-deferred (local EMFILE watcher, Phases 1–3 same) — runs in CI

### Fast-follows (reviewer-triaged, none block merge)
per-IP limiter not endpoint-namespaced (Contact+Interest share one per-IP bucket; per-slug ARE separate) · inbox family-scoped not per-athlete (by-plan) · `contacts.get.ts` membership `.single()` swallows error → 403 not 500 on transient DB err · inbox PII test weak (real guard = explicit SELECT, correct) · extract `useTurnstileWidget` · `formatLeadDate` dup + tab nav/panel order cosmetic.

### 🔴 Launch gate (before ANY public-prod promote of Contact/Interest)
Provision **Turnstile** (`NUXT_TURNSTILE_SECRET_KEY` + `NUXT_PUBLIC_TURNSTILE_SITE_KEY`, then redeploy — SPA bakes NUXT_PUBLIC at build) **or** confirm **Upstash** (`UPSTASH_REDIS_REST_URL/TOKEN`). With Turnstile off AND Upstash unset, both endpoints have only the honeypot. Merge to develop/QA is fine.

https://claude.ai/code/session_015gubyo2cjj8t6C3DGJvsKu