### PR TITLE
fix(settings): align all Settings page widths to max-w-7xl

### DIFF
--- a/pages/settings/account.vue
+++ b/pages/settings/account.vue
@@ -3,7 +3,7 @@
     class="min-h-screen bg-linear-to-br from-slate-50 via-blue-50 to-slate-100"
   >
     <div class="border-b border-slate-200 bg-white">
-      <div class="mx-auto max-w-4xl px-4 py-4 sm:px-6">
+      <div class="mx-auto max-w-7xl px-4 py-4 sm:px-6">
         <NuxtLink
           to="/settings"
           class="mb-3 inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-blue-600 transition hover:bg-blue-50 hover:text-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
@@ -16,7 +16,7 @@
       </div>
     </div>
 
-    <main class="mx-auto max-w-4xl space-y-6 px-4 py-8 sm:px-6">
+    <main class="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6">
       <!-- Account Info -->
       <section
         class="rounded-xl border border-slate-200 bg-white p-6 shadow-xs"

--- a/pages/settings/communication-templates.vue
+++ b/pages/settings/communication-templates.vue
@@ -4,7 +4,7 @@
   >
     <!-- Page Header -->
     <div class="border-b border-slate-200 bg-white">
-      <div class="mx-auto max-w-4xl px-4 py-4 sm:px-6">
+      <div class="mx-auto max-w-7xl px-4 py-4 sm:px-6">
         <NuxtLink
           to="/settings"
           class="mb-3 inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-blue-600 transition hover:bg-blue-50 hover:text-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
@@ -21,7 +21,7 @@
       </div>
     </div>
 
-    <main class="mx-auto max-w-4xl px-4 py-8 sm:px-6">
+    <main class="mx-auto max-w-7xl px-4 py-8 sm:px-6">
       <!-- Tabs -->
       <div class="mb-8 flex gap-4">
         <button

--- a/pages/settings/dashboard.vue
+++ b/pages/settings/dashboard.vue
@@ -4,7 +4,7 @@
   >
     <!-- Page Header -->
     <div class="border-b border-slate-200 bg-white">
-      <div class="mx-auto max-w-5xl px-4 py-4 sm:px-6">
+      <div class="mx-auto max-w-7xl px-4 py-4 sm:px-6">
         <NuxtLink
           to="/settings"
           class="mb-3 inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-blue-600 transition hover:bg-blue-50 hover:text-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
@@ -22,7 +22,7 @@
       </div>
     </div>
 
-    <main class="mx-auto max-w-5xl space-y-6 px-4 py-8 sm:px-6">
+    <main class="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6">
       <!-- Stats Bar toggles -->
       <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-xs">
         <h2

--- a/pages/settings/family-management.vue
+++ b/pages/settings/family-management.vue
@@ -4,7 +4,7 @@
   >
     <!-- Page Header -->
     <div class="border-b border-slate-200 bg-white">
-      <div class="mx-auto max-w-4xl px-4 py-4 sm:px-6">
+      <div class="mx-auto max-w-7xl px-4 py-4 sm:px-6">
         <NuxtLink
           to="/settings"
           class="mb-3 inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-blue-600 transition hover:bg-blue-50 hover:text-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
@@ -19,7 +19,7 @@
       </div>
     </div>
 
-    <main class="mx-auto max-w-4xl px-4 py-8 sm:px-6">
+    <main class="mx-auto max-w-7xl px-4 py-8 sm:px-6">
       <!-- Error Alert -->
       <div
         v-if="error"

--- a/pages/settings/index.vue
+++ b/pages/settings/index.vue
@@ -10,7 +10,7 @@
       description="Manage your profile, preferences, and account settings"
     />
 
-    <main class="mx-auto max-w-4xl px-4 py-8 sm:px-6">
+    <main class="mx-auto max-w-7xl px-4 py-8 sm:px-6">
       <!-- Profile Section -->
       <div class="mb-8">
         <h2

--- a/pages/settings/location.vue
+++ b/pages/settings/location.vue
@@ -6,7 +6,7 @@
 
     <!-- Page Header -->
     <div class="border-b border-slate-200 bg-white">
-      <div class="mx-auto max-w-4xl px-4 py-4 sm:px-6">
+      <div class="mx-auto max-w-7xl px-4 py-4 sm:px-6">
         <NuxtLink
           to="/settings"
           class="mb-3 inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-blue-600 transition hover:bg-blue-50 hover:text-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
@@ -21,7 +21,7 @@
       </div>
     </div>
 
-    <main class="mx-auto max-w-4xl px-4 py-8 sm:px-6">
+    <main class="mx-auto max-w-7xl px-4 py-8 sm:px-6">
       <div
         v-if="isLoading"
         class="rounded-xl border border-slate-200 bg-white p-12 text-center shadow-xs"

--- a/pages/settings/notifications.vue
+++ b/pages/settings/notifications.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="mx-auto max-w-2xl px-4 py-8">
+  <div class="mx-auto max-w-7xl px-4 py-8">
     <NuxtLink
       to="/settings"
       class="mb-3 inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-blue-600 transition hover:bg-blue-50 hover:text-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"

--- a/pages/settings/player-details.vue
+++ b/pages/settings/player-details.vue
@@ -8,7 +8,7 @@
       class="sticky top-16 z-30 border-b border-slate-200 bg-white/90 backdrop-blur-lg"
     >
       <div
-        class="mx-auto flex max-w-4xl items-center justify-between px-4 py-3 sm:px-6"
+        class="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6"
       >
         <div class="flex items-center gap-3">
           <NuxtLink
@@ -46,7 +46,7 @@
       </div>
     </div>
 
-    <main class="mx-auto max-w-4xl px-4 py-6 sm:px-6">
+    <main class="mx-auto max-w-7xl px-4 py-6 sm:px-6">
       <!-- Profile Completeness Hero -->
       <div
         class="mb-8 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm"

--- a/pages/settings/profile.vue
+++ b/pages/settings/profile.vue
@@ -4,7 +4,7 @@
   >
     <!-- Page Header -->
     <div class="border-b border-slate-200 bg-white">
-      <div class="mx-auto max-w-4xl px-4 py-4 sm:px-6">
+      <div class="mx-auto max-w-7xl px-4 py-4 sm:px-6">
         <NuxtLink
           to="/settings"
           class="mb-3 inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-blue-600 transition hover:bg-blue-50 hover:text-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
@@ -19,7 +19,7 @@
       </div>
     </div>
 
-    <main class="mx-auto max-w-4xl space-y-6 px-4 py-8 sm:px-6">
+    <main class="mx-auto max-w-7xl space-y-6 px-4 py-8 sm:px-6">
       <ProfilePhotoSection />
       <ProfilePersonalInfoSection />
       <ProfileEmailSection />

--- a/pages/settings/school-preferences.vue
+++ b/pages/settings/school-preferences.vue
@@ -4,7 +4,7 @@
   >
     <!-- Page Header -->
     <div class="border-b border-slate-200 bg-white">
-      <div class="mx-auto max-w-4xl px-4 py-4 sm:px-6">
+      <div class="mx-auto max-w-7xl px-4 py-4 sm:px-6">
         <NuxtLink
           to="/settings"
           class="mb-3 inline-flex items-center gap-1 rounded-lg px-3 py-2 text-sm font-medium text-blue-600 transition hover:bg-blue-50 hover:text-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
@@ -21,7 +21,7 @@
       </div>
     </div>
 
-    <main class="mx-auto max-w-4xl px-4 py-8 sm:px-6">
+    <main class="mx-auto max-w-7xl px-4 py-8 sm:px-6">
       <!-- Loading State -->
       <div
         v-if="isLoading"


### PR DESCRIPTION
Settings pages were narrower than the main app pages. Dashboard / Schools / Coaches / Interactions use `max-w-7xl` (1280px); Settings pages used `max-w-4xl` (896px), with `settings/dashboard` at `max-w-5xl` and `settings/notifications` at `max-w-2xl`. Every page hardcodes its own container (no shared wrapper) so they drifted.

Widened **all** Settings page containers to `max-w-7xl` for parity (Chris's call — full parity). Purely width-class swaps; the `school-preferences` modal (`max-w-lg`) is left untouched.

Files: account, communication-templates, dashboard, family-management, index, location, notifications, player-details, profile, school-preferences.

**Test plan:** width-class-only change; lint 0, audit:tokens 0 err. Verify visually on QA. Follow-up worth considering: hoist the container into a shared layout/component so widths can't drift again.

https://claude.ai/code/session_015gubyo2cjj8t6C3DGJvsKu