### PR TITLE
fix(profile): unblock Athletic Metrics visibility toggle

### DIFF
--- a/components/profile/ProfileSetup.vue
+++ b/components/profile/ProfileSetup.vue
@@ -269,7 +269,6 @@ function onSectionConfigUpdate(sections: ProfileSection[]) {
         </h3>
         <SectionConfigEditor
           :model-value="draft.section_config"
-          :show-metrics="draft.show_metrics"
           @update:model-value="onSectionConfigUpdate"
         />
       </section>

--- a/components/profile/setup/SectionConfigEditor.vue
+++ b/components/profile/setup/SectionConfigEditor.vue
@@ -6,13 +6,9 @@ import type { ProfileSection } from "~/types/models";
 import { SECTION_META } from "~/utils/profile/sectionMeta";
 import { normalizeSectionConfig } from "~/utils/profile/sectionConfig";
 
-const props = withDefaults(
-  defineProps<{
-    modelValue: ProfileSection[];
-    showMetrics?: boolean;
-  }>(),
-  { showMetrics: true },
-);
+const props = defineProps<{
+  modelValue: ProfileSection[];
+}>();
 
 const emit = defineEmits<{
   "update:modelValue": [sections: ProfileSection[]];
@@ -36,12 +32,6 @@ function toggleVisibility(key: ProfileSection["key"]) {
     section.key === key ? { ...section, visible: !section.visible } : section,
   );
   emit("update:modelValue", [...next, ...unknownSections.value]);
-}
-
-function isDisabled(key: ProfileSection["key"]) {
-  // Phase 1's show_metrics remains the authoritative owner control for the
-  // metrics row until it grows a dedicated toggle here.
-  return key === "metrics" && !props.showMetrics;
 }
 
 onMounted(() => {
@@ -103,7 +93,6 @@ onBeforeUnmount(() => {
         variant="outline"
         color="slate"
         size="sm"
-        :disabled="isDisabled(section.key)"
         :aria-pressed="section.visible"
         @click="toggleVisibility(section.key)"
       >

--- a/tests/unit/components/profile/SectionConfigEditor.spec.ts
+++ b/tests/unit/components/profile/SectionConfigEditor.spec.ts
@@ -39,14 +39,20 @@ describe("SectionConfigEditor", () => {
     expect(emitted.find((s) => s.key === "unknown_key")).toEqual(unknown);
   });
 
-  it("disables (not hides) the metrics toggle when showMetrics is false", () => {
+  it("lets the metrics toggle flip like any other section (no special disable)", async () => {
     const w = mount(SectionConfigEditor, {
-      props: { modelValue: sections as never, showMetrics: false },
+      props: { modelValue: sections as never },
     });
     const toggles = w.findAll("[data-test='section-visibility']");
-    const metricsToggle = toggles.find((t) => t.attributes("aria-pressed") !== undefined && t.text().length > 0);
-    expect(w.text()).toMatch(/metrics/i); // still rendered, not hidden
-    expect(metricsToggle).toBeTruthy();
-    expect(toggles[0].attributes("disabled")).toBeDefined();
+    // metrics is the first known section (DEFAULT_SECTION_ORDER[0])
+    expect(toggles[0].attributes("disabled")).toBeUndefined();
+    await toggles[0].trigger("click");
+    const emitted = w.emitted("update:modelValue")?.[0]?.[0] as {
+      key: string;
+      visible: boolean;
+    }[];
+    const metrics = emitted.find((s) => s.key === "metrics");
+    expect(metrics).toBeTruthy();
+    expect(metrics!.visible).toBe(false); // flipped from the fixture's visible → hidden
   });
 });


### PR DESCRIPTION
## Bug
On the Public Profile setup → Section Configuration, the **Athletic Metrics** row showed as **Hidden + disabled** even for an athlete with metrics entered — with no way to enable it.

## Root cause
`SectionConfigEditor` force-disabled the metrics toggle whenever `show_metrics` was false:
```ts
function isDisabled(key) { return key === "metrics" && !props.showMetrics; }
```
A Phase-1 residue ("show_metrics remains authoritative until it grows a dedicated toggle here"). It deadlocked the row: `show_metrics=false` → toggle disabled → owner can't set it visible → `show_metrics` stays false forever.

## Fix
The toggle **is** the dedicated control now. Clicking it writes `section_config`, and both sides already derive `show_metrics` from it:
- server `reconcileVisibility` (`profile.put.ts:81-83`) sets `show_metrics = sections.metrics.visible`
- client `onSectionConfigUpdate` → `deriveLegacyVisibility` (`ProfileSetup.vue:154`) keeps the draft + live preview in sync

Removed the `isDisabled` special-case + the now-unused `showMetrics` prop, so metrics toggles like every other section. Replaced the stale test that asserted the disabled behavior with one asserting it flips.

Owners with `show_metrics=false` (e.g. owen@andrikanich.com) can now flip Athletic Metrics to Visible themselves — no data migration needed.

## Test plan
- ✅ SectionConfigEditor + ProfileSetup specs pass (10/10)
- ✅ type-check 0 · lint 0 · audit:tokens 0
- Manual: open Public Profile setup as an athlete with `show_metrics=false`, toggle Athletic Metrics → Visible, confirm it renders on the public page.

https://claude.ai/code/session_015gubyo2cjj8t6C3DGJvsKu