### PR TITLE
Promote develop → main: inbox auth fix (#516)

### DIFF
--- a/composables/useProfileContacts.ts
+++ b/composables/useProfileContacts.ts
@@ -1,5 +1,6 @@
 // composables/useProfileContacts.ts
 import { ref, onMounted } from "vue";
+import { useAuthFetch } from "~/composables/useAuthFetch";
 import { createClientLogger } from "~/utils/logger";
 
 const logger = createClientLogger("profile-contacts");
@@ -31,6 +32,7 @@ interface ProfileContactsResponse {
 }
 
 export function useProfileContacts() {
+  const { $fetchAuth } = useAuthFetch();
   const leads = ref<ProfileLead[]>([]);
   const counts = ref<ProfileContactCounts>({
     interestThisMonth: 0,
@@ -44,7 +46,7 @@ export function useProfileContacts() {
     loading.value = true;
     error.value = null;
     try {
-      const data = await $fetch<ProfileContactsResponse>(
+      const data = await $fetchAuth<ProfileContactsResponse>(
         "/api/player/profile/contacts",
       );
       leads.value = data.leads;

--- a/tests/unit/composables/useProfileContacts.spec.ts
+++ b/tests/unit/composables/useProfileContacts.spec.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-vi.stubGlobal("$fetch", vi.fn());
+// The inbox composable must authenticate through useAuthFetch (Bearer token),
+// NOT bare $fetch — the app sets no auth cookie, so a bare $fetch 401s in prod.
+// Mocking useAuthFetch (and leaving global $fetch unstubbed) makes a regression
+// to bare $fetch fail here instead of only in production.
+const mockFetchAuth = vi.fn();
+vi.mock("~/composables/useAuthFetch", () => ({
+  useAuthFetch: () => ({ $fetchAuth: mockFetchAuth }),
+}));
 
 const mockLogger = {
   info: vi.fn(),
@@ -37,8 +44,7 @@ describe("useProfileContacts", () => {
   });
 
   it("initializes with empty leads and zeroed counts", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({ leads: [], counts: null });
-    vi.stubGlobal("$fetch", mockFetch);
+    mockFetchAuth.mockResolvedValue({ leads: [], counts: null });
     const { useProfileContacts } = await import(
       "~/composables/useProfileContacts"
     );
@@ -52,11 +58,10 @@ describe("useProfileContacts", () => {
   });
 
   it("fetchContacts populates leads and counts from GET /api/player/profile/contacts", async () => {
-    const mockFetch = vi.fn().mockResolvedValue({
+    mockFetchAuth.mockResolvedValue({
       leads: [sampleLead],
       counts: sampleCounts,
     });
-    vi.stubGlobal("$fetch", mockFetch);
     const { useProfileContacts } = await import(
       "~/composables/useProfileContacts"
     );
@@ -64,15 +69,14 @@ describe("useProfileContacts", () => {
     const promise = fetchContacts();
     expect(loading.value).toBe(true);
     await promise;
-    expect(mockFetch).toHaveBeenCalledWith("/api/player/profile/contacts");
+    expect(mockFetchAuth).toHaveBeenCalledWith("/api/player/profile/contacts");
     expect(leads.value).toEqual([sampleLead]);
     expect(counts.value).toEqual(sampleCounts);
     expect(loading.value).toBe(false);
   });
 
-  it("fetchContacts sets a user-friendly error and resets loading when $fetch rejects", async () => {
-    const mockFetch = vi.fn().mockRejectedValue(new Error("Network error"));
-    vi.stubGlobal("$fetch", mockFetch);
+  it("fetchContacts sets a user-friendly error and resets loading when the request rejects", async () => {
+    mockFetchAuth.mockRejectedValue(new Error("Network error"));
     const { useProfileContacts } = await import(
       "~/composables/useProfileContacts"
     );


### PR DESCRIPTION
Production promotion. Carries:

- **#516** fix(profile): authenticate the inbox fetch — Player Details > Inbox 401'd for all users because `useProfileContacts` used bare `$fetch` (no Bearer token). Verified working on QA (leads render, counts correct).

Merge as a **merge commit** (repo convention). main is ahead by the #493 back-merge gap (`invalid-refresh-token` test) — untouched by this promote.

https://claude.ai/code/session_01NNNakkveQMuqWoMbBuV9v6