### PR TITLE
fix(security): exempt public share-page endpoints from CSRF

### DIFF
--- a/server/middleware/csrf.ts
+++ b/server/middleware/csrf.ts
@@ -26,6 +26,12 @@ export const CSRF_EXEMPT_PREFIXES = [
   "/api/csrf-token",
   "/api/health",
   "/api/auth",
+  // Public share-page endpoints (contact / express-interest / view). These are
+  // called by unauthenticated visitors who have no session and therefore no
+  // CSRF token — CSRF protects cookie-authenticated actions, which these are
+  // not. Abuse is instead gated by honeypot + per-IP/per-slug rate limiting +
+  // Cloudflare Turnstile inside each handler.
+  "/api/public/",
 ] as const;
 
 // Exact full paths that are CSRF-exempt

--- a/tests/unit/server/csrf-middleware.spec.ts
+++ b/tests/unit/server/csrf-middleware.spec.ts
@@ -74,6 +74,17 @@ describe("CSRF middleware path exemptions", () => {
     it("exempts the RFC 8058 one-click email unsubscribe exact path", () => {
       expect(isCsrfExemptPath("/api/email/unsubscribe")).toBe(true);
     });
+    it("exempts public share-page endpoints (contact/interest/view)", () => {
+      expect(
+        isCsrfExemptPath("/api/public/profile/owen-andrikanich-2028/contact"),
+      ).toBe(true);
+      expect(
+        isCsrfExemptPath("/api/public/profile/owen-andrikanich-2028/interest"),
+      ).toBe(true);
+      expect(
+        isCsrfExemptPath("/api/public/profile/owen-andrikanich-2028/view"),
+      ).toBe(true);
+    });
     it("does not exempt undefined path", () => {
       expect(isCsrfExemptPath(undefined)).toBe(false);
     });
@@ -97,6 +108,10 @@ describe("CSRF middleware path exemptions", () => {
     });
     it("does NOT exempt arbitrary paths containing 'schools'", () => {
       expect(isCsrfExemptPath("/api/admin/schools/export")).toBe(false);
+    });
+    it("does NOT exempt a lookalike prefix without the trailing slash", () => {
+      // "/api/public/" (trailing slash) must not match "/api/publications".
+      expect(isCsrfExemptPath("/api/publications/create")).toBe(false);
     });
     // Regression guard for the drift this file previously had: there is no
     // suffix-based cascade-delete/deletion-blockers exemption in the real
@@ -126,6 +141,7 @@ describe("exported constants match what the middleware actually enforces", () =>
       "/api/csrf-token",
       "/api/health",
       "/api/auth",
+      "/api/public/",
     ]);
   });
 


### PR DESCRIPTION
**Bug (live on QA):** Contact Player → "Couldn't send your message" and Express Interest → "Couldn't send your interest". Both return **403 "Invalid CSRF token"**.

**Root cause:** the global CSRF middleware requires a token on all POST/PUT/PATCH/DELETE, but the public share-page endpoints are called by unauthenticated visitors with no session → no CSRF token → 403. The forms could never submit.

**Fix:** add `/api/public/` to `CSRF_EXEMPT_PREFIXES`. CSRF protects cookie-authenticated actions from cross-site abuse; these endpoints have no auth and set no cookie, so CSRF is inapplicable. They already carry their own anti-abuse: honeypot + per-IP/per-slug rate limiting + Turnstile. Trailing slash prevents matching a lookalike prefix (`/api/publications`).

Covers `POST /api/public/profile/[slug]/{contact,interest,view}`.

## Test plan
- [x] Reproduced the 403 live on QA via the real form request
- [x] `csrf-middleware.spec` — added exempt + lookalike-guard cases (25 pass)
- [x] type-check 0 · lint 0
- [ ] Verify submit succeeds on QA after merge

https://claude.ai/code/session_0171A2GPq5iCs5X9ciXwBFqJ