### PR TITLE
fix(profile): hero stacks by container width; deepen Navy swatch

### DIFF
--- a/components/profile/public/ProfileHero.vue
+++ b/components/profile/public/ProfileHero.vue
@@ -52,7 +52,7 @@ const headerBgClass = computed(() => heroBackgroundClass(props.data.headerColor)
 </script>
 
 <template>
-  <header :class="[headerBgClass, 'text-white']">
+  <header :class="[headerBgClass, 'text-white', '@container']">
     <!-- Coach-header strip (Figma node 5:7): brand left, verified badge right -->
     <div
       class="flex items-center justify-between border-b border-white/10 px-6 py-3 sm:px-10"
@@ -78,16 +78,16 @@ const headerBgClass = computed(() => heroBackgroundClass(props.data.headerColor)
 
     <!-- Hero body -->
     <div class="px-6 py-8 sm:px-10 sm:py-10">
-      <div class="flex flex-col gap-6 sm:flex-row sm:items-start">
+      <div class="flex flex-col gap-6 @2xl:flex-row @2xl:items-start">
         <img
           v-if="data.photoUrl"
           :src="data.photoUrl"
           :alt="`${data.playerName} profile photo`"
-          class="h-28 w-28 shrink-0 rounded-full object-cover ring-2 ring-white/20 sm:h-32 sm:w-32"
+          class="h-28 w-28 shrink-0 rounded-full object-cover ring-2 ring-white/20 @2xl:h-32 @2xl:w-32"
         />
         <div
           v-else
-          class="flex h-28 w-28 shrink-0 items-center justify-center rounded-full bg-brand-slate-700 text-3xl font-semibold ring-2 ring-white/20 sm:h-32 sm:w-32"
+          class="flex h-28 w-28 shrink-0 items-center justify-center rounded-full bg-brand-slate-700 text-3xl font-semibold ring-2 ring-white/20 @2xl:h-32 @2xl:w-32"
           aria-hidden="true"
         >
           {{ data.playerName.charAt(0) }}
@@ -140,7 +140,7 @@ const headerBgClass = computed(() => heroBackgroundClass(props.data.headerColor)
         </div>
 
         <!-- Actions: Contact (secondary, outline-on-dark) over Express (primary) -->
-        <div class="flex shrink-0 flex-col gap-3 sm:w-48">
+        <div class="flex shrink-0 flex-col gap-3 @2xl:w-48">
           <button
             type="button"
             class="inline-flex items-center justify-center gap-2 rounded-lg border border-white/25 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-white/10 focus:ring-2 focus:ring-white/40 focus:outline-none"

--- a/components/profile/setup/ProfileAppearanceEditor.vue
+++ b/components/profile/setup/ProfileAppearanceEditor.vue
@@ -7,7 +7,7 @@ import { useProfileBanner } from "~/composables/useProfileBanner";
 // purple / indigo). Keys are constrained to the header_color enum the server
 // accepts (server/api/player/profile.put.ts).
 const HEADER_COLORS = [
-  { key: "slate", label: "Navy", swatch: "bg-slate-800" },
+  { key: "slate", label: "Navy", swatch: "bg-slate-900" },
   { key: "blue", label: "Blue", swatch: "bg-blue-700" },
   { key: "teal", label: "Teal", swatch: "bg-teal-700" },
   { key: "rose", label: "Red", swatch: "bg-rose-700" },


### PR DESCRIPTION
Setup-preview polish.

- **Hero stacks by container width.** `ProfileHero`'s avatar / info / actions row moves from a viewport breakpoint (`sm:`) to a container query (`@container` on the header, `@2xl:` on the row). It now stacks based on its own width, so the narrow 50/50 setup preview (~590px) renders cleanly instead of cramming three columns. The full-width public page (>672px container) is unchanged — still a row.
- **Navy swatch** uses `bg-slate-900` (was `slate-800`) so it matches the real hero background and reads as navy, not near-black.

Tailwind v4 native container queries (no plugin).

## Test plan
- [x] type-check 0 · lint 0 · audit:tokens 0
- [x] unit — ProfileHero + PublicProfileCard specs green (17)
- [ ] After merge: public hero unchanged at full width; narrows/stacks below ~672px (and in the setup preview)

https://claude.ai/code/session_0171A2GPq5iCs5X9ciXwBFqJ