### PR TITLE
ci(claude): allow GitHub Action to create/close issues

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      issues: read
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:
@@ -43,7 +43,7 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr:*)'
+          # Allow Claude to manage issues (create/close/comment/view) and read auth/PR state.
+          # Without these, gh issue create/close come back "requires approval" in the
+          # non-interactive job and get blocked.
+          claude_args: '--allowed-tools "Bash(gh issue create:*),Bash(gh issue close:*),Bash(gh issue comment:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh pr:*),Bash(gh auth status:*)"'


### PR DESCRIPTION
## Why
In issue #19 the Claude GitHub Action reported it was **blocked** from creating a follow-up issue and closing #19:
- job token only had `issues: read`
- `gh issue create` / `gh issue close` were not in `--allowed-tools`, so they returned "requires approval" in the non-interactive run

## Change
`.github/workflows/claude.yml`:
- `issues: read` → `issues: write`
- add `claude_args` allowlisting `gh issue create/close/comment/view/edit` (+ existing `gh pr`, `gh auth status`)

## Effect / follow-up
GitHub reads `issues`/`issue_comment` workflows from the **default branch**, so this only takes full effect for the bot once promoted to `main`. On develop/QA it's staged. After it reaches `main`, re-trigger by commenting `@claude` on issue #19.

## Note
`issues: write` lets any `@claude` comment create/close issues in this repo. Owner-acceptable; flagged for awareness.

https://claude.ai/code/session_013sJ4UvoPQboiAL3Bd95PX6