### PR TITLE
feat(profile): align public player profile to Figma redesign

### DIFF
--- a/components/profile/PublicProfileCard.vue
+++ b/components/profile/PublicProfileCard.vue
@@ -11,6 +11,7 @@ import TeamHistoryPanel from "~/components/profile/public/TeamHistoryPanel.vue";
 import AwardsHonors from "~/components/profile/public/AwardsHonors.vue";
 import ContactPlayerModal from "~/components/profile/public/ContactPlayerModal.vue";
 import ExpressInterestPopover from "~/components/profile/public/ExpressInterestPopover.vue";
+import { buildSocialLinks } from "~/utils/profile/socialLinks";
 
 // `slug` is optional because the owner-side live preview (ProfileLivePreview)
 // renders this card before the profile has a real public URL.
@@ -24,6 +25,29 @@ const emit = defineEmits<{ contact: []; interest: [] }>();
 const visibleSections = computed(() =>
   props.data.sections.filter((s) => s.visible),
 );
+
+// Figma pairs Academic Profile + Target Program & Values into one two-column
+// row. When both are visible the pair renders together at the academics slot,
+// and the standalone `values` entry is skipped so it isn't drawn twice.
+const academicsVisible = computed(() =>
+  visibleSections.value.some((s) => s.key === "academics"),
+);
+const valuesVisible = computed(() =>
+  visibleSections.value.some((s) => s.key === "values"),
+);
+
+const footerSocials = computed(() => buildSocialLinks(props.data.social));
+
+const lastUpdated = computed(() => {
+  if (!props.data.updatedAt) return null;
+  const d = new Date(props.data.updatedAt);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+});
 
 // The public page deliberately hides the player's target schools (Phase 2
 // decision) — the modal always falls back to its free-text school field.
@@ -114,13 +138,25 @@ function onInterestSubmitted() {
           :player-name="data.playerName"
         />
         <HighlightsReel v-else-if="section.key === 'film'" :film="data.film" />
-        <AcademicPanel
+        <!-- Academics + Target render as a paired two-column row (Figma). When
+             values is also visible it is drawn here and skipped below. -->
+        <div
           v-else-if="section.key === 'academics'"
-          :academics="data.academics"
-          :ncaa-id="data.athletic?.ncaa_id"
-        />
+          class="grid grid-cols-1 gap-6"
+          :class="{ 'md:grid-cols-2 md:items-start': valuesVisible }"
+        >
+          <AcademicPanel
+            :academics="data.academics"
+            :ncaa-id="data.athletic?.ncaa_id"
+          />
+          <TargetProgramValues
+            v-if="valuesVisible"
+            :looking-for="data.lookingFor"
+            :values-tags="data.valuesTags"
+          />
+        </div>
         <TargetProgramValues
-          v-else-if="section.key === 'values'"
+          v-else-if="section.key === 'values' && !academicsVisible"
           :looking-for="data.lookingFor"
           :values-tags="data.valuesTags"
         />
@@ -132,12 +168,35 @@ function onInterestSubmitted() {
       </template>
     </div>
 
-    <footer class="bg-gray-50 px-6 py-4 text-center">
-      <p class="text-xs text-gray-400">
-        Powered by
-        <a href="/" class="text-gray-500 hover:text-gray-700"
-          >The Recruiting Compass</a
+    <footer class="border-t border-gray-100 bg-gray-50 px-6 py-5">
+      <div class="flex flex-wrap items-center justify-between gap-3">
+        <a
+          href="/"
+          class="flex items-center gap-2 text-xs font-medium text-gray-500 hover:text-gray-700"
         >
+          <UIcon
+            name="i-heroicons-viewfinder-circle"
+            class="h-4 w-4"
+            aria-hidden="true"
+          />
+          Powered by The Recruiting Compass
+        </a>
+        <div v-if="footerSocials.length" class="flex items-center gap-3">
+          <a
+            v-for="link in footerSocials"
+            :key="link.platform"
+            :href="link.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            :aria-label="link.platform"
+            class="text-gray-400 hover:text-gray-600"
+          >
+            <UIcon :name="link.icon" class="h-4 w-4" aria-hidden="true" />
+          </a>
+        </div>
+      </div>
+      <p v-if="lastUpdated" class="mt-3 text-xs text-gray-400">
+        Profile last updated: {{ lastUpdated }}
       </p>
     </footer>
 

--- a/components/profile/public/AcademicPanel.vue
+++ b/components/profile/public/AcademicPanel.vue
@@ -1,6 +1,7 @@
 <!-- components/profile/public/AcademicPanel.vue -->
 <script setup lang="ts">
 import type { PublicProfileData } from "~/types/models";
+import SectionHeader from "~/components/profile/public/SectionHeader.vue";
 
 defineProps<{
   academics: PublicProfileData["academics"];
@@ -10,51 +11,61 @@ defineProps<{
 
 <template>
   <section v-if="academics">
-    <h2 class="mb-3 text-sm font-semibold text-brand-slate-900">Academics</h2>
+    <SectionHeader icon="i-heroicons-academic-cap" title="Academic Profile" />
     <DesignSystemCard padding="md">
-      <dl class="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
+      <div v-if="academics.high_school" class="mb-4">
+        <p class="text-xs text-brand-slate-500">High School</p>
+        <p class="mt-0.5 font-medium text-brand-slate-900">
+          {{ academics.high_school }}
+        </p>
+      </div>
+
+      <dl class="grid grid-cols-3 gap-x-6 gap-y-4 text-sm">
         <div v-if="academics.gpa != null" class="flex flex-col">
           <dt class="text-xs text-brand-slate-500">GPA</dt>
-          <dd class="font-medium text-brand-slate-900">
+          <dd class="text-lg font-semibold text-brand-slate-900">
             {{ academics.gpa.toFixed(2) }}
           </dd>
         </div>
         <div v-if="academics.sat_score != null" class="flex flex-col">
-          <dt class="text-xs text-brand-slate-500">SAT</dt>
-          <dd class="font-medium text-brand-slate-900">
+          <dt class="text-xs text-brand-slate-500">SAT Score</dt>
+          <dd class="text-lg font-semibold text-brand-slate-900">
             {{ academics.sat_score }}
           </dd>
         </div>
         <div v-if="academics.act_score != null" class="flex flex-col">
-          <dt class="text-xs text-brand-slate-500">ACT</dt>
-          <dd class="font-medium text-brand-slate-900">
+          <dt class="text-xs text-brand-slate-500">ACT Score</dt>
+          <dd class="text-lg font-semibold text-brand-slate-900">
             {{ academics.act_score }}
           </dd>
         </div>
         <div v-if="academics.graduation_year" class="flex flex-col">
-          <dt class="text-xs text-brand-slate-500">Grad Year</dt>
+          <dt class="text-xs text-brand-slate-500">Graduation Year</dt>
           <dd class="font-medium text-brand-slate-900">
-            {{ academics.graduation_year }}
+            Class of {{ academics.graduation_year }}
           </dd>
         </div>
-        <div v-if="academics.high_school" class="flex flex-col">
-          <dt class="text-xs text-brand-slate-500">High School</dt>
+        <div v-if="academics.intended_major" class="col-span-2 flex flex-col">
+          <dt class="text-xs text-brand-slate-500">Desired Major</dt>
           <dd class="font-medium text-brand-slate-900">
-            {{ academics.high_school }}
-          </dd>
-        </div>
-        <div v-if="ncaaId" class="flex flex-col">
-          <dt class="text-xs text-brand-slate-500">NCAA Eligibility ID</dt>
-          <dd class="font-mono font-medium text-brand-slate-900">
-            {{ ncaaId }}
+            {{ academics.intended_major }}
           </dd>
         </div>
       </dl>
+
       <div v-if="academics.core_courses?.length" class="mt-4">
         <p class="mb-1.5 text-xs text-brand-slate-500">Core Courses</p>
         <p class="text-sm text-brand-slate-700">
           {{ academics.core_courses.join(", ") }}
         </p>
+      </div>
+
+      <div
+        v-if="ncaaId"
+        class="mt-4 rounded-lg bg-brand-slate-50 px-3 py-2 text-xs font-medium text-brand-slate-600"
+      >
+        NCAA Eligibility Center ID:
+        <span class="font-mono text-brand-slate-900">{{ ncaaId }}</span>
       </div>
     </DesignSystemCard>
   </section>

--- a/components/profile/public/AwardsHonors.vue
+++ b/components/profile/public/AwardsHonors.vue
@@ -1,24 +1,27 @@
 <!-- components/profile/public/AwardsHonors.vue -->
 <script setup lang="ts">
 import type { ProfileAward } from "~/types/models";
+import SectionHeader from "~/components/profile/public/SectionHeader.vue";
 
 defineProps<{ awards: ProfileAward[] }>();
 </script>
 
 <template>
   <section v-if="awards.length">
-    <h2 class="mb-3 text-sm font-semibold text-brand-slate-900">
-      Awards &amp; Honors
-    </h2>
-    <div class="flex flex-wrap gap-1.5">
-      <DesignSystemBadge
+    <SectionHeader icon="i-heroicons-trophy" title="Awards & Athletic Honors" />
+    <div class="flex flex-wrap gap-2">
+      <span
         v-for="(award, idx) in awards"
         :key="`${award.title}-${idx}`"
-        color="orange"
-        variant="light"
+        class="inline-flex items-center gap-1.5 rounded-full bg-brand-orange-100 px-3 py-1.5 text-sm font-medium text-brand-orange-800"
       >
+        <UIcon
+          name="i-heroicons-trophy"
+          class="h-3.5 w-3.5 shrink-0 text-brand-orange-600"
+          aria-hidden="true"
+        />
         {{ award.title }}<span v-if="award.year"> · {{ award.year }}</span>
-      </DesignSystemBadge>
+      </span>
     </div>
   </section>
 </template>

--- a/components/profile/public/HighlightsReel.vue
+++ b/components/profile/public/HighlightsReel.vue
@@ -1,6 +1,7 @@
 <!-- components/profile/public/HighlightsReel.vue -->
 <script setup lang="ts">
 import type { VideoLink } from "~/types/models";
+import SectionHeader from "~/components/profile/public/SectionHeader.vue";
 
 defineProps<{ film: VideoLink[] | null }>();
 
@@ -14,37 +15,41 @@ const PLATFORM_LABEL: Record<VideoLink["platform"], string> = {
 
 <template>
   <section v-if="film?.length">
-    <h2 class="mb-3 text-sm font-semibold text-brand-slate-900">
-      Highlights
-    </h2>
-    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
-      <DesignSystemCard v-for="link in film" :key="link.url" padding="md">
-        <a
-          :href="link.url"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="flex items-center gap-3"
+    <SectionHeader icon="i-heroicons-film" title="Featured Highlights" />
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <a
+        v-for="link in film"
+        :key="link.url"
+        :href="link.url"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="group block overflow-hidden rounded-xl border border-brand-slate-200 bg-white transition-shadow hover:shadow-md"
+      >
+        <div
+          class="relative flex aspect-video items-center justify-center bg-gradient-to-br from-brand-slate-800 to-brand-slate-900"
         >
-          <div
-            class="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-slate-100 text-brand-slate-600"
+          <span
+            class="flex h-12 w-12 items-center justify-center rounded-full bg-white/90 text-brand-slate-900 shadow-sm transition-transform group-hover:scale-110"
             aria-hidden="true"
           >
-            <svg class="h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+            <svg class="ml-0.5 h-6 w-6" fill="currentColor" viewBox="0 0 20 20">
               <path
                 d="M6.3 2.841A1.5 1.5 0 004 4.11v11.78a1.5 1.5 0 002.3 1.269l9.344-5.89a1.5 1.5 0 000-2.538L6.3 2.841z"
               />
             </svg>
-          </div>
-          <div class="min-w-0">
-            <p class="truncate text-sm font-medium text-brand-slate-900">
-              {{ link.title || PLATFORM_LABEL[link.platform] }}
-            </p>
-            <p class="text-xs text-brand-slate-500">
-              {{ PLATFORM_LABEL[link.platform] }}
-            </p>
-          </div>
-        </a>
-      </DesignSystemCard>
+          </span>
+          <span
+            class="absolute bottom-2 right-2 rounded bg-black/50 px-1.5 py-0.5 text-[10px] font-medium text-white"
+          >
+            {{ PLATFORM_LABEL[link.platform] }}
+          </span>
+        </div>
+        <div class="px-3 py-2.5">
+          <p class="truncate text-sm font-medium text-brand-slate-900">
+            {{ link.title || PLATFORM_LABEL[link.platform] }}
+          </p>
+        </div>
+      </a>
     </div>
   </section>
 </template>

--- a/components/profile/public/MetricsGrid.vue
+++ b/components/profile/public/MetricsGrid.vue
@@ -4,6 +4,7 @@ import { computed } from "vue";
 import type { PublicMetric, PublicProfileData } from "~/types/models";
 import { buildRecruitingCredentials } from "~/utils/profile/recruitingCredentials";
 import MetricsCredentials from "~/components/profile/public/MetricsCredentials.vue";
+import SectionHeader from "~/components/profile/public/SectionHeader.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -21,36 +22,23 @@ const credentials = computed(() =>
 
 <template>
   <section v-if="metrics.length">
-    <h2 class="mb-3 text-sm font-semibold text-brand-slate-900">
-      Verified Athletic Metrics
-    </h2>
+    <SectionHeader
+      icon="i-heroicons-chart-bar"
+      title="Verified Athletic Metrics"
+    />
     <MetricsCredentials :credentials="credentials" />
-    <div class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4">
+    <div class="grid grid-cols-2 gap-4 sm:grid-cols-3">
       <DesignSystemCard v-for="metric in metrics" :key="metric.key" padding="md">
-        <div class="flex items-baseline gap-1">
-          <span class="text-2xl font-bold text-brand-slate-900">{{
+        <p class="text-xs font-medium text-brand-slate-500">
+          {{ metric.label }}
+        </p>
+        <div class="mt-2 flex items-baseline gap-1">
+          <span class="text-3xl font-bold text-brand-slate-900">{{
             metric.value
           }}</span>
           <span v-if="metric.unit" class="text-sm text-brand-slate-500">{{
             metric.unit
           }}</span>
-        </div>
-        <div class="mt-1 flex items-center gap-1.5">
-          <p class="text-xs text-brand-slate-500">{{ metric.label }}</p>
-          <svg
-            v-if="metric.verified"
-            class="h-3.5 w-3.5 shrink-0 text-brand-emerald-600"
-            fill="currentColor"
-            viewBox="0 0 20 20"
-            role="img"
-            aria-label="Verified"
-          >
-            <path
-              fill-rule="evenodd"
-              d="M16.704 4.153a.75.75 0 01.143 1.052l-8 10.5a.75.75 0 01-1.127.075l-4.5-4.5a.75.75 0 011.06-1.06l3.894 3.893 7.48-9.817a.75.75 0 011.05-.143z"
-              clip-rule="evenodd"
-            />
-          </svg>
         </div>
       </DesignSystemCard>
     </div>

--- a/components/profile/public/ProfileHero.vue
+++ b/components/profile/public/ProfileHero.vue
@@ -53,11 +53,11 @@ const socialLinks = computed(() => buildSocialLinks(props.data.social));
         v-if="data.photoUrl"
         :src="data.photoUrl"
         :alt="`${data.playerName} profile photo`"
-        class="h-24 w-24 shrink-0 rounded-full object-cover ring-2 ring-white/20"
+        class="h-32 w-32 shrink-0 rounded-2xl object-cover ring-2 ring-white/20 sm:h-36 sm:w-36"
       />
       <div
         v-else
-        class="flex h-24 w-24 shrink-0 items-center justify-center rounded-full bg-brand-slate-700 text-2xl font-semibold ring-2 ring-white/20"
+        class="flex h-32 w-32 shrink-0 items-center justify-center rounded-2xl bg-brand-slate-700 text-3xl font-semibold ring-2 ring-white/20 sm:h-36 sm:w-36"
         aria-hidden="true"
       >
         {{ data.playerName.charAt(0) }}
@@ -111,24 +111,28 @@ const socialLinks = computed(() => buildSocialLinks(props.data.social));
           </template>
         </div>
 
-        <div class="mt-6 flex flex-wrap items-center gap-3">
-          <DesignSystemButton color="blue" variant="solid" @click="$emit('contact')">
-            Contact Player
-          </DesignSystemButton>
-          <DesignSystemButton
-            color="slate"
-            variant="outline"
-            :disabled="interestSent"
-            @click="$emit('interest')"
-          >
-            {{ interestSent ? "Interest Sent" : "Express Interest" }}
-          </DesignSystemButton>
-          <span
-            class="inline-flex items-center gap-1.5 rounded-full bg-brand-emerald-900/40 px-3 py-1 text-xs font-medium text-brand-emerald-300 ring-1 ring-brand-emerald-700/50"
-          >
-            Verified Coach Access
-          </span>
-        </div>
+      </div>
+
+      <div
+        class="flex shrink-0 flex-col gap-3 sm:w-44"
+      >
+        <DesignSystemButton
+          color="blue"
+          variant="solid"
+          full-width
+          @click="$emit('contact')"
+        >
+          Contact Player
+        </DesignSystemButton>
+        <DesignSystemButton
+          color="slate"
+          variant="outline"
+          full-width
+          :disabled="interestSent"
+          @click="$emit('interest')"
+        >
+          {{ interestSent ? "Interest Sent" : "Express Interest" }}
+        </DesignSystemButton>
       </div>
     </div>
   </header>

--- a/components/profile/public/SectionHeader.vue
+++ b/components/profile/public/SectionHeader.vue
@@ -1,0 +1,15 @@
+<!-- components/profile/public/SectionHeader.vue -->
+<script setup lang="ts">
+defineProps<{ icon: string; title: string }>();
+</script>
+
+<template>
+  <div class="mb-3 flex items-center gap-2">
+    <UIcon
+      :name="icon"
+      class="h-[18px] w-[18px] shrink-0 text-brand-slate-500"
+      aria-hidden="true"
+    />
+    <h2 class="text-sm font-semibold text-brand-slate-900">{{ title }}</h2>
+  </div>
+</template>

--- a/components/profile/public/TargetProgramValues.vue
+++ b/components/profile/public/TargetProgramValues.vue
@@ -1,5 +1,7 @@
 <!-- components/profile/public/TargetProgramValues.vue -->
 <script setup lang="ts">
+import SectionHeader from "~/components/profile/public/SectionHeader.vue";
+
 defineProps<{
   lookingFor: string | null;
   valuesTags: string[];
@@ -8,9 +10,10 @@ defineProps<{
 
 <template>
   <section v-if="lookingFor || valuesTags.length">
-    <h2 class="mb-3 text-sm font-semibold text-brand-slate-900">
-      What I'm Looking For
-    </h2>
+    <SectionHeader
+      icon="i-heroicons-viewfinder-circle"
+      title="Target Program & Values"
+    />
     <DesignSystemCard padding="md">
       <p v-if="lookingFor" class="text-sm leading-relaxed text-brand-slate-700">
         {{ lookingFor }}

--- a/components/profile/public/TeamHistoryPanel.vue
+++ b/components/profile/public/TeamHistoryPanel.vue
@@ -1,30 +1,37 @@
 <!-- components/profile/public/TeamHistoryPanel.vue -->
 <script setup lang="ts">
 import type { PublicTeamHistoryEntry } from "~/types/models";
+import SectionHeader from "~/components/profile/public/SectionHeader.vue";
 
 defineProps<{ entries: PublicTeamHistoryEntry[] | null }>();
 </script>
 
 <template>
   <section v-if="entries?.length">
-    <h2 class="mb-3 text-sm font-semibold text-brand-slate-900">
-      Team History
-    </h2>
+    <SectionHeader
+      icon="i-heroicons-clock"
+      title="Team History & Coaching References"
+    />
     <DesignSystemCard padding="md">
       <ul class="divide-y divide-brand-slate-100">
         <li
           v-for="(entry, idx) in entries"
           :key="`${entry.name}-${idx}`"
-          class="flex flex-wrap items-center justify-between gap-2 py-3 first:pt-0 last:pb-0"
+          class="flex flex-wrap items-start justify-between gap-2 py-3 first:pt-0 last:pb-0"
         >
           <div class="min-w-0">
-            <p class="text-sm font-medium text-brand-slate-900">
-              {{ entry.name }}
-            </p>
-            <p class="text-xs text-brand-slate-500">
-              <span v-if="entry.level">{{ entry.level }}</span>
-              <span v-if="entry.level && entry.coach"> · </span>
-              <span v-if="entry.coach">Coach {{ entry.coach }}</span>
+            <div class="flex flex-wrap items-center gap-2">
+              <p class="text-sm font-medium text-brand-slate-900">
+                {{ entry.name }}
+              </p>
+              <DesignSystemBadge v-if="entry.level" color="slate" variant="light">
+                {{ entry.level }}
+              </DesignSystemBadge>
+            </div>
+            <p v-if="entry.coach || entry.contact" class="mt-1 text-xs text-brand-slate-500">
+              <span v-if="entry.coach">Coach: {{ entry.coach }}</span>
+              <span v-if="entry.coach && entry.contact"> — </span>
+              <span v-if="entry.contact">Reference Contact: {{ entry.contact }}</span>
             </p>
           </div>
           <span

--- a/components/profile/setup/ProfileLivePreview.vue
+++ b/components/profile/setup/ProfileLivePreview.vue
@@ -57,6 +57,7 @@ const previewData = computed<PublicProfileData>(() => {
             graduation_year: details.graduation_year as number | undefined,
             high_school: (details.school_name ?? details.high_school) as
               string | undefined,
+            intended_major: details.intended_major as string | undefined,
             core_courses: details.core_courses as string[] | undefined,
           }
         : null,
@@ -122,6 +123,7 @@ const previewData = computed<PublicProfileData>(() => {
     teamHistory: isSectionVisible(sections, "team_history")
       ? buildTeamHistory(details)
       : null,
+    updatedAt: null,
     sections,
   };
 });

--- a/layouts/public.vue
+++ b/layouts/public.vue
@@ -1,5 +1,41 @@
+<!-- layouts/public.vue -->
+<!--
+  Standalone layout for public share pages (e.g. /p/[slug]). Deliberately does
+  NOT render the app <Header> — an external coach must never see app navigation,
+  search, or notifications. Only a slim coach-header bar (logo + verified badge),
+  mirroring the Figma design (node 5:7).
+-->
 <template>
-  <main>
+  <div class="min-h-screen bg-gray-50">
+    <header class="bg-brand-slate-900 text-white">
+      <div
+        class="mx-auto flex h-14 max-w-6xl items-center justify-between px-4 sm:px-6"
+      >
+        <a
+          href="/"
+          class="flex items-center gap-2 transition-opacity hover:opacity-80"
+        >
+          <UIcon
+            name="i-heroicons-viewfinder-circle"
+            class="h-6 w-6 text-white"
+            aria-hidden="true"
+          />
+          <span class="text-sm font-semibold tracking-tight">
+            The Recruiting Compass
+          </span>
+        </a>
+        <span
+          class="inline-flex items-center gap-1.5 rounded-full bg-brand-emerald-900/40 px-3 py-1 text-xs font-medium text-brand-emerald-300 ring-1 ring-brand-emerald-700/50"
+        >
+          <span
+            class="h-1.5 w-1.5 rounded-full bg-brand-emerald-400"
+            aria-hidden="true"
+          />
+          Verified Coach Access
+        </span>
+      </div>
+    </header>
+
     <slot />
-  </main>
+  </div>
 </template>

--- a/pages/p/[slug].vue
+++ b/pages/p/[slug].vue
@@ -2,8 +2,10 @@
 <script setup lang="ts">
 import type { PublicProfileData } from "~/types/models";
 
-// No auth middleware — this page is publicly accessible
-definePageMeta({ layout: "default" });
+// No auth middleware — this page is publicly accessible. The `public` layout
+// renders a standalone coach-header bar instead of the app <Header>, so no app
+// navigation/search/notifications leak onto this externally-shared page.
+definePageMeta({ layout: "public" });
 
 const route = useRoute();
 const slug = route.params.slug as string;
@@ -50,7 +52,7 @@ useSeoMeta({
 </script>
 
 <template>
-  <div class="min-h-screen bg-gray-50">
+  <div>
     <!-- Loading -->
     <div
       v-if="status === 'pending'"

--- a/server/api/public/profile/[slug].get.ts
+++ b/server/api/public/profile/[slug].get.ts
@@ -53,6 +53,7 @@ interface AssemblePublicProfileInput {
     show_athletic: boolean;
     show_film: boolean;
     show_schools: boolean;
+    updated_at?: string | null;
   };
   user: { full_name: string | null; profile_photo_url: string | null } | null;
   details: Record<string, unknown> | null;
@@ -88,6 +89,8 @@ export function assemblePublicProfile(
             graduation_year: details.graduation_year as number | undefined,
             high_school: (details.school_name ?? details.high_school) as
               string | undefined,
+            intended_major: (details.intended_major as string | undefined) ||
+              undefined,
             core_courses: details.core_courses as string[] | undefined,
           }
         : null,
@@ -150,6 +153,7 @@ export function assemblePublicProfile(
     teamHistory: isSectionVisible(sections, "team_history")
       ? buildTeamHistory(details)
       : null,
+    updatedAt: profile.updated_at ?? null,
     sections,
   };
 }

--- a/tests/unit/components/profile/PublicProfileCard.spec.ts
+++ b/tests/unit/components/profile/PublicProfileCard.spec.ts
@@ -59,7 +59,7 @@ describe("PublicProfileCard", () => {
       props: { data: dataAwardsHidden, slug: "owen-a" },
     });
     expect(w.text()).toContain("Exit Velocity"); // metrics visible
-    expect(w.text()).not.toContain("Awards & Honors");
+    expect(w.text()).not.toContain("Awards & Athletic Honors");
     expect(w.text()).not.toContain("All-Conference");
   });
 
@@ -67,7 +67,7 @@ describe("PublicProfileCard", () => {
     const w = mount(PublicProfileCard, {
       props: { data: dataAwardsVisible, slug: "owen-a" },
     });
-    expect(w.text()).toContain("Awards & Honors");
+    expect(w.text()).toContain("Awards & Athletic Honors");
     expect(w.text()).toContain("All-Conference");
   });
 

--- a/types/models.ts
+++ b/types/models.ts
@@ -533,6 +533,7 @@ export interface PublicProfileData {
     act_score?: number;
     graduation_year?: number;
     high_school?: string;
+    intended_major?: string;
     core_courses?: string[];
   } | null;
   /** null when show_athletic is false */
@@ -581,6 +582,8 @@ export interface PublicProfileData {
   metrics: PublicMetric[] | null;
   /** null when the "team_history" section is not visible */
   teamHistory: PublicTeamHistoryEntry[] | null;
+  /** ISO timestamp of the profile row's last update; drives the footer stamp. */
+  updatedAt: string | null;
   sections: ProfileSection[];
 }
 


### PR DESCRIPTION
Closes 25 fidelity gaps between the live public player profile and the Figma design (node 5-5), audited against Owen Andrikanich's profile on QA.

## What changed

**Structure & layout**
- New `public` layout — public share pages no longer render the app `<Header>` (nav/search/notifications were leaking onto an externally-shared page via `layout: default`). Adds the Figma coach-header bar (brand + Verified Coach Access badge).
- Academic Profile + Target Program & Values render as a paired two-column row (Figma), instead of two full-width stacked sections.

**Hero**
- Headshot: circle 96px → rounded-rect 140px.
- Action buttons: inline row → right-side vertical stack.
- Verified Coach Access pill moved to the coach-header bar.

**Sections**
- New `SectionHeader` primitive adds the Figma lucide-style icon to all six section headers.
- Full titles restored: Featured Highlights, Academic Profile, Target Program & Values, Team History & Coaching References, Awards & Athletic Honors.
- Metrics: card order inverted (label top / value bottom), fixed 3-col, per-metric checkmark dropped.
- Highlights: text link list → thumbnail-card gallery with play overlay (placeholder thumbnails — no thumbnail data in the model yet).
- Academics: adds Desired Major + a distinct NCAA eligibility strip.
- Team history: level shown as a badge, coach + reference-contact line (contact rendered only when present).
- Awards: medal icon per chip.
- Footer: brand left, social icons right, "Profile last updated" stamp.

**Data**
- `assemblePublicProfile` now exposes `academics.intended_major` and top-level `updatedAt`; owner live-preview mirror kept in parity.

## Deferred (intentional)
- Full-bleed container — kept the white card (lower risk).
- Team-level taxonomy stays grade/Travel (our data model), not Figma's mock label strings.

## Test plan
- [x] `npm run type-check` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] `npm run audit:tokens` — 0 errors (5 pre-existing chart warnings)
- [x] unit — 150/150 on profile + public-API suites (fixed 1 stale title assertion)
- [ ] Visual verify on QA after merge (feature-branch previews disabled on this project)

No migration.

https://claude.ai/code/session_0171A2GPq5iCs5X9ciXwBFqJ