### PR TITLE
fix(profile): authenticate the inbox fetch (bare $fetch 401'd in prod)

### DIFF
--- a/composables/useProfileContacts.ts
+++ b/composables/useProfileContacts.ts
@@ -1,5 +1,6 @@
 // composables/useProfileContacts.ts
 import { ref, onMounted } from "vue";
+import { useAuthFetch } from "~/composables/useAuthFetch";
 import { createClientLogger } from "~/utils/logger";
 
 const logger = createClientLogger("profile-contacts");
@@ -31,6 +32,7 @@ interface ProfileContactsResponse {
 }
 
 export function useProfileContacts() {
+  const { $fetchAuth } = useAuthFetch();
   const leads = ref<ProfileLead[]>([]);
   const counts = ref<ProfileContactCounts>({
     interestThisMonth: 0,
@@ -44,7 +46,7 @@ export function useProfileContacts() {
     loading.value = true;
     error.value = null;
     try {
-      const data = await $fetch<ProfileContactsResponse>(
+      const data = await $fetchAuth<ProfileContactsResponse>(
         "/api/player/profile/contacts",
       );
       leads.value = data.leads;

--- a/tests/unit/composables/useProfileContacts.spec.ts
+++ b/tests/unit/composables/useProfileContacts.spec.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.stubGlobal("$fetch", vi.fn());
+// The inbox composable must authenticate through useAuthFetch (Bearer token),
+// NOT bare $fetch — the app sets no auth cookie, so a bare $fetch 401s in prod.
+// Mocking useAuthFetch (and leaving global $fetch unstubbed) makes a regression
+// to bare $fetch fail here instead of only in production.
+const mockFetchAuth = vi.fn();
+vi.mock("~/composables/useAuthFetch", () => ({
+  useAuthFetch: () => ({ $fetchAuth: mockFetchAuth }),
+}));
 
 const mockLogger = {
   info: vi.fn(),
@@ -37,8 +44,7 @@ describe("useProfileContacts", () => {
   });
 
   it("initializes with empty leads and zeroed counts", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({ leads: [], counts: null });
-    vi.stubGlobal("$fetch", mockFetch);
+    mockFetchAuth.mockResolvedValue({ leads: [], counts: null });
     const { useProfileContacts } = await import(
       "~/composables/useProfileContacts"
     );
@@ -52,11 +58,10 @@ describe("useProfileContacts", () => {
   });
 
   it("fetchContacts populates leads and counts from GET /api/player/profile/contacts", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
+    mockFetchAuth.mockResolvedValue({
       leads: [sampleLead],
       counts: sampleCounts,
     });
-    vi.stubGlobal("$fetch", mockFetch);
     const { useProfileContacts } = await import(
       "~/composables/useProfileContacts"
     );
@@ -64,15 +69,14 @@ describe("useProfileContacts", () => {
     const promise = fetchContacts();
     expect(loading.value).toBe(true);
     await promise;
-    expect(mockFetch).toHaveBeenCalledWith("/api/player/profile/contacts");
+    expect(mockFetchAuth).toHaveBeenCalledWith("/api/player/profile/contacts");
     expect(leads.value).toEqual([sampleLead]);
     expect(counts.value).toEqual(sampleCounts);
     expect(loading.value).toBe(false);
   });
 
-  it("fetchContacts sets a user-friendly error and resets loading when $fetch rejects", async () => {
-    const mockFetch = vi.fn().mockRejectedValue(new Error("Network error"));
-    vi.stubGlobal("$fetch", mockFetch);
+  it("fetchContacts sets a user-friendly error and resets loading when the request rejects", async () => {
+    mockFetchAuth.mockRejectedValue(new Error("Network error"));
     const { useProfileContacts } = await import(
       "~/composables/useProfileContacts"
     );


### PR DESCRIPTION
## Problem

Prod launch bug: **Player Details > Inbox** shows *"Something went wrong — Failed to load your inbox"* for every user.

Confirmed via prod runtime logs — the authed browser calls return **401 "no token found"**:
```
GET /api/player/profile/contacts 401  (×2, user's "Try Again" clicks)
```

## Root cause

`useProfileContacts` called **bare `$fetch`**, which sends no auth header. This app keeps its Supabase session in localStorage and attaches it as `Authorization: Bearer <access_token>` **only** through `useAuthFetch` — no `sb-access-token` cookie is ever set (grep = none), so the server's cookie fallback never fires. Result: no token reaches `requireAuth` → 401. All 27 other authed composables use `useAuthFetch`; this one was the outlier.

iOS reads the same `profile_contacts` rows directly and shows the leads, which is why the data looked fine there.

## Fix

- `useProfileContacts` → `useAuthFetch().$fetchAuth` (GET, so no CSRF needed; the wrapper handles it).
- Test previously stubbed global `$fetch` so it passed green while prod 401'd. Now mocks `useAuthFetch` and leaves `$fetch` unstubbed, so a regression to bare `$fetch` fails in CI, not just in prod.

## Test plan

- [x] `useProfileContacts.spec.ts` + `ProfileInbox.spec.ts` — 8 pass
- [x] `npm run type-check` clean
- [ ] After deploy: Player Details > Inbox loads leads for an authed player

## Not in this PR (separate follow-ups found same session)

- Web notifications bell shows "No notifications" despite 5 rows in DB (different path — direct Supabase/RLS client read; RLS + query verified correct, needs live browser-console inspection).
- iOS push not firing (APNs).

https://claude.ai/code/session_01NNNakkveQMuqWoMbBuV9v6