### PR TITLE
Promote: pin Claude Action to v1.0.207 (develop → main)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,11 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        # Pinned off the floating @v1 tag: it drifted to a build that hardcodes
+        # Claude Code v2.1.79, whose installer 403s from the CDN (curl exit 22),
+        # failing the job before Claude runs (upstream issue #1091). v1.0.207 is
+        # the current stable release.
+        uses: anthropics/claude-code-action@v1.0.207
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 


### PR DESCRIPTION
Promotes #524. Single change: pin anthropics/claude-code-action@v1 → @v1.0.207, fixing the install-step 403 (upstream #1091) so the bot works on prod. No app code, no migration.

https://claude.ai/code/session_013sJ4UvoPQboiAL3Bd95PX6