### PR TITLE
fix(profile): match public hero to Figma (headshot, buttons, coach-bar)

### DIFF
--- a/components/profile/public/ProfileHero.vue
+++ b/components/profile/public/ProfileHero.vue
@@ -3,6 +3,7 @@
 import { computed } from "vue";
 import type { PublicProfileData } from "~/types/models";
 import { buildSocialLinks } from "~/utils/profile/socialLinks";
+import { formatPositionsShort } from "~/utils/positions/canonical";
 
 const props = withDefaults(
   defineProps<{ data: PublicProfileData; interestSent?: boolean }>(),
@@ -27,16 +28,18 @@ const physicals = computed(() => {
   const parts: string[] = [];
   if (heightLabel.value) parts.push(heightLabel.value);
   if (a?.weight_lbs) parts.push(`${a.weight_lbs} lbs`);
-  const posPieces: string[] = [];
-  if (a?.primary_position) posPieces.push(a.primary_position);
-  if (props.data.jerseyNumber != null)
-    posPieces.push(`#${props.data.jerseyNumber}`);
-  if (posPieces.length) parts.push(posPieces.join("/"));
+  // Coach-facing position shorthand, e.g. "3B/2B".
+  const posShort = formatPositionsShort(
+    a?.primary_sport,
+    a?.positions,
+    a?.primary_position,
+  );
+  if (posShort) parts.push(posShort);
   if (props.data.academics?.graduation_year) {
     parts.push(`Class of ${props.data.academics.graduation_year}`);
   }
   if (props.data.academics?.gpa != null) {
-    parts.push(`GPA ${props.data.academics.gpa.toFixed(2)}`);
+    parts.push(`${props.data.academics.gpa.toFixed(2)} GPA`);
   }
   return parts;
 });
@@ -45,94 +48,113 @@ const socialLinks = computed(() => buildSocialLinks(props.data.social));
 </script>
 
 <template>
-  <header class="bg-brand-slate-900 px-6 py-10 text-white sm:px-10">
+  <header class="bg-brand-slate-900 text-white">
+    <!-- Coach-header strip (Figma node 5:7): brand left, verified badge right -->
     <div
-      class="mx-auto flex max-w-5xl flex-col gap-6 sm:flex-row sm:items-start"
+      class="flex items-center justify-between border-b border-white/10 px-6 py-3 sm:px-10"
     >
-      <img
-        v-if="data.photoUrl"
-        :src="data.photoUrl"
-        :alt="`${data.playerName} profile photo`"
-        class="h-32 w-32 shrink-0 rounded-2xl object-cover ring-2 ring-white/20 sm:h-36 sm:w-36"
-      />
-      <div
-        v-else
-        class="flex h-32 w-32 shrink-0 items-center justify-center rounded-2xl bg-brand-slate-700 text-3xl font-semibold ring-2 ring-white/20 sm:h-36 sm:w-36"
-        aria-hidden="true"
-      >
-        {{ data.playerName.charAt(0) }}
+      <div class="flex items-center gap-2">
+        <UIcon
+          name="i-heroicons-viewfinder-circle"
+          class="h-5 w-5"
+          aria-hidden="true"
+        />
+        <span class="text-sm font-semibold tracking-tight">RecruitingCompass</span>
       </div>
+      <span
+        class="inline-flex items-center gap-1.5 rounded-full bg-brand-emerald-900/40 px-3 py-1 text-xs font-medium text-brand-emerald-300 ring-1 ring-brand-emerald-700/50"
+      >
+        <span
+          class="h-1.5 w-1.5 rounded-full bg-brand-emerald-400"
+          aria-hidden="true"
+        />
+        Verified Coach Access
+      </span>
+    </div>
 
-      <div class="min-w-0 flex-1">
-        <div class="flex flex-wrap items-center gap-3">
-          <h1 class="text-2xl font-bold tracking-tight sm:text-3xl">
-            {{ data.playerName }}
-          </h1>
-          <DesignSystemBadge
-            v-if="data.athletic?.primary_sport"
-            color="blue"
-            variant="solid"
-          >
-            {{ data.athletic.primary_sport }}
-          </DesignSystemBadge>
-        </div>
-
-        <p
-          v-if="physicals.length"
-          class="mt-2 text-sm text-brand-slate-300"
-        >
-          {{ physicals.join(" · ") }}
-        </p>
-
-        <p
-          v-if="data.bio"
-          class="mt-4 max-w-2xl text-sm leading-relaxed text-brand-slate-200"
-        >
-          {{ data.bio }}
-        </p>
-
+    <!-- Hero body -->
+    <div class="px-6 py-8 sm:px-10 sm:py-10">
+      <div class="flex flex-col gap-6 sm:flex-row sm:items-start">
+        <img
+          v-if="data.photoUrl"
+          :src="data.photoUrl"
+          :alt="`${data.playerName} profile photo`"
+          class="h-28 w-28 shrink-0 rounded-full object-cover ring-2 ring-white/20 sm:h-32 sm:w-32"
+        />
         <div
-          v-if="socialLinks.length"
-          class="mt-3 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-brand-slate-300"
+          v-else
+          class="flex h-28 w-28 shrink-0 items-center justify-center rounded-full bg-brand-slate-700 text-3xl font-semibold ring-2 ring-white/20 sm:h-32 sm:w-32"
+          aria-hidden="true"
         >
-          <template v-for="(link, i) in socialLinks" :key="link.platform">
-            <span v-if="i > 0" aria-hidden="true" class="text-brand-slate-500"
-              >·</span
-            >
-            <a
-              :href="link.url"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="inline-flex items-center gap-1 hover:text-white"
-            >
-              <UIcon :name="link.icon" class="h-4 w-4" aria-hidden="true" />
-              {{ link.handle }}
-            </a>
-          </template>
+          {{ data.playerName.charAt(0) }}
         </div>
 
-      </div>
+        <div class="min-w-0 flex-1">
+          <div class="flex flex-wrap items-center gap-3">
+            <h1 class="text-2xl font-bold tracking-tight sm:text-3xl">
+              {{ data.playerName }}
+            </h1>
+            <DesignSystemBadge
+              v-if="data.athletic?.primary_sport"
+              color="blue"
+              variant="solid"
+            >
+              {{ data.athletic.primary_sport }}
+            </DesignSystemBadge>
+          </div>
 
-      <div
-        class="flex shrink-0 flex-col gap-3 sm:w-44"
-      >
-        <DesignSystemButton
-          color="blue"
-          variant="solid"
-          full-width
-          @click="$emit('contact')"
-        >
-          Contact Player
-        </DesignSystemButton>
-        <DesignSystemButton
-          color="slate"
-          variant="outline"
-          full-width
-          :disabled="interestSent"
-          @click="$emit('interest')"
-        >
-          {{ interestSent ? "Interest Sent" : "Express Interest" }}
-        </DesignSystemButton>
+          <p v-if="physicals.length" class="mt-2 text-sm text-brand-slate-300">
+            {{ physicals.join(" · ") }}
+          </p>
+
+          <p
+            v-if="data.bio"
+            class="mt-4 max-w-2xl text-sm leading-relaxed text-brand-slate-200"
+          >
+            {{ data.bio }}
+          </p>
+
+          <div
+            v-if="socialLinks.length"
+            class="mt-4 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-brand-slate-300"
+          >
+            <template v-for="(link, i) in socialLinks" :key="link.platform">
+              <span v-if="i > 0" aria-hidden="true" class="text-brand-slate-500"
+                >·</span
+              >
+              <a
+                :href="link.url"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-1 hover:text-white"
+              >
+                <UIcon :name="link.icon" class="h-4 w-4" aria-hidden="true" />
+                {{ link.handle }}
+              </a>
+            </template>
+          </div>
+        </div>
+
+        <!-- Actions: Contact (secondary, outline-on-dark) over Express (primary) -->
+        <div class="flex shrink-0 flex-col gap-3 sm:w-48">
+          <button
+            type="button"
+            class="inline-flex items-center justify-center gap-2 rounded-lg border border-white/25 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-white/10 focus:ring-2 focus:ring-white/40 focus:outline-none"
+            @click="$emit('contact')"
+          >
+            <UIcon name="i-heroicons-envelope" class="h-4 w-4" aria-hidden="true" />
+            Contact Player
+          </button>
+          <button
+            type="button"
+            :disabled="interestSent"
+            class="inline-flex items-center justify-center gap-2 rounded-lg bg-brand-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-blue-700 focus:ring-2 focus:ring-brand-blue-500 focus:ring-offset-2 focus:ring-offset-brand-slate-900 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+            @click="$emit('interest')"
+          >
+            <UIcon name="i-heroicons-star" class="h-4 w-4" aria-hidden="true" />
+            {{ interestSent ? "Interest Sent" : "Express Interest" }}
+          </button>
+        </div>
       </div>
     </div>
   </header>

--- a/layouts/public.vue
+++ b/layouts/public.vue
@@ -2,40 +2,12 @@
 <!--
   Standalone layout for public share pages (e.g. /p/[slug]). Deliberately does
   NOT render the app <Header> — an external coach must never see app navigation,
-  search, or notifications. Only a slim coach-header bar (logo + verified badge),
-  mirroring the Figma design (node 5:7).
+  search, or notifications. The Figma coach-header bar (brand + verified badge)
+  lives inside the profile card itself (see ProfileHero), so this layout is just
+  a bare, chrome-free shell.
 -->
 <template>
   <div class="min-h-screen bg-gray-50">
-    <header class="bg-brand-slate-900 text-white">
-      <div
-        class="mx-auto flex h-14 max-w-6xl items-center justify-between px-4 sm:px-6"
-      >
-        <a
-          href="/"
-          class="flex items-center gap-2 transition-opacity hover:opacity-80"
-        >
-          <UIcon
-            name="i-heroicons-viewfinder-circle"
-            class="h-6 w-6 text-white"
-            aria-hidden="true"
-          />
-          <span class="text-sm font-semibold tracking-tight">
-            The Recruiting Compass
-          </span>
-        </a>
-        <span
-          class="inline-flex items-center gap-1.5 rounded-full bg-brand-emerald-900/40 px-3 py-1 text-xs font-medium text-brand-emerald-300 ring-1 ring-brand-emerald-700/50"
-        >
-          <span
-            class="h-1.5 w-1.5 rounded-full bg-brand-emerald-400"
-            aria-hidden="true"
-          />
-          Verified Coach Access
-        </span>
-      </div>
-    </header>
-
     <slot />
   </div>
 </template>


### PR DESCRIPTION
Follow-up to #500 — the hero diverged from the Figma design (node 5-15). Corrects the header/hero to match.

## Changes
- **Headshot** circle (was rounded-rect).
- **Coach-header strip** (RecruitingCompass + Verified Coach Access) moved from the page layout into the top of the hero card with a divider — Figma shows it as the card's top strip. `public` layout is now a bare, chrome-free shell (still no app `<Header>`).
- **Buttons** match Figma emphasis: **Express Interest** = primary solid-blue (star icon); **Contact Player** = secondary outline on the dark surface (mail icon).
- **Physicals** use position shorthand ("3B/2B" via `formatPositionsShort`) + trailing "3.80 GPA".

## Known remaining delta
Social icons still use generic heroicons (at-symbol/camera/musical-note) rather than X/Instagram/TikTok brand marks — needs inline brand SVGs, tracked separately.

## Test plan
- [x] type-check 0 · lint 0 · audit:tokens 0
- [x] unit — ProfileHero + PublicProfileCard specs green (18)
- [ ] Visual verify on QA after merge

Note: QA is currently serving a manual `vercel` CLI deploy (not develop git). Merging this + the git redeploy should reclaim the qa alias; if not, a develop redeploy will.

https://claude.ai/code/session_0171A2GPq5iCs5X9ciXwBFqJ