### PR TITLE
fix(e2e): resolve Express Interest submit-button strict-mode collision

### DIFF
--- a/components/profile/public/ExpressInterestPopover.vue
+++ b/components/profile/public/ExpressInterestPopover.vue
@@ -339,7 +339,14 @@ function handleClose() {
         <DesignSystemButton type="button" variant="outline" color="slate" @click="handleClose">
           Cancel
         </DesignSystemButton>
-        <DesignSystemButton type="submit" variant="solid" color="blue" :disabled="submitting" :loading="submitting">
+        <DesignSystemButton
+          data-test="submit-interest"
+          type="submit"
+          variant="solid"
+          color="blue"
+          :disabled="submitting"
+          :loading="submitting"
+        >
           Express interest
         </DesignSystemButton>
       </div>

--- a/tests/e2e/profile-interest.spec.ts
+++ b/tests/e2e/profile-interest.spec.ts
@@ -104,7 +104,10 @@ test.describe("Public profile — Express Interest", () => {
       // Honeypot (`hp`) intentionally left untouched — a real coach never
       // sees or fills it; a filled value would silently no-op the submit.
 
-      await anonPage.getByRole("button", { name: "Express interest" }).click();
+      // The hero "Express Interest" button and the popover's submit button
+      // share the accessible name "Express interest" (strict-mode collision) —
+      // target the submit by its stable data-test inside the open dialog.
+      await anonPage.locator('[data-test="submit-interest"]').click();
 
       await expect(anonPage.getByText("Interest sent.")).toBeVisible();
       await expect(


### PR DESCRIPTION
The Phase-4 E2E, run for real against develop (via workflow_dispatch — `e2e.yml` only gates PRs to `main`, so this was its first actual execution), caught a genuine strict-mode violation: the hero "Express Interest" button and the popover's submit button share the accessible name "Express interest", so `getByRole('button', {name})` matched two elements and the click threw.

Fix: added a stable `data-test="submit-interest"` to the popover submit button (the convention every other field already follows) and target it in the spec. Same collision class as the earlier Close-button fix.

**Test plan:** popover unit spec 13/13, E2E `--list` parses, type-check/lint/audit:tokens clean. Re-running the full E2E against develop to confirm the flow goes green.

https://claude.ai/code/session_015gubyo2cjj8t6C3DGJvsKu