### PR TITLE
fix(profile): Express Interest asks for the coach's school, not a position

### DIFF
--- a/components/profile/PublicProfileCard.vue
+++ b/components/profile/PublicProfileCard.vue
@@ -85,17 +85,6 @@ onMounted(() => {
   }
 });
 
-// Programs offered to the popover derive from the athlete's public sport +
-// positions — null-safe since `athletic` is null when that section is
-// hidden, in which case the popover falls back to its free-text input.
-const interestPrograms = computed(() => {
-  const a = props.data.athletic;
-  const values = [a?.primary_sport, ...(a?.positions ?? [])].filter(
-    (v): v is string => !!v,
-  );
-  return [...new Set(values)];
-});
-
 function handleInterest() {
   emit("interest");
   if (!props.slug) return;
@@ -211,7 +200,6 @@ function onInterestSubmitted() {
       v-if="showInterestPopover && slug"
       :slug="slug"
       :player-name="data.playerName"
-      :programs="interestPrograms"
       @close="closeInterestPopover"
       @submitted="onInterestSubmitted"
     />

--- a/components/profile/public/ExpressInterestPopover.vue
+++ b/components/profile/public/ExpressInterestPopover.vue
@@ -15,7 +15,6 @@ import { useRuntimeConfig } from "#app";
 const props = defineProps<{
   slug: string;
   playerName: string;
-  programs?: string[];
 }>();
 
 const emit = defineEmits<{
@@ -40,8 +39,6 @@ const coachName = ref("");
 const coachEmail = ref("");
 const hp = ref("");
 
-const hasProgramOptions = computed(() => !!props.programs?.length);
-
 const fieldErrors = ref<{ program?: string; coachEmail?: string; note?: string }>({});
 const submitError = ref("");
 const submitting = ref(false);
@@ -53,9 +50,9 @@ function validate(): boolean {
   const errors: typeof fieldErrors.value = {};
   const trimmedProgram = program.value.trim();
   if (!trimmedProgram) {
-    errors.program = "Please select or enter a program.";
+    errors.program = "Please enter your school or program.";
   } else if (trimmedProgram.length > 80) {
-    errors.program = "Keep the program under 80 characters.";
+    errors.program = "Keep it under 80 characters.";
   }
   if (note.value.trim().length > 1000) {
     errors.note = "Keep the note under 1000 characters.";
@@ -235,30 +232,17 @@ function handleClose() {
     <form v-else class="flex flex-col gap-4 px-5 py-4" @submit.prevent="handleSubmit">
       <div>
         <label class="mb-1 block text-sm font-medium text-brand-slate-700" for="interest-program">
-          Program
+          School / Program
           <span aria-hidden="true" class="text-red-500">*</span>
         </label>
-        <select
-          v-if="hasProgramOptions"
-          id="interest-program"
-          data-test="program-select"
-          v-model="program"
-          required
-          class="w-full rounded-xl border-2 bg-white px-3 py-2 focus:border-transparent focus:ring-2 focus:ring-brand-blue-500"
-          :class="fieldErrors.program ? 'border-red-500' : 'border-brand-slate-300'"
-        >
-          <option value="" disabled>Select a program</option>
-          <option v-for="p in programs" :key="p" :value="p">{{ p }}</option>
-        </select>
         <input
-          v-else
           id="interest-program"
           data-test="program-input"
           type="text"
           v-model="program"
           required
           maxlength="80"
-          placeholder="e.g. Baseball - SS"
+          placeholder="e.g. Ohio State University"
           class="w-full rounded-xl border-2 bg-white px-3 py-2 focus:border-transparent focus:ring-2 focus:ring-brand-blue-500"
           :class="fieldErrors.program ? 'border-red-500' : 'border-brand-slate-300'"
         />

--- a/tests/unit/components/profile/ExpressInterestPopover.spec.ts
+++ b/tests/unit/components/profile/ExpressInterestPopover.spec.ts
@@ -23,15 +23,7 @@ describe("ExpressInterestPopover", () => {
     turnstileSiteKey = "";
   });
 
-  it("renders a program select when programs are provided", () => {
-    const w = mount(ExpressInterestPopover, {
-      props: { ...baseProps, programs: ["Baseball - SS", "Baseball - OF"] },
-    });
-    expect(w.find("[data-test='program-select']").exists()).toBe(true);
-    expect(w.find("[data-test='program-input']").exists()).toBe(false);
-  });
-
-  it("renders a free-text program input when programs is empty", () => {
+  it("renders a free-text School / Program input (no dropdown that leaks the athlete's schools)", () => {
     const w = mount(ExpressInterestPopover, { props: baseProps });
     expect(w.find("[data-test='program-input']").exists()).toBe(true);
     expect(w.find("[data-test='program-select']").exists()).toBe(false);

--- a/tests/unit/components/profile/PublicProfileCard.spec.ts
+++ b/tests/unit/components/profile/PublicProfileCard.spec.ts
@@ -150,31 +150,20 @@ describe("PublicProfileCard", () => {
     expect(w.findComponent(ExpressInterestPopover).exists()).toBe(false);
   });
 
-  it("derives programs from primary_sport + positions, deduped", async () => {
-    const dataWithPositions = {
-      ...dataAwardsHidden,
-      athletic: { primary_sport: "Baseball", positions: ["SS", "Baseball"] },
-    };
+  it("opens the Express Interest popover on the hero interest event", async () => {
     const w = mount(PublicProfileCard, {
-      props: { data: dataWithPositions, slug: "owen-a" },
+      props: { data: dataAwardsHidden, slug: "owen-a" },
     });
-    const hero = w.findComponent(ProfileHero);
-    await hero.vm.$emit("interest");
+    expect(w.findComponent(ExpressInterestPopover).exists()).toBe(false);
 
+    await w.findComponent(ProfileHero).vm.$emit("interest");
+
+    // The popover no longer receives a programs list — it collects the
+    // coach's own school/program via a free-text field, so the athlete's
+    // followed schools are never exposed to the visitor.
     const popover = w.findComponent(ExpressInterestPopover);
-    expect(popover.props("programs")).toEqual(["Baseball", "SS"]);
-  });
-
-  it("passes empty programs when athletic is null (hidden section)", async () => {
-    const dataNoAthletic = { ...dataAwardsHidden, athletic: null };
-    const w = mount(PublicProfileCard, {
-      props: { data: dataNoAthletic, slug: "owen-a" },
-    });
-    const hero = w.findComponent(ProfileHero);
-    await hero.vm.$emit("interest");
-
-    const popover = w.findComponent(ExpressInterestPopover);
-    expect(popover.props("programs")).toEqual([]);
+    expect(popover.exists()).toBe(true);
+    expect(popover.props("programs")).toBeUndefined();
   });
 
   it("keeps the popover mounted (showing its confirmation) on submitted, and only unmounts on close", async () => {


### PR DESCRIPTION
The Express Interest "Program" field offered the athlete's own sport + positions ("Baseball / SS") — wrong: a coach represents a **school**, not the player's position. And listing the player's followed schools would leak the player's target list to an external visitor.

**Change:** single free-text **"School / Program"** field (placeholder "e.g. Ohio State University"). The visitor enters their own program; the athlete's schools are never exposed. Server field (`program`) + endpoint unchanged.

Drops the unused `programs` prop + deriving computed in PublicProfileCard; stale program-select/derivation tests updated.

## Test plan
- [x] type-check 0 · lint 0
- [x] unit — ExpressInterestPopover + PublicProfileCard specs green (83)
- [ ] Verify on QA after merge (once #505 CSRF fix is in, so the form can submit)

Note: touches PublicProfileCard, which #504 also edits — expect a trivial merge resolution depending on merge order.

https://claude.ai/code/session_0171A2GPq5iCs5X9ciXwBFqJ