### PR TITLE
test: fill CRUD coverage gaps (tasks, athlete messages, metrics + templates E2E)

### DIFF
--- a/composables/useUserTasks.ts
+++ b/composables/useUserTasks.ts
@@ -66,10 +66,18 @@ export const useUserTasks = () => {
     }
   };
 
+  // Unique id — Date.now() alone collides for tasks added in the same
+  // millisecond, which made deleteTask/toggleTask/updateTask hit every task
+  // sharing that timestamp.
+  const newTaskId = () =>
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? `task-${crypto.randomUUID()}`
+      : `task-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
   // Add a new task
   const addTask = async (text: string) => {
     const newTask: UserTask = {
-      id: `task-${Date.now()}`,
+      id: newTaskId(),
       text,
       completed: false,
       created_at: new Date().toISOString(),

--- a/pages/settings/communication-templates.vue
+++ b/pages/settings/communication-templates.vue
@@ -187,9 +187,12 @@ const editTemplate = (template: CommunicationTemplate) => {
   activeTab.value = "create";
 };
 
-const onTemplateSaved = () => {
+const onTemplateSaved = async () => {
   editingTemplate.value = null;
   activeTab.value = "list";
+  // TemplateEditor mutates its own useCommunicationTemplates() instance, so the
+  // page's list ref is stale after a create/edit — refetch to surface the row.
+  await loadUserTemplates();
 };
 
 const onEditCancel = () => {
@@ -199,9 +202,10 @@ const onEditCancel = () => {
   }
 };
 
-const onTemplateDeleted = () => {
+const onTemplateDeleted = async () => {
   editingTemplate.value = null;
   activeTab.value = "list";
+  await loadUserTemplates();
 };
 
 onMounted(() => {

--- a/tests/e2e/tier1-critical/metrics-crud-atomic.spec.ts
+++ b/tests/e2e/tier1-critical/metrics-crud-atomic.spec.ts
@@ -1,0 +1,108 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Atomic CRUD — performance-metric lifecycle.
+ *
+ * Metrics are standalone (only user_id + family_unit_id, auto-injected), so no
+ * parent entity to manage. The test walks one metric through
+ * log → view → edit value → reload to confirm persistence → delete via the
+ * ConfirmDialog.
+ *
+ * Metric type "other" is used because the type options are sport-registry
+ * driven and this account's sport is unknown; "other" is always present and
+ * takes the free-text name + editable unit path.
+ *
+ * The card is anchored by a UUID token dropped into Notes, which keeps the
+ * locator unambiguous under fullyParallel sharding and the player's large
+ * accumulated metric history.
+ *
+ * Auth: storageState (player.json, default project context).
+ */
+test.describe("Performance Metrics CRUD — atomic lifecycle", () => {
+  test.describe.configure({ mode: "serial" });
+  test.setTimeout(120_000);
+
+  test("log → view → edit value → delete a metric", async ({ page }) => {
+    const token = `e2e-metric-${crypto.randomUUID().slice(0, 8)}`;
+    const initialValue = "42";
+    const updatedValue = "57";
+
+    // 1. LOG — open the modal, submit a real sport metric type
+    await page.goto("/performance");
+    // networkidle lets family context (activeFamilyId) hydrate — createMetric
+    // throws "Family context not loaded" without it.
+    await page.waitForLoadState("networkidle");
+    await page.getByRole("button", { name: "+ Log Metric" }).click();
+
+    const dialog = page.getByRole("dialog", { name: "Log Performance Metric" });
+    await expect(dialog).toBeVisible();
+
+    // Pick the first real metric type (not the placeholder, not "other"). A
+    // real type is chosen over "other" so the Edit modal's type select — which
+    // only lists registry types — has a matching option and can save. The type
+    // is sport-driven, so read it at runtime rather than hardcoding.
+    const metricType = await dialog
+      .locator("#metricType option")
+      .evaluateAll((opts) => {
+        const o = (opts as HTMLOptionElement[]).find(
+          (e) => e.value && e.value !== "other",
+        );
+        return o ? o.value : null;
+      });
+    expect(metricType).toBeTruthy();
+    await dialog.locator("#metricType").selectOption(metricType!);
+    await dialog.locator("#value").fill(initialValue);
+    // Notes render verbatim on the history card — the unique anchor for locating
+    // exactly this metric among the player's existing rows of the same type.
+    await dialog.locator("#notes").fill(token);
+    // #date is pre-filled to today on mount
+
+    const submit = dialog.getByRole("button", { name: "Log Metric" });
+    await expect(submit).toBeEnabled();
+    await submit.click();
+    await expect(dialog).toBeHidden();
+
+    // 2. READ — the history card carrying our token is visible. The token also
+    // appears in the Summary/Trends sections, so pin to the History card by its
+    // Edit button (only history cards have one).
+    const card = page
+      .locator("div.rounded-lg.bg-white.p-6.shadow-sm")
+      .filter({ hasText: token })
+      .filter({ has: page.getByRole("button", { name: "Edit", exact: true }) });
+    await expect(card).toBeVisible();
+    await expect(card).toContainText(initialValue);
+
+    // 3. UPDATE — open Edit on THAT card, change the value, save
+    await card.getByRole("button", { name: "Edit", exact: true }).click();
+    const editValue = page.locator("#editValue");
+    await expect(editValue).toBeVisible();
+    await editValue.fill(updatedValue);
+    await page.getByRole("button", { name: "Save Changes" }).click();
+    await expect(editValue).toBeHidden();
+
+    // 4. Reload — confirm the new value persisted
+    await page.reload();
+    await page.waitForLoadState("domcontentloaded");
+    const reloadedCard = page
+      .locator("div.rounded-lg.bg-white.p-6.shadow-sm")
+      .filter({ hasText: token })
+      .filter({ has: page.getByRole("button", { name: "Edit", exact: true }) });
+    await expect(reloadedCard).toContainText(updatedValue);
+
+    // 5. DELETE — card Delete opens the ConfirmDialog; confirm inside it
+    await reloadedCard
+      .getByRole("button", { name: "Delete", exact: true })
+      .click();
+    await page
+      .getByRole("dialog", { name: "Delete Metric" })
+      .getByRole("button", { name: "Delete", exact: true })
+      .click();
+
+    // 6. VERIFY — the metric is gone
+    await expect(
+      page
+        .locator("div.rounded-lg.bg-white.p-6.shadow-sm")
+        .filter({ hasText: token }),
+    ).toHaveCount(0);
+  });
+});

--- a/tests/e2e/tier1-critical/templates-crud-atomic.spec.ts
+++ b/tests/e2e/tier1-critical/templates-crud-atomic.spec.ts
@@ -1,0 +1,79 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Atomic CRUD — communication-template lifecycle.
+ *
+ * Templates are standalone (user_id + family_unit_id, auto-injected). The test
+ * creates an OWNED template (predefined built-ins reroute to a "copy" flow and
+ * have no Delete), then walks it through
+ * create → view → edit name → delete via the editor's ConfirmDialog.
+ *
+ * The template name carries a UUID token so list assertions stay unambiguous
+ * under fullyParallel sharding.
+ *
+ * Auth: storageState (player.json, default project context).
+ */
+test.describe("Communication Templates CRUD — atomic lifecycle", () => {
+  test.describe.configure({ mode: "serial" });
+  test.setTimeout(120_000);
+
+  test("create → view → edit name → delete a template", async ({ page }) => {
+    const token = crypto.randomUUID().slice(0, 8);
+    const name = `E2E Template ${token}`;
+    const renamed = `${name} edited`;
+    const body = `Hi Coach, this is a test outreach ${token}.`;
+
+    // 1. CREATE — switch to the Create New tab, fill the editor, save
+    await page.goto("/settings/communication-templates");
+    // networkidle lets family context (activeFamilyId) hydrate before create —
+    // loadTemplates scopes the list by it, so acting too early hides the new row.
+    await page.waitForLoadState("networkidle");
+    await page.getByRole("button", { name: /Create New/ }).click();
+
+    // Labels aren't bound (no for=/id), so target inputs by placeholder and by
+    // the editor form's single select/textarea. Type defaults to "email".
+    const editorForm = page.locator("form");
+    await page.getByPlaceholder("e.g., Initial Outreach").fill(name);
+    await editorForm.locator("textarea").fill(body);
+    await page.getByRole("button", { name: "Save Template" }).click();
+
+    // 2. READ — page returns to the list tab; our card is present
+    const card = page
+      .locator("div.rounded-lg.bg-white.p-6.shadow-sm")
+      .filter({ has: page.getByRole("heading", { name, exact: true }) });
+    await expect(card.first()).toBeVisible();
+
+    // 3. UPDATE — open Edit, change the name, save
+    await card.first().getByRole("button", { name: "Edit", exact: true }).click();
+    await expect(page.getByRole("heading", { name: "Edit Template" })).toBeVisible();
+    await page.getByPlaceholder("e.g., Initial Outreach").fill(renamed);
+    await page.getByRole("button", { name: "Save Template" }).click();
+
+    // 4. VERIFY update — renamed card appears, old name gone
+    await expect(
+      page.getByRole("heading", { name: renamed, exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name, exact: true }),
+    ).toHaveCount(0);
+
+    // 5. DELETE — Delete lives inside the editor; open Edit, then delete
+    const renamedCard = page
+      .locator("div.rounded-lg.bg-white.p-6.shadow-sm")
+      .filter({ has: page.getByRole("heading", { name: renamed, exact: true }) });
+    await renamedCard
+      .first()
+      .getByRole("button", { name: "Edit", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Delete", exact: true }).click();
+    await page
+      .getByRole("dialog", { name: "Delete Template" })
+      .getByRole("button", { name: "Delete", exact: true })
+      .click();
+
+    // 6. VERIFY delete — template is gone from the list
+    await expect(
+      page.getByRole("heading", { name: renamed, exact: true }),
+    ).toHaveCount(0);
+  });
+});

--- a/tests/unit/composables/useAthleteMessages.spec.ts
+++ b/tests/unit/composables/useAthleteMessages.spec.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFetchAuth = vi.fn();
+
+vi.mock("~/composables/useAuthFetch", () => ({
+  useAuthFetch: () => ({ $fetchAuth: mockFetchAuth }),
+}));
+
+const { useAthleteMessages } = await import("~/composables/useAthleteMessages");
+
+const ATHLETE_ID = "11111111-1111-4111-8111-111111111111";
+const SCHOOL_ID = "22222222-2222-4222-8222-222222222222";
+
+describe("useAthleteMessages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("logSend", () => {
+    it("POSTs the message payload to /api/athlete/messages and returns the id", async () => {
+      mockFetchAuth.mockResolvedValue({ success: true, id: "msg-1" });
+      const { logSend } = useAthleteMessages();
+
+      const input = {
+        athleteUserId: ATHLETE_ID,
+        schoolId: SCHOOL_ID,
+        coachId: null,
+        templateSlug: "intro-standard",
+        channel: "email",
+        programNote: "Team just won state",
+        subject: "Interested in your program",
+        body: "Hello coach...",
+      };
+      const result = await logSend(input);
+
+      expect(mockFetchAuth).toHaveBeenCalledWith("/api/athlete/messages", {
+        method: "POST",
+        body: input,
+      });
+      expect(result).toEqual({ success: true, id: "msg-1" });
+    });
+
+    it("propagates a rejected send so callers can surface the failure", async () => {
+      mockFetchAuth.mockRejectedValue(new Error("Failed to log message"));
+      const { logSend } = useAthleteMessages();
+
+      await expect(
+        logSend({ athleteUserId: ATHLETE_ID }),
+      ).rejects.toThrow("Failed to log message");
+    });
+  });
+
+  describe("checkSend", () => {
+    it("POSTs to /api/athlete/messages/check and returns the guardrail signals", async () => {
+      const signals = {
+        programNoteReused: false,
+        daysSinceLastContact: 3,
+        recentContact: true,
+        messageCountToSchool: 2,
+      };
+      mockFetchAuth.mockResolvedValue(signals);
+      const { checkSend } = useAthleteMessages();
+
+      const input = {
+        athleteUserId: ATHLETE_ID,
+        schoolId: SCHOOL_ID,
+        programNote: "Team just won state",
+      };
+      const result = await checkSend(input);
+
+      expect(mockFetchAuth).toHaveBeenCalledWith(
+        "/api/athlete/messages/check",
+        { method: "POST", body: input },
+      );
+      expect(result).toEqual(signals);
+    });
+
+    it("surfaces a blocking programNoteReused signal", async () => {
+      mockFetchAuth.mockResolvedValue({
+        programNoteReused: true,
+        daysSinceLastContact: null,
+        recentContact: false,
+        messageCountToSchool: 0,
+      });
+      const { checkSend } = useAthleteMessages();
+
+      const result = await checkSend({
+        athleteUserId: ATHLETE_ID,
+        schoolId: SCHOOL_ID,
+        programNote: "Same note reused elsewhere",
+      });
+
+      expect(result.programNoteReused).toBe(true);
+    });
+  });
+});

--- a/tests/unit/composables/useUserTasks.spec.ts
+++ b/tests/unit/composables/useUserTasks.spec.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { setActivePinia, createPinia } from "pinia";
+import { useUserTasks } from "~/composables/useUserTasks";
+import { useUserStore } from "~/stores/user";
+
+const STORAGE_KEY = "user_tasks";
+const USER_ID = "user-123";
+
+const storageKeyFor = (id: string) => `${STORAGE_KEY}-${id}`;
+
+describe("useUserTasks", () => {
+  let userStore: ReturnType<typeof useUserStore>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    localStorage.clear();
+    userStore = useUserStore();
+    userStore.user = {
+      id: USER_ID,
+      email: "test@example.com",
+      name: "Test User",
+    };
+    vi.clearAllMocks();
+  });
+
+  const readStored = () => {
+    const raw = localStorage.getItem(storageKeyFor(USER_ID));
+    return raw ? JSON.parse(raw) : null;
+  };
+
+  describe("addTask (create)", () => {
+    it("appends a new pending task and persists it to localStorage", async () => {
+      const { addTask, tasks } = useUserTasks();
+
+      const created = await addTask("Email Coach Smith");
+
+      expect(created).toMatchObject({
+        text: "Email Coach Smith",
+        completed: false,
+      });
+      expect(created.id).toBeTruthy();
+      expect(created.created_at).toBeTruthy();
+      expect(tasks.value).toHaveLength(1);
+      expect(tasks.value[0]).toEqual(created);
+
+      expect(readStored()).toEqual([created]);
+    });
+
+    it("appends after existing tasks rather than overwriting them", async () => {
+      const { addTask, tasks } = useUserTasks();
+
+      await addTask("First");
+      await addTask("Second");
+
+      expect(tasks.value.map((t) => t.text)).toEqual(["First", "Second"]);
+      expect(readStored()).toHaveLength(2);
+    });
+
+    it("does not persist when there is no signed-in user", async () => {
+      userStore.user = null;
+      const { addTask, tasks } = useUserTasks();
+
+      await addTask("Ghost task");
+
+      // Task is added to in-memory state, but saveTasks no-ops without a user.
+      expect(tasks.value).toHaveLength(1);
+      expect(readStored()).toBeNull();
+    });
+  });
+
+  describe("fetchTasks (read)", () => {
+    it("loads tasks previously persisted for the user", async () => {
+      const stored = [
+        {
+          id: "task-1",
+          text: "Existing",
+          completed: false,
+          created_at: "2026-01-01T00:00:00.000Z",
+        },
+      ];
+      localStorage.setItem(storageKeyFor(USER_ID), JSON.stringify(stored));
+
+      const { fetchTasks, tasks } = useUserTasks();
+      await fetchTasks();
+
+      expect(tasks.value).toEqual(stored);
+    });
+
+    it("yields an empty list when nothing is stored", async () => {
+      const { fetchTasks, tasks } = useUserTasks();
+      await fetchTasks();
+
+      expect(tasks.value).toEqual([]);
+    });
+
+    it("is a no-op without a signed-in user", async () => {
+      userStore.user = null;
+      const { fetchTasks, tasks, loading } = useUserTasks();
+
+      await fetchTasks();
+
+      expect(tasks.value).toEqual([]);
+      expect(loading.value).toBe(false);
+    });
+
+    it("recovers to an empty list when stored JSON is corrupt", async () => {
+      localStorage.setItem(storageKeyFor(USER_ID), "{not-json");
+
+      const { fetchTasks, tasks, loading } = useUserTasks();
+      await fetchTasks();
+
+      expect(tasks.value).toEqual([]);
+      expect(loading.value).toBe(false);
+    });
+
+    it("scopes storage per user id", async () => {
+      localStorage.setItem(
+        storageKeyFor("other-user"),
+        JSON.stringify([
+          { id: "x", text: "Not mine", completed: false, created_at: "" },
+        ]),
+      );
+
+      const { fetchTasks, tasks } = useUserTasks();
+      await fetchTasks();
+
+      expect(tasks.value).toEqual([]);
+    });
+  });
+
+  describe("updateTask + toggleTask (update)", () => {
+    it("updates task text and persists the change", async () => {
+      const { addTask, updateTask, tasks } = useUserTasks();
+      const created = await addTask("Original");
+
+      await updateTask(created.id, "Revised");
+
+      expect(tasks.value[0].text).toBe("Revised");
+      expect(readStored()[0].text).toBe("Revised");
+    });
+
+    it("ignores updates to an unknown task id", async () => {
+      const { addTask, updateTask, tasks } = useUserTasks();
+      await addTask("Keep me");
+
+      await updateTask("missing-id", "Nope");
+
+      expect(tasks.value[0].text).toBe("Keep me");
+    });
+
+    it("toggles completion on and stamps completed_at", async () => {
+      const { addTask, toggleTask, tasks } = useUserTasks();
+      const created = await addTask("Do the thing");
+
+      await toggleTask(created.id);
+
+      expect(tasks.value[0].completed).toBe(true);
+      expect(tasks.value[0].completed_at).toBeTruthy();
+      expect(readStored()[0].completed).toBe(true);
+    });
+
+    it("toggles completion back off and clears completed_at", async () => {
+      const { addTask, toggleTask, tasks } = useUserTasks();
+      const created = await addTask("Do the thing");
+
+      await toggleTask(created.id);
+      await toggleTask(created.id);
+
+      expect(tasks.value[0].completed).toBe(false);
+      expect(tasks.value[0].completed_at).toBeNull();
+    });
+  });
+
+  describe("deleteTask + clearCompleted (delete)", () => {
+    it("removes a task and persists the removal", async () => {
+      const { addTask, deleteTask, tasks } = useUserTasks();
+      const a = await addTask("A");
+      const b = await addTask("B");
+
+      await deleteTask(a.id);
+
+      expect(tasks.value).toEqual([b]);
+      expect(readStored()).toEqual([b]);
+    });
+
+    it("is a no-op when deleting an unknown task id", async () => {
+      const { addTask, deleteTask, tasks } = useUserTasks();
+      await addTask("Only one");
+
+      await deleteTask("missing-id");
+
+      expect(tasks.value).toHaveLength(1);
+    });
+
+    it("clearCompleted removes only completed tasks", async () => {
+      const { addTask, toggleTask, clearCompleted, tasks } = useUserTasks();
+      const done = await addTask("Done");
+      await addTask("Pending");
+      await toggleTask(done.id);
+
+      await clearCompleted();
+
+      expect(tasks.value.map((t) => t.text)).toEqual(["Pending"]);
+      expect(readStored().map((t: { text: string }) => t.text)).toEqual([
+        "Pending",
+      ]);
+    });
+  });
+
+  describe("computed counts", () => {
+    it("reports pending, completed, and total counts", async () => {
+      const { addTask, toggleTask, taskCount, pendingCount, completedCount } =
+        useUserTasks();
+      const first = await addTask("One");
+      await addTask("Two");
+      await addTask("Three");
+      await toggleTask(first.id);
+
+      expect(taskCount.value).toBe(3);
+      expect(completedCount.value).toBe(1);
+      expect(pendingCount.value).toBe(2);
+    });
+  });
+});

--- a/tests/unit/server/api/athlete/messages-check.post.spec.ts
+++ b/tests/unit/server/api/athlete/messages-check.post.spec.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+/**
+ * The check endpoint fires up to three queries against athlete_messages:
+ *  1. programNote dedupe — select("id")...limit(1), awaited directly
+ *  2. last contact      — select("sent_at")...maybeSingle()
+ *  3. message count     — select("id", { count, head }), awaited after .eq()
+ * The mock branches on the select() call to return each shape.
+ */
+const mockState = {
+  userId: "user-123",
+  resolvedTargetId: "athlete-999",
+  dedupeMatches: [] as { id: string }[],
+  lastSentAt: null as string | null,
+  countToSchool: 0,
+};
+
+vi.mock("~/server/utils/auth", () => ({
+  requireAuth: vi.fn(async () => ({ id: mockState.userId })),
+}));
+
+vi.mock("~/server/utils/athleteAccess", () => ({
+  resolveTargetAthleteId: vi.fn(async () => mockState.resolvedTargetId),
+}));
+
+vi.mock("~/server/utils/logger", () => ({
+  useLogger: vi.fn(() => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+vi.mock("~/server/utils/supabase", () => ({
+  useSupabaseAdmin: vi.fn(() => ({
+    from: () => ({
+      select: (_field: string, opts?: { count?: string; head?: boolean }) => {
+        if (opts?.count) {
+          // count chain — thenable resolving { count } after the .eq() calls
+          const countable: any = {
+            eq: () => countable,
+            then: (resolve: (v: unknown) => void) =>
+              resolve({ count: mockState.countToSchool }),
+          };
+          return countable;
+        }
+        // dedupe + last-contact chains share these builder methods
+        const builder: any = {
+          eq: () => builder,
+          neq: () => builder,
+          order: () => builder,
+          limit: () => builder,
+          maybeSingle: () =>
+            Promise.resolve({
+              data: mockState.lastSentAt
+                ? { sent_at: mockState.lastSentAt }
+                : null,
+              error: null,
+            }),
+          then: (resolve: (v: unknown) => void) =>
+            resolve({ data: mockState.dedupeMatches, error: null }),
+        };
+        return builder;
+      },
+    }),
+  })),
+}));
+
+vi.mock("h3", async () => {
+  const actual = await vi.importActual<typeof import("h3")>("h3");
+  return {
+    ...actual,
+    defineEventHandler: (fn: Function) => fn,
+    readBody: vi.fn(async (event: any) => event._body),
+  };
+});
+
+const { default: handler } = await import(
+  "~/server/api/athlete/messages/check.post"
+);
+
+const ATHLETE_ID = "11111111-1111-4111-8111-111111111111";
+const SCHOOL_ID = "22222222-2222-4222-8222-222222222222";
+
+const makeEvent = (body: unknown) =>
+  ({ node: { req: {}, res: {} }, _body: body }) as any;
+
+describe("POST /api/athlete/messages/check", () => {
+  beforeEach(() => {
+    mockState.userId = "user-123";
+    mockState.resolvedTargetId = "athlete-999";
+    mockState.dedupeMatches = [];
+    mockState.lastSentAt = null;
+    mockState.countToSchool = 0;
+  });
+
+  it("flags programNoteReused when the note was sent to a different program", async () => {
+    mockState.dedupeMatches = [{ id: "prior-msg" }];
+
+    const result = await handler(
+      makeEvent({
+        athleteUserId: ATHLETE_ID,
+        schoolId: SCHOOL_ID,
+        programNote: "Team won state",
+      }),
+    );
+
+    expect(result.programNoteReused).toBe(true);
+  });
+
+  it("does not flag reuse when there is no prior match", async () => {
+    mockState.dedupeMatches = [];
+
+    const result = await handler(
+      makeEvent({
+        athleteUserId: ATHLETE_ID,
+        schoolId: SCHOOL_ID,
+        programNote: "Fresh note",
+      }),
+    );
+
+    expect(result.programNoteReused).toBe(false);
+  });
+
+  it("marks recentContact when last message to the program was < 7 days ago", async () => {
+    mockState.lastSentAt = new Date(
+      Date.now() - 2 * 86_400_000,
+    ).toISOString();
+    mockState.countToSchool = 3;
+
+    const result = await handler(
+      makeEvent({ athleteUserId: ATHLETE_ID, schoolId: SCHOOL_ID }),
+    );
+
+    expect(result.daysSinceLastContact).toBe(2);
+    expect(result.recentContact).toBe(true);
+    expect(result.messageCountToSchool).toBe(3);
+  });
+
+  it("does not mark recentContact when last message was >= 7 days ago", async () => {
+    mockState.lastSentAt = new Date(
+      Date.now() - 10 * 86_400_000,
+    ).toISOString();
+
+    const result = await handler(
+      makeEvent({ athleteUserId: ATHLETE_ID, schoolId: SCHOOL_ID }),
+    );
+
+    expect(result.daysSinceLastContact).toBe(10);
+    expect(result.recentContact).toBe(false);
+  });
+
+  it("returns null timing signals when the athlete has no prior contact", async () => {
+    const result = await handler(
+      makeEvent({ athleteUserId: ATHLETE_ID, schoolId: SCHOOL_ID }),
+    );
+
+    expect(result.daysSinceLastContact).toBeNull();
+    expect(result.recentContact).toBe(false);
+    expect(result.messageCountToSchool).toBe(0);
+  });
+
+  it("rejects a body with a non-uuid athleteUserId", async () => {
+    await expect(
+      handler(makeEvent({ athleteUserId: "not-a-uuid" })),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+});

--- a/tests/unit/server/api/athlete/messages-index.post.spec.ts
+++ b/tests/unit/server/api/athlete/messages-index.post.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockState = {
+  userId: "user-123",
+  resolvedTargetId: "athlete-999",
+  insertedRow: null as Record<string, unknown> | null,
+  insertError: null as { message: string } | null,
+  returnedId: "msg-1",
+};
+
+vi.mock("~/server/utils/auth", () => ({
+  requireAuth: vi.fn(async () => ({ id: mockState.userId })),
+}));
+
+vi.mock("~/server/utils/athleteAccess", () => ({
+  resolveTargetAthleteId: vi.fn(async () => mockState.resolvedTargetId),
+}));
+
+vi.mock("~/server/utils/logger", () => ({
+  useLogger: vi.fn(() => ({
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
+
+vi.mock("~/server/utils/supabase", () => ({
+  useSupabaseAdmin: vi.fn(() => ({
+    from: (table: string) => {
+      expect(table).toBe("athlete_messages");
+      return {
+        insert: (row: Record<string, unknown>) => {
+          mockState.insertedRow = row;
+          return {
+            select: () => ({
+              single: () =>
+                Promise.resolve(
+                  mockState.insertError
+                    ? { data: null, error: mockState.insertError }
+                    : { data: { id: mockState.returnedId }, error: null },
+                ),
+            }),
+          };
+        },
+      };
+    },
+  })),
+}));
+
+vi.mock("h3", async () => {
+  const actual = await vi.importActual<typeof import("h3")>("h3");
+  return {
+    ...actual,
+    defineEventHandler: (fn: Function) => fn,
+    readBody: vi.fn(async (event: any) => event._body),
+  };
+});
+
+const { default: handler } = await import(
+  "~/server/api/athlete/messages/index.post"
+);
+
+const ATHLETE_ID = "11111111-1111-4111-8111-111111111111";
+const SCHOOL_ID = "22222222-2222-4222-8222-222222222222";
+
+const makeEvent = (body: unknown) =>
+  ({ node: { req: {}, res: {} }, _body: body }) as any;
+
+describe("POST /api/athlete/messages", () => {
+  beforeEach(() => {
+    mockState.userId = "user-123";
+    mockState.resolvedTargetId = "athlete-999";
+    mockState.insertedRow = null;
+    mockState.insertError = null;
+    mockState.returnedId = "msg-1";
+  });
+
+  it("logs a message against the resolved target athlete and returns its id", async () => {
+    const result = await handler(
+      makeEvent({
+        athleteUserId: ATHLETE_ID,
+        schoolId: SCHOOL_ID,
+        templateSlug: "intro-standard",
+        channel: "email",
+        programNote: "  Team won state  ",
+      }),
+    );
+
+    expect(result).toEqual({ success: true, id: "msg-1" });
+    expect(mockState.insertedRow).toMatchObject({
+      user_id: "athlete-999",
+      school_id: SCHOOL_ID,
+      template_slug: "intro-standard",
+      channel: "email",
+      program_note: "Team won state", // trimmed
+      created_by: "user-123",
+    });
+  });
+
+  it("nulls out an empty program note rather than storing whitespace", async () => {
+    await handler(
+      makeEvent({ athleteUserId: ATHLETE_ID, programNote: "   " }),
+    );
+    expect(mockState.insertedRow?.program_note).toBeNull();
+  });
+
+  it("rejects a body with a non-uuid athleteUserId", async () => {
+    await expect(
+      handler(makeEvent({ athleteUserId: "not-a-uuid" })),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("throws 500 when the insert fails", async () => {
+    mockState.insertError = { message: "db down" };
+    await expect(
+      handler(makeEvent({ athleteUserId: ATHLETE_ID })),
+    ).rejects.toMatchObject({ statusCode: 500 });
+  });
+});

--- a/tests/unit/server/api/video-links/crud.spec.ts
+++ b/tests/unit/server/api/video-links/crud.spec.ts
@@ -129,6 +129,102 @@ describe("POST /api/video-links", () => {
   });
 });
 
+describe("PATCH /api/video-links/:id", () => {
+  const VALID_ID = "11111111-1111-1111-1111-111111111111";
+
+  // Capture the object passed to .update() so we can assert the health-reset
+  // side effect. Returns whatever `data` the caller wires up.
+  const stubUpdate = (data: unknown, captured: { update?: unknown }) => {
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === "video_links") {
+        return {
+          update: (payload: unknown) => {
+            captured.update = payload;
+            return {
+              eq: () => ({
+                eq: () => ({
+                  select: () => ({
+                    maybeSingle: () => Promise.resolve({ data, error: null }),
+                  }),
+                }),
+              }),
+            };
+          },
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    });
+  };
+
+  it("rejects a parent with 403", async () => {
+    mockAssertNotParent.mockRejectedValueOnce(
+      Object.assign(new Error("Parents cannot perform this action."), {
+        statusCode: 403,
+      }),
+    );
+
+    const handler = (await import("~/server/api/video-links/[id].patch"))
+      .default;
+    await expect(handler(fakeEvent({ id: VALID_ID }))).rejects.toMatchObject({
+      statusCode: 403,
+    });
+  });
+
+  it("rejects an invalid body with 422", async () => {
+    mockReadBody.mockResolvedValue({ platform: "not-a-real-platform" });
+
+    const handler = (await import("~/server/api/video-links/[id].patch"))
+      .default;
+    await expect(handler(fakeEvent({ id: VALID_ID }))).rejects.toMatchObject({
+      statusCode: 422,
+    });
+  });
+
+  it("returns 404 when the video link is not owned by the caller", async () => {
+    const captured: { update?: unknown } = {};
+    stubUpdate(null, captured);
+    mockReadBody.mockResolvedValue({ title: "New title" });
+
+    const handler = (await import("~/server/api/video-links/[id].patch"))
+      .default;
+    await expect(handler(fakeEvent({ id: VALID_ID }))).rejects.toMatchObject({
+      statusCode: 404,
+    });
+  });
+
+  it("updates a non-url field without touching health-check state", async () => {
+    const captured: { update?: unknown } = {};
+    stubUpdate({ id: VALID_ID, title: "New title" }, captured);
+    mockReadBody.mockResolvedValue({ title: "New title" });
+
+    const handler = (await import("~/server/api/video-links/[id].patch"))
+      .default;
+    const res = (await handler(fakeEvent({ id: VALID_ID }))) as {
+      videoLink: { id: string };
+    };
+
+    expect(res.videoLink.id).toBe(VALID_ID);
+    expect(captured.update).toMatchObject({ title: "New title" });
+    expect(captured.update).not.toHaveProperty("health_status");
+  });
+
+  it("resets health-check state when the url is edited", async () => {
+    const captured: { update?: unknown } = {};
+    stubUpdate({ id: VALID_ID }, captured);
+    mockReadBody.mockResolvedValue({ url: "https://youtube.com/watch?v=new" });
+
+    const handler = (await import("~/server/api/video-links/[id].patch"))
+      .default;
+    await handler(fakeEvent({ id: VALID_ID }));
+
+    expect(captured.update).toMatchObject({
+      url: "https://youtube.com/watch?v=new",
+      health_status: "unknown",
+      last_health_check: null,
+    });
+  });
+});
+
 describe("DELETE /api/video-links/:id", () => {
   it("returns 404 when the video link is not owned by the caller", async () => {
     mockSupabase.from.mockImplementation((table: string) => {


### PR DESCRIPTION
## Summary

Pre-release CRUD coverage audit found the entities with no create/update/delete tests. This fills them and fixes two real bugs surfaced along the way.

### Coverage added
- **User tasks** (`useUserTasks`) — unit CRUD (add/update/toggle/delete/clearCompleted), localStorage persistence, no-user + corrupt-JSON edges.
- **Athlete messages** — `useAthleteMessages` (logSend/checkSend) unit; `POST /api/athlete/messages` (log insert) + `POST /api/athlete/messages/check` (outreach guardrails) server unit.
- **Performance metrics** — tier1 `metrics-crud-atomic` E2E lifecycle.
- **Communication templates** — tier1 `templates-crud-atomic` E2E lifecycle.

### Bugs fixed (TDD-surfaced)
1. **User-task id collision** — ids were `task-${Date.now()}`, so two tasks added in the same millisecond shared an id and deleting/toggling/updating one hit both (data loss). Now `crypto.randomUUID()` with a random-suffix fallback.
2. **Stale template list** — `TemplateEditor` mutates its own `useCommunicationTemplates()` instance (per-call refs) and `onTemplateSaved`/`onTemplateDeleted` only switched tabs, so a created/deleted template didn't appear/disappear in "My Templates" until a full page reload. Both handlers now refetch.

## Test plan
- Unit: 30 new tests green (`useUserTasks`, `useAthleteMessages`, both message endpoints).
- E2E: both `*-crud-atomic` specs green locally on a node-server preview build (chromium).
- `nuxi typecheck` + `eslint .` pass (pre-push gate).

## Not covered (flagged, not gaps)
- Video-links API has no PATCH/update case.
- User-tasks E2E skipped (localStorage widget, low value vs flake risk).
- Social handles aren't a discrete add/delete entity.

https://claude.ai/code/session_01YDtRZb488wxdTp5wFF7o4R