### PR TITLE
Promote develop → main: header bell notifications fix (#520)

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -32,7 +32,10 @@
               aria-hidden="true"
             />
           </NuxtLink>
-          <NotificationCenter />
+          <NotificationCenter
+            :notifications="notifications"
+            @mark-as-read="handleMarkAsRead"
+          />
           <HeaderProfile class="hidden md:block" />
 
           <!-- Mobile Menu Button -->
@@ -157,10 +160,11 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted } from "vue";
+import { ref, computed, onMounted, watch } from "vue";
 import { useRoute } from "vue-router";
 import { useUserStore } from "~/stores/user";
 import { useAuthLifecycle } from "~/composables/useAuthLifecycle";
+import { useNotifications } from "~/composables/useNotifications";
 import AthleteSwitcher from "~/components/AthleteSwitcher.vue";
 import HeaderNav from "~/components/Header/HeaderNav.vue";
 import HeaderProfile from "~/components/Header/HeaderProfile.vue";
@@ -171,6 +175,22 @@ const authLifecycle = useAuthLifecycle();
 const userStore = useUserStore();
 const user = computed(() => userStore.user || null);
 const isMobileMenuOpen = ref(false);
+
+// The header bell is presentational — it renders whatever `notifications` it's
+// handed. Own the fetch here so the dropdown actually shows the user's items.
+// fetchNotifications no-ops until the user is in the store, so fetch once the
+// user resolves (it may hydrate after mount).
+const { notifications, fetchNotifications, markAsRead } = useNotifications();
+watch(
+  user,
+  (current) => {
+    if (current) fetchNotifications({ limit: 10 });
+  },
+  { immediate: true },
+);
+const handleMarkAsRead = (id: string) => {
+  markAsRead(id);
+};
 
 const navItems = [
   { to: "/dashboard", label: "Dashboard", icon: "i-heroicons-home" },

--- a/components/Header/NotificationCenter.vue
+++ b/components/Header/NotificationCenter.vue
@@ -146,7 +146,7 @@ interface Notification {
   title: string;
   message: string;
   scheduled_for: string;
-  read_at?: string;
+  read_at?: string | null;
 }
 
 interface Props {

--- a/tests/unit/components/Header/HeaderNotifications.spec.ts
+++ b/tests/unit/components/Header/HeaderNotifications.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { ref } from "vue";
+import { mount, flushPromises } from "@vue/test-utils";
+import Header from "~/components/Header.vue";
+
+// Regression guard: the header bell is presentational (renders whatever
+// `notifications` it's handed). Header owns the fetch and must pass the result
+// down — it previously rendered <NotificationCenter /> with no prop, so the
+// dropdown was always empty. This asserts Header fetches and forwards.
+
+const sampleNotifications = [
+  {
+    id: "n1",
+    title: "New contact from a coach",
+    message: "A coach reached out.",
+    scheduled_for: "2026-08-27T12:00:00.000Z",
+    read_at: null,
+  },
+];
+const mockNotifications = ref(sampleNotifications);
+const mockFetchNotifications = vi.fn();
+const mockMarkAsRead = vi.fn();
+vi.mock("~/composables/useNotifications", () => ({
+  useNotifications: vi.fn(() => ({
+    notifications: mockNotifications,
+    fetchNotifications: mockFetchNotifications,
+    markAsRead: mockMarkAsRead,
+  })),
+}));
+
+const mockUser = ref<{ id: string } | null>({ id: "u1" });
+vi.mock("~/stores/user", () => ({
+  useUserStore: vi.fn(() => ({ get user() {
+    return mockUser.value;
+  }, isAuthenticated: true })),
+}));
+vi.mock("~/composables/useAuthLifecycle", () => ({
+  useAuthLifecycle: vi.fn(() => ({})),
+}));
+vi.mock("vue-router", () => ({
+  useRoute: vi.fn(() => ({ path: "/dashboard" })),
+}));
+
+const NotificationCenterStub = {
+  name: "NotificationCenter",
+  props: ["notifications"],
+  emits: ["mark-as-read", "notification-click"],
+  template: `<div data-test="bell" :data-count="notifications.length"></div>`,
+};
+
+const createWrapper = () =>
+  mount(Header, {
+    global: {
+      stubs: {
+        NuxtLink: { template: "<a><slot /></a>", props: ["to"] },
+        NotificationCenter: NotificationCenterStub,
+        AthleteSwitcher: true,
+        HeaderNav: true,
+        HeaderProfile: true,
+      },
+    },
+  });
+
+describe("Header notifications wiring", () => {
+  beforeEach(() => {
+    mockNotifications.value = sampleNotifications;
+    mockUser.value = { id: "u1" };
+    mockFetchNotifications.mockReset();
+    mockMarkAsRead.mockReset();
+  });
+
+  it("fetches notifications once the user is present and passes them to the bell", async () => {
+    const wrapper = createWrapper();
+    await flushPromises();
+
+    expect(mockFetchNotifications).toHaveBeenCalledWith({ limit: 10 });
+    const bell = wrapper.find('[data-test="bell"]');
+    expect(bell.exists()).toBe(true);
+    expect(bell.attributes("data-count")).toBe("1");
+  });
+
+  it("forwards the bell's mark-as-read to the composable", async () => {
+    const wrapper = createWrapper();
+    await flushPromises();
+    wrapper.findComponent(NotificationCenterStub).vm.$emit("mark-as-read", "n1");
+    expect(mockMarkAsRead).toHaveBeenCalledWith("n1");
+  });
+});


### PR DESCRIPTION
Production promotion. Carries:

- **#520** fix(notifications): populate the header bell — the bell dropdown showed "No notifications" for everyone because Header.vue rendered the prop-driven bell with no data and never fetched. Verified on QA (dropdown populated, unread badge, mark-all-read).

Merge as a **merge commit** (repo convention).

https://claude.ai/code/session_01NNNakkveQMuqWoMbBuV9v6