### PR TITLE
fix(profile): format public metrics via canonical registry + dedupe by type

### DIFF
--- a/server/api/public/profile/[slug].get.ts
+++ b/server/api/public/profile/[slug].get.ts
@@ -275,7 +275,9 @@ export default defineEventHandler(async (event) => {
     if (isSectionVisible(sections, "metrics")) {
       const { data } = await supabase
         .from("performance_metrics")
-        .select("metric_type, display_value, value, unit, verified, is_primary")
+        .select(
+          "metric_type, display_value, value, unit, verified, is_primary, created_at",
+        )
         .eq("user_id", profile.user_id);
       metricsRows = data ?? [];
     }

--- a/tests/unit/utils/profile/publicProfileBuilders.spec.ts
+++ b/tests/unit/utils/profile/publicProfileBuilders.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { buildPublicMetrics } from "~/utils/profile/publicProfileBuilders";
+
+describe("buildPublicMetrics", () => {
+  it("formats values via the canonical registry, ignoring stale DB unit/display_value", () => {
+    // Real-world garbage row: batting_avg stored with unit "unit" and an
+    // unformatted value. Canonical format wins: 0.41 -> ".410", unit dropped.
+    const [metric] = buildPublicMetrics([
+      {
+        metric_type: "batting_avg",
+        value: 0.41,
+        unit: "unit",
+        display_value: null,
+        verified: false,
+        is_primary: false,
+        created_at: "2026-01-01T00:00:00Z",
+      },
+    ]);
+    expect(metric.value).toBe(".410");
+    expect(metric.unit).toBeNull();
+    expect(metric.label).toBe("Batting Average");
+  });
+
+  it("keeps the newest row when a metric_type is logged more than once", () => {
+    const metrics = buildPublicMetrics([
+      {
+        metric_type: "velocity",
+        value: 77.3,
+        unit: "mph",
+        verified: true,
+        is_primary: false,
+        created_at: "2025-06-01T00:00:00Z",
+      },
+      {
+        metric_type: "velocity",
+        value: 82.3,
+        unit: "mph",
+        verified: true,
+        is_primary: false,
+        created_at: "2026-05-01T00:00:00Z",
+      },
+    ]);
+    expect(metrics).toHaveLength(1);
+    expect(metrics[0].value).toBe("82.3");
+    expect(metrics[0].label).toBe("Fastball Velocity");
+    expect(metrics[0].unit).toBe("mph");
+  });
+
+  it("ranks primary + verified first and caps at six cards", () => {
+    const rows = Array.from({ length: 8 }, (_, i) => ({
+      metric_type: `custom_${i}`,
+      value: i,
+      verified: i < 2,
+      is_primary: i === 0,
+      created_at: `2026-01-0${i + 1}T00:00:00Z`,
+    }));
+    const metrics = buildPublicMetrics(rows);
+    expect(metrics).toHaveLength(6);
+    expect(metrics[0].key).toBe("custom_0"); // primary ranks first
+  });
+});

--- a/utils/profile/publicProfileBuilders.ts
+++ b/utils/profile/publicProfileBuilders.ts
@@ -1,5 +1,5 @@
 import type { PublicMetric, PublicTeamHistoryEntry } from "~/types/models";
-import { getMetricDef } from "~/utils/metrics/canonical";
+import { getMetricDef, applyFormat } from "~/utils/metrics/canonical";
 
 export function buildPublicMetrics(
   rows: Array<{
@@ -9,20 +9,45 @@ export function buildPublicMetrics(
     unit?: string | null;
     verified?: boolean | null;
     is_primary?: boolean | null;
+    created_at?: string | null;
   }>,
 ): PublicMetric[] {
+  // A player can log the same metric_type more than once (e.g. two velocity
+  // readings). The public profile shows one card per type — keep the newest
+  // row (most-recent created_at; ISO strings sort lexicographically).
+  const newestByType = new Map<string, (typeof rows)[number]>();
+  for (const r of rows) {
+    const prev = newestByType.get(r.metric_type);
+    if (!prev || (r.created_at ?? "") > (prev.created_at ?? "")) {
+      newestByType.set(r.metric_type, r);
+    }
+  }
+
   const rank = (r: (typeof rows)[number]) =>
     (r.is_primary ? 0 : 1) * 10 + (r.verified ? 0 : 1);
-  return [...rows]
+
+  return [...newestByType.values()]
     .sort((a, b) => rank(a) - rank(b))
     .slice(0, 6)
-    .map((r) => ({
-      key: r.metric_type,
-      label: getMetricDef(r.metric_type).label,
-      value: r.display_value ?? (r.value != null ? String(r.value) : ""),
-      unit: r.unit ?? null,
-      verified: !!r.verified,
-    }));
+    .map((r) => {
+      const def = getMetricDef(r.metric_type);
+      // Value + unit come from the canonical registry, not the stored row:
+      // the DB `unit`/`display_value` columns carry stale/garbage data (e.g.
+      // batting_avg stored unit "unit"). applyFormat gives the correct render
+      // (batting_avg 0.41 -> ".410", unit ""); fall back to the raw value only
+      // when it isn't numeric.
+      const num = typeof r.value === "number" ? r.value : Number(r.value);
+      const value = Number.isFinite(num)
+        ? applyFormat(def.format, num)
+        : (r.display_value ?? (r.value != null ? String(r.value) : ""));
+      return {
+        key: r.metric_type,
+        label: def.label,
+        value,
+        unit: def.unit || null,
+        verified: !!r.verified,
+      };
+    });
 }
 
 const GRADE_FIELDS: Array<[string, string, string]> = [


### PR DESCRIPTION
Follow-up to #500 — two public-profile metric bugs surfaced on Owen's live QA page.

## Bugs
1. **Batting Average rendered "0.41 unit".** `buildPublicMetrics` used the stored `value`/`unit` columns, which carry garbage for some rows (batting_avg stored `unit = "unit"`, unformatted `value = 0.41`). Now value + unit come from the canonical `MetricDef` via `applyFormat` -> `.410`, no unit. Falls back to raw value only when non-numeric.
2. **Duplicate `metric_type` rows both rendered** (two velocity readings -> "Fastball Velocity" twice). Now one card per type, keeping the newest row (most-recent `created_at`). Endpoint SELECT adds `created_at`.

## Test plan
- [x] `npm run type-check` — 0 errors
- [x] `npm run lint` — 0 errors
- [x] unit — new `publicProfileBuilders.spec.ts` (3) + public/metrics suites green
- [ ] Visual verify on QA after merge

No migration. Render-path fix — underlying rows untouched.

https://claude.ai/code/session_0171A2GPq5iCs5X9ciXwBFqJ