### PR TITLE
fix(security): allow Cloudflare Turnstile in the CSP (prod forms broken)

### DIFF
--- a/server/middleware/security-headers.ts
+++ b/server/middleware/security-headers.ts
@@ -46,9 +46,14 @@ export default defineEventHandler((event) => {
   // Supabase Storage: frame-src/object-src for PDF previews, wss: for WebSocket
   const supabaseUrl = process.env.NUXT_PUBLIC_SUPABASE_URL || "";
   const supabaseWss = supabaseUrl.replace("https://", "wss://");
+  // Cloudflare Turnstile (public-profile Contact/Interest anti-abuse): loads
+  // its script (script-src), renders the challenge in an iframe (frame-src),
+  // and calls home during the challenge (connect-src). Without these the
+  // widget is CSP-blocked and no token can be minted → every submit 403s.
+  const turnstile = "https://challenges.cloudflare.com";
   const cspHeader = isProduction
-    ? `default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' ${supabaseUrl} ${supabaseWss} https://vitals.vercel-insights.com; worker-src 'self' blob:; frame-src 'self' ${supabaseUrl}; object-src 'self' ${supabaseUrl}; frame-ancestors 'none'`
-    : `default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://va.vercel-scripts.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https: http://localhost:*; worker-src 'self' blob:; frame-src 'self' ${supabaseUrl}; object-src 'self' ${supabaseUrl}; frame-ancestors 'self'`;
+    ? `default-src 'self'; script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com ${turnstile}; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' ${supabaseUrl} ${supabaseWss} https://vitals.vercel-insights.com ${turnstile}; worker-src 'self' blob:; frame-src 'self' ${supabaseUrl} ${turnstile}; object-src 'self' ${supabaseUrl}; frame-ancestors 'none'`
+    : `default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://va.vercel-scripts.com ${turnstile}; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https: http://localhost:*; worker-src 'self' blob:; frame-src 'self' ${supabaseUrl} ${turnstile}; object-src 'self' ${supabaseUrl}; frame-ancestors 'self'`;
 
   setHeader(event, "Content-Security-Policy", cspHeader);
 });


### PR DESCRIPTION
**Prod launch bug — public Contact/Interest forms are broken.** Found right after the Turnstile env was set + promoted.

With Turnstile enforced server-side, the client can't load the widget because the CSP blocks it:

> Loading `https://challenges.cloudflare.com/turnstile/v0/api.js` violates the Content Security Policy directive: `script-src 'self' 'unsafe-inline' https://va.vercel-scripts.com`. Blocked.

No widget → no token minted → **every submit 403s** ("Verification failed"). Verified live on prod (`myrecruitingcompass.com`): modal renders, Turnstile script CSP-blocked in console, tokenless POST → 403.

**Fix:** allowlist `https://challenges.cloudflare.com` in `script-src` (api.js), `frame-src` (challenge iframe), and `connect-src` (challenge callbacks), in both prod + dev CSP. No other origins opened.

## Test plan
- [x] type-check 0 · lint 0
- [ ] After promote to prod: Contact modal renders the Turnstile widget (no CSP error), a real submit succeeds, lead lands in profile_contacts

⚠️ **This needs to reach prod (develop → main) to fix the live forms.**

https://claude.ai/code/session_0171A2GPq5iCs5X9ciXwBFqJ