### PR TITLE
ci(claude): pin action to v1.0.207 (floating @v1 install broke)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,11 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        # Pinned off the floating @v1 tag: it drifted to a build that hardcodes
+        # Claude Code v2.1.79, whose installer 403s from the CDN (curl exit 22),
+        # failing the job before Claude runs (upstream issue #1091). v1.0.207 is
+        # the current stable release.
+        uses: anthropics/claude-code-action@v1.0.207
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
## Why
After #522/#523 landed the perms fix, the Claude Action began failing at the **install** step (before Claude runs):

\`\`\`
Failed to install Claude Code after 3 attempts: Install failed with exit code 22
\`\`\`

Root cause is upstream, not our config: the floating \`@v1\` tag drifted to a build that hardcodes Claude Code \`v2.1.79\`, whose installer 403s from the CDN (curl exit 22). Tracked as anthropics/claude-code-action#1091. \`@v1\` (\`62529b7c\`) ≠ \`v1.0.207\` (\`7c4f5666\`) — distinct builds.

## Change
Pin \`anthropics/claude-code-action@v1\` → \`@v1.0.207\` (current stable release).

## Effect
Must reach \`main\` (default branch) to fix the \`issue_comment\` bot. Staged on QA here.

https://claude.ai/code/session_013sJ4UvoPQboiAL3Bd95PX6