### PR TITLE
fix(profile): widen public profile container to match Figma

### DIFF
--- a/pages/p/[slug].vue
+++ b/pages/p/[slug].vue
@@ -84,7 +84,7 @@ useSeoMeta({
     </div>
 
     <!-- Profile card -->
-    <div v-else-if="profile" class="mx-auto max-w-2xl px-4 py-8">
+    <div v-else-if="profile" class="mx-auto max-w-6xl px-4 py-8">
       <ProfilePublicProfileCard :data="profile" :slug="slug" />
     </div>
 


### PR DESCRIPTION
Public profile page (`pages/p/[slug].vue`) was capped at `max-w-2xl` (672px) from the Phase-1 redesign; the Figma design is **1200px** wide. Bumped to `max-w-6xl` (1152px, nearest standard Tailwind token).

Sections stay single-column (per Chris — "just widen container"). If the wider layout reads sparse, a multi-column rework is a follow-up.

**Test plan:** 1-line utility-class change; pre-push type-check + lint green. Verify visually on the QA preview.

https://claude.ai/code/session_015gubyo2cjj8t6C3DGJvsKu