### PR TITLE
feat: inbound coach messages from public profile become tracked interactions

### DIFF
--- a/components/profile/AssignCoachModal.vue
+++ b/components/profile/AssignCoachModal.vue
@@ -1,0 +1,352 @@
+<template>
+  <Teleport to="body">
+    <Transition name="fade">
+      <div
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="assign-coach-title"
+        @keydown.escape="handleClose"
+      >
+        <div
+          class="max-h-[90vh] w-full max-w-lg overflow-auto rounded-xl border border-slate-200 bg-white shadow-xl"
+        >
+          <!-- Header -->
+          <div
+            class="flex items-center justify-between border-b border-slate-200 p-6"
+          >
+            <h2
+              id="assign-coach-title"
+              class="text-xl font-bold text-slate-900"
+            >
+              Assign to a coach
+            </h2>
+            <button
+              aria-label="Close assign coach dialog"
+              class="text-2xl text-slate-500 transition hover:text-slate-900"
+              @click="handleClose"
+            >
+              &times;
+            </button>
+          </div>
+
+          <div class="space-y-6 p-6">
+            <!-- School resolver -->
+            <div v-if="!props.presetSchoolId">
+              <label
+                for="school-select"
+                class="mb-1 block text-sm font-medium text-slate-500"
+              >
+                School
+              </label>
+              <select
+                id="school-select"
+                v-model="schoolId"
+                data-test="school-select"
+                class="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-slate-900 focus:ring-2 focus:ring-brand-blue-500/20"
+              >
+                <option value="">Select a school&hellip;</option>
+                <option
+                  v-for="school in schools"
+                  :key="school.id"
+                  :value="school.id"
+                >
+                  {{ school.name }}
+                </option>
+              </select>
+            </div>
+
+            <!-- Coach step -->
+            <div v-if="schoolId" class="space-y-3">
+              <div v-if="existingCoaches.length > 0">
+                <label
+                  for="coach-select"
+                  class="mb-1 block text-sm font-medium text-slate-500"
+                >
+                  Existing coaches at this school
+                </label>
+                <select
+                  id="coach-select"
+                  v-model="selectedCoachId"
+                  data-test="existing-coach-select"
+                  class="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-slate-900 focus:ring-2 focus:ring-brand-blue-500/20"
+                  @change="creatingNew = false"
+                >
+                  <option value="">Select an existing coach&hellip;</option>
+                  <option
+                    v-for="coach in existingCoaches"
+                    :key="coach.id"
+                    :value="coach.id"
+                  >
+                    {{ coach.first_name }} {{ coach.last_name }}
+                  </option>
+                </select>
+              </div>
+
+              <button
+                type="button"
+                data-test="create-new-coach"
+                class="text-sm font-medium text-brand-blue-600 hover:text-brand-blue-700"
+                @click="startCreateNew"
+              >
+                + Create new coach
+              </button>
+
+              <div v-if="creatingNew" class="grid grid-cols-2 gap-4">
+                <div>
+                  <label
+                    for="new-first-name"
+                    class="mb-1 block text-sm font-medium text-slate-500"
+                  >
+                    First Name
+                  </label>
+                  <input
+                    id="new-first-name"
+                    v-model="newCoach.first_name"
+                    type="text"
+                    data-test="new-coach-first-name"
+                    class="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-slate-900 focus:ring-2 focus:ring-brand-blue-500/20"
+                  />
+                </div>
+                <div>
+                  <label
+                    for="new-last-name"
+                    class="mb-1 block text-sm font-medium text-slate-500"
+                  >
+                    Last Name
+                  </label>
+                  <input
+                    id="new-last-name"
+                    v-model="newCoach.last_name"
+                    type="text"
+                    data-test="new-coach-last-name"
+                    class="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-slate-900 focus:ring-2 focus:ring-brand-blue-500/20"
+                  />
+                </div>
+                <div class="col-span-2">
+                  <label
+                    for="new-email"
+                    class="mb-1 block text-sm font-medium text-slate-500"
+                  >
+                    Email
+                  </label>
+                  <input
+                    id="new-email"
+                    v-model="newCoach.email"
+                    type="email"
+                    data-test="new-coach-email"
+                    class="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-slate-900 focus:ring-2 focus:ring-brand-blue-500/20"
+                  />
+                </div>
+                <div class="col-span-2">
+                  <label
+                    for="new-role"
+                    class="mb-1 block text-sm font-medium text-slate-500"
+                  >
+                    Role
+                  </label>
+                  <select
+                    id="new-role"
+                    v-model="newCoach.role"
+                    data-test="new-coach-role"
+                    class="w-full rounded-lg border border-slate-300 bg-white px-4 py-2 text-slate-900 focus:ring-2 focus:ring-brand-blue-500/20"
+                  >
+                    <option value="head">Head Coach</option>
+                    <option value="assistant">Assistant Coach</option>
+                    <option value="recruiting">Recruiting Coordinator</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+
+            <DesignSystemErrorState v-if="submitError" :error="submitError" />
+
+            <!-- Actions -->
+            <div class="flex gap-4 border-t border-slate-200 pt-4">
+              <DesignSystemButton
+                data-test="confirm-assign"
+                :disabled="!canConfirm"
+                :loading="submitting"
+                full-width
+                @click="handleConfirm"
+              >
+                {{ submitting ? "Assigning..." : "Assign & Log Interaction" }}
+              </DesignSystemButton>
+              <DesignSystemButton
+                variant="outline"
+                color="slate"
+                full-width
+                @click="handleClose"
+              >
+                Cancel
+              </DesignSystemButton>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref, watch } from "vue";
+import { useCoachStore } from "~/stores/coaches";
+import { useSchoolStore } from "~/stores/schools";
+import { useInteractions } from "~/composables/useInteractions";
+import { useProfileContacts, type ProfileLead } from "~/composables/useProfileContacts";
+import { useFamilyContext } from "~/composables/useFamilyContext";
+import { createClientLogger } from "~/utils/logger";
+import type { Coach } from "~/types/models";
+
+const logger = createClientLogger("AssignCoachModal");
+
+const props = withDefaults(
+  defineProps<{ lead: ProfileLead; presetSchoolId?: string }>(),
+  { presetSchoolId: undefined },
+);
+
+const emit = defineEmits<{ resolved: []; close: [] }>();
+
+const coachStore = useCoachStore();
+const schoolStore = useSchoolStore();
+const { createInteraction } = useInteractions();
+const { resolveLead } = useProfileContacts();
+const { activeFamilyId } = useFamilyContext();
+
+const schools = computed(() => schoolStore.schools);
+
+function splitName(full: string): { first: string; last: string } {
+  const trimmed = full.trim();
+  const lastSpace = trimmed.lastIndexOf(" ");
+  if (lastSpace === -1) {
+    return { first: trimmed, last: "" };
+  }
+  return {
+    first: trimmed.slice(0, lastSpace).trim(),
+    last: trimmed.slice(lastSpace + 1).trim(),
+  };
+}
+
+const schoolId = ref(props.presetSchoolId ?? "");
+const selectedCoachId = ref("");
+const creatingNew = ref(false);
+const submitting = ref(false);
+const submitError = ref<string | null>(null);
+
+const { first: prefilledFirst, last: prefilledLast } = splitName(
+  props.lead.coach_name,
+);
+
+const newCoach = ref({
+  first_name: prefilledFirst,
+  last_name: prefilledLast,
+  email: props.lead.coach_email ?? "",
+  role: "head" as Coach["role"],
+});
+
+const existingCoaches = computed(() =>
+  coachStore.coaches.filter((c: Coach) => c.school_id === schoolId.value),
+);
+
+function startCreateNew() {
+  creatingNew.value = true;
+  selectedCoachId.value = "";
+}
+
+const canConfirm = computed(() => {
+  if (!schoolId.value) return false;
+  if (creatingNew.value) {
+    return (
+      newCoach.value.first_name.trim().length > 0 &&
+      newCoach.value.last_name.trim().length > 0
+    );
+  }
+  return selectedCoachId.value.length > 0;
+});
+
+onMounted(async () => {
+  if (!schoolId.value && activeFamilyId.value) {
+    await schoolStore.fetchSchools(activeFamilyId.value);
+    const match = (schools.value as { id: string; name: string }[]).find(
+      (s) =>
+        props.lead.school_name &&
+        s.name.toLowerCase() === props.lead.school_name.toLowerCase(),
+    );
+    if (match) schoolId.value = match.id;
+  }
+});
+
+watch(
+  schoolId,
+  async (id) => {
+    if (id) await coachStore.fetchCoaches(id);
+  },
+  { immediate: true },
+);
+
+async function handleConfirm() {
+  if (!canConfirm.value || !schoolId.value) return;
+
+  submitting.value = true;
+  submitError.value = null;
+
+  try {
+    let coachId = selectedCoachId.value;
+
+    if (creatingNew.value) {
+      const created = await coachStore.createCoach(schoolId.value, {
+        first_name: newCoach.value.first_name,
+        last_name: newCoach.value.last_name,
+        email: newCoach.value.email || null,
+        role: newCoach.value.role,
+        phone: null,
+        twitter_handle: null,
+        instagram_handle: null,
+        notes: null,
+        tags: [],
+        source: "Public profile lead",
+        last_contact_date: null,
+      });
+      coachId = created.id;
+    }
+
+    const interaction = await createInteraction({
+      school_id: schoolId.value,
+      coach_id: coachId,
+      type: props.lead.type === "interest" ? "interest" : "email",
+      direction: "inbound",
+      occurred_at: new Date().toISOString(),
+      content: props.lead.note ?? "",
+      subject:
+        props.lead.type === "interest"
+          ? "Interest via public profile"
+          : "Contact via public profile",
+    });
+
+    await resolveLead(props.lead.id, interaction.id);
+    emit("resolved");
+  } catch (err) {
+    logger.error("Failed to assign coach and log interaction", err);
+    submitError.value =
+      "Couldn't assign this lead. Please try again.";
+  } finally {
+    submitting.value = false;
+  }
+}
+
+function handleClose() {
+  emit("close");
+}
+</script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/components/profile/ProfileInbox.vue
+++ b/components/profile/ProfileInbox.vue
@@ -2,6 +2,35 @@
   <div class="space-y-6">
     <StatsTiles :stats="inboxStats" aria-label="Inbound Leads Statistics" />
 
+    <div class="flex items-center justify-end gap-2 text-sm">
+      <button
+        type="button"
+        data-test="filter-open"
+        class="rounded-full px-3 py-1 font-medium transition"
+        :class="
+          filter === 'open'
+            ? 'bg-brand-blue-600 text-white'
+            : 'text-slate-500 hover:text-slate-900'
+        "
+        @click="filter = 'open'"
+      >
+        Open
+      </button>
+      <button
+        type="button"
+        data-test="filter-all"
+        class="rounded-full px-3 py-1 font-medium transition"
+        :class="
+          filter === 'all'
+            ? 'bg-brand-blue-600 text-white'
+            : 'text-slate-500 hover:text-slate-900'
+        "
+        @click="filter = 'all'"
+      >
+        All
+      </button>
+    </div>
+
     <DesignSystemLoadingState
       v-if="loading"
       message="Loading your inbox..."
@@ -18,7 +47,7 @@
     />
     <ul v-else class="space-y-3">
       <li
-        v-for="lead in leads"
+        v-for="lead in visibleLeads"
         :key="lead.id"
         class="rounded-xl border border-slate-200 bg-white p-4 shadow-xs"
       >
@@ -32,6 +61,22 @@
               >
                 {{ lead.type === "interest" ? "Interest" : "Contact" }}
               </DesignSystemBadge>
+              <DesignSystemBadge
+                v-if="lead.status === 'pending'"
+                color="orange"
+                variant="light"
+                size="sm"
+              >
+                Needs coach
+              </DesignSystemBadge>
+              <DesignSystemBadge
+                v-else-if="lead.status === 'resolved'"
+                color="emerald"
+                variant="light"
+                size="sm"
+              >
+                Tracked
+              </DesignSystemBadge>
               <span class="truncate font-semibold text-slate-900">{{
                 lead.coach_name
               }}</span>
@@ -44,6 +89,34 @@
             <p v-if="lead.note" class="mt-2 line-clamp-2 text-sm text-slate-500">
               {{ lead.note }}
             </p>
+            <div
+              v-if="lead.status === 'pending'"
+              class="mt-3 flex items-center gap-2"
+            >
+              <button
+                type="button"
+                :data-test="`assign-coach-${lead.id}`"
+                class="rounded-lg bg-brand-blue-600 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-brand-blue-700"
+                @click="activeLead = lead"
+              >
+                Assign coach
+              </button>
+              <button
+                type="button"
+                :data-test="`dismiss-${lead.id}`"
+                class="rounded-lg border border-slate-300 px-3 py-1.5 text-sm font-medium text-slate-600 transition hover:bg-slate-50"
+                @click="dismissLead(lead.id)"
+              >
+                Dismiss
+              </button>
+            </div>
+            <NuxtLink
+              v-else-if="lead.status === 'resolved' && lead.interaction_id"
+              :to="`/interactions/${lead.interaction_id}`"
+              class="mt-3 inline-block text-sm font-medium text-brand-blue-600 hover:underline"
+            >
+              View interaction
+            </NuxtLink>
           </div>
           <span class="shrink-0 text-xs whitespace-nowrap text-slate-400">
             {{ formatLeadDate(lead.created_at) }}
@@ -51,15 +124,41 @@
         </div>
       </li>
     </ul>
+
+    <AssignCoachModal
+      v-if="activeLead"
+      :lead="activeLead"
+      @resolved="onResolved"
+      @close="activeLead = null"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import StatsTiles from "~/components/shared/StatsTiles.vue";
-import { useProfileContacts } from "~/composables/useProfileContacts";
+import AssignCoachModal from "~/components/profile/AssignCoachModal.vue";
+import {
+  useProfileContacts,
+  type ProfileLead,
+} from "~/composables/useProfileContacts";
 
-const { leads, counts, loading, error, fetchContacts } = useProfileContacts();
+const { leads, counts, loading, error, fetchContacts, dismissLead } =
+  useProfileContacts();
+
+const filter = ref<"open" | "all">("open");
+const activeLead = ref<ProfileLead | null>(null);
+
+const visibleLeads = computed(() =>
+  filter.value === "all"
+    ? leads.value
+    : leads.value.filter((lead) => lead.status !== "dismissed"),
+);
+
+function onResolved(): void {
+  activeLead.value = null;
+  fetchContacts();
+}
 
 const inboxStats = computed(() => [
   {

--- a/composables/useActivityFeed.ts
+++ b/composables/useActivityFeed.ts
@@ -94,6 +94,7 @@ export const useActivityFeed = () => {
       unofficial_visit: "🏫",
       official_visit: "🎓",
       other: "📝",
+      interest: "🙋",
     };
     return iconMap[type] || "📝";
   };

--- a/composables/useInteractions.ts
+++ b/composables/useInteractions.ts
@@ -251,9 +251,6 @@ export const useInteractions = () => {
     files?: File[],
   ) => {
     if (!userStore.user) throw new Error("User not authenticated");
-    if (userStore.user.role !== "player") {
-      throw new Error("Only players can create interactions");
-    }
     if (!activeFamily.activeFamilyId.value) {
       throw new Error("No family context available");
     }

--- a/composables/useProfileContacts.ts
+++ b/composables/useProfileContacts.ts
@@ -17,6 +17,8 @@ export interface ProfileLead {
   program: string | null;
   note: string | null;
   matched_coach_id: string | null;
+  status: "pending" | "resolved" | "dismissed";
+  interaction_id: string | null;
   created_at: string;
 }
 

--- a/composables/useProfileContacts.ts
+++ b/composables/useProfileContacts.ts
@@ -61,7 +61,31 @@ export function useProfileContacts() {
     }
   }
 
+  async function resolveLead(id: string, interactionId: string): Promise<void> {
+    await $fetchAuth(`/api/player/profile/contacts/${id}/resolve`, {
+      method: "POST",
+      body: { status: "resolved", interactionId },
+    });
+    await fetchContacts();
+  }
+
+  async function dismissLead(id: string): Promise<void> {
+    await $fetchAuth(`/api/player/profile/contacts/${id}/resolve`, {
+      method: "POST",
+      body: { status: "dismissed" },
+    });
+    await fetchContacts();
+  }
+
   onMounted(() => fetchContacts());
 
-  return { leads, counts, loading, error, fetchContacts };
+  return {
+    leads,
+    counts,
+    loading,
+    error,
+    fetchContacts,
+    resolveLead,
+    dismissLead,
+  };
 }

--- a/planning/DESIGN_public-profile-inbound-to-interaction-2026-08-27.md
+++ b/planning/DESIGN_public-profile-inbound-to-interaction-2026-08-27.md
@@ -1,0 +1,192 @@
+# Design — Public-profile inbound coach messages → tracked interactions
+
+**Date:** 2026-08-27
+**Author:** Chris + Claude
+**Status:** Draft, pending review — updated with code investigation 2026-08-27
+**Related:** Public Player Profile feature (PR #487, #512, #516); coach `last_contact_date` trigger; `createInboundInteractionAlert` nudge system.
+
+---
+
+## Investigation findings (verified against code 2026-08-27)
+
+Read the real files, not just the summary. Corrections to first-draft assumptions:
+
+1. **This was half-built on purpose.** `matchCoachByEmail.ts` docstring literally says: *"an unmatched email logs the interaction with coach_id=NULL, and the player links/creates the coach later."* That intended interaction-logging **never shipped** — blocked by `interactions.school_id` NOT NULL (a coach-less lead has no school id). That's why Chris "thought this was already worked on." The matcher and lead capture landed; the interaction step did not.
+2. **The reach-out nudge is SCHOOL-based, not coach-based.** `server/utils/rules/interactionGap.ts` keys `calculateDaysSinceContact` off `interaction.school_id` and only fires for priority A/B schools with status interested/contacted/visited. So what feeds the nudge is a correct `school_id` on the interaction (a matched coach supplies it via `coaches.school_id`, NOT NULL). Coach linkage separately drives coach detail, `last_contact_date` trigger, and coach analytics. Both matter; they're different systems.
+3. **`useInteractions.create` already fires `createInboundInteractionAlert` for `direction:"inbound"`** (composables/useInteractions.ts:320). A client-side assign path gets the inbound alert for free — no manual call.
+4. **The public endpoints already write their own `notifications` row** (`type: inbound_interaction`, `related_entity_type: "profile_contact"`). The matched path must NOT also fire `createInboundInteractionAlert` or we double-notify. Keep the single endpoint notification; repoint `related_entity_type/id` to the new interaction when one is created.
+5. **`matchCoachByEmail` returns only `{ coachId }`** — selects `id` alone. Must extend to also return `schoolId` (`select("id, school_id")`) so the matched-path interaction can set `school_id`.
+6. **`CoachSelect.vue` is school-scoped** — filters coaches by a required `schoolId` prop. NOT a drop-in for cross-school lead assignment (the lead's school is free-text `school_name`, often no id). Assignment must resolve/create the school first, then pick/create the coach within it.
+7. **Coach + interaction creation already exist client-side under RLS:** `stores/coaches.ts createCoach(schoolId, data)` and `useInteractions.create`. The assign flow should REUSE these (DRY) rather than a server-side re-implementation. A server `assign.post.ts` that re-does coach+interaction+school inserts with the admin client would duplicate all of it.
+8. **`profile_contacts` has no `status`/`interaction_id` columns** (verified in types/database.ts:2028). Migration required. `matched_coach_id` FK to coaches already exists.
+9. **Interest can be identity-less:** `interest.post.ts` makes `coachName` optional and `program` required; an interest submission may carry no coach name AND no email → nothing to match or assign. Contact requires `coachName` + `note`. This splits behavior (see Open Questions #1/#5).
+
+---
+
+## Problem
+
+Coaches contact players through the public profile page (`pages/p/[slug].vue`) via two forms:
+
+- **Contact** (`ContactPlayerModal.vue` → `POST /api/public/profile/[slug]/contact`)
+- **Express Interest** (`ExpressInterestPopover.vue` → `POST /api/public/profile/[slug]/interest`)
+
+Today each submission writes **only**:
+
+1. A `profile_contacts` lead row (with `matched_coach_id` populated *only if* the coach's email already exists in that family's `coaches`).
+2. A `notifications` row (`type: inbound_interaction`, linked to the lead).
+3. A notification email.
+
+**It never creates an `interactions` row.** So inbound coach outreach never appears on the interactions page, never feeds interaction analytics, and never triggers the per-coach "reach out after X days" relationship nudges (`createInboundInteractionAlert`, gap-rules). The public-profile redesign shipped lead capture + email-matching but stopped short of the interaction. This closes that gap.
+
+## Goal
+
+Inbound coach messages become **first-class, coach-linked interactions** on the interactions page — without polluting the `coaches` table with orphaned or duplicate records that would break per-coach relationship tracking.
+
+### Non-goals
+
+- No auto-creation of coach records from unauthenticated public input (the source of orphans/dupes).
+- No schema change to `interactions` (school_id / logged_by stay NOT NULL).
+- iOS parity of the *assignment UI* is a follow-up (see Parity), not part of this slice. The interactions these produce already render on iOS.
+
+---
+
+## Key constraints (why the design is shaped this way)
+
+`interactions` requires:
+
+- `school_id` **NOT NULL** (FK schools)
+- `logged_by` **NOT NULL** (FK users)
+- `coach_id` nullable, but the email matcher returns `null` for unknown coaches and **deliberately never creates a coach**.
+
+A matched coach carries a NOT-NULL `school_id`, so a matched interaction satisfies every constraint with no invention. An *unmatched* lead has neither a coach nor (reliably) a real `school_id` — only free-text `school_name`. Rather than nullable-hack the schema or fabricate a school, the unmatched lead **defers** interaction creation until a human assigns the coach (which supplies the school).
+
+Chris's stated risk (verbatim intent): prioritize the interaction, but **orphaned/duplicate coach records would hinder relationship-building and the reach-out nudges**. The human dedup gate below is the core of the design, not an afterthought.
+
+---
+
+## Design
+
+### Two outcomes at submission time
+
+**A. Email matches an existing coach** (`matchCoachByEmail` returns an id):
+Create the `interactions` row immediately, server-side (service-role admin client, mirroring how `profile_contacts`/`notifications` are already written):
+
+| column | value |
+|---|---|
+| `coach_id` | matched coach id |
+| `school_id` | matched coach's `school_id` (NOT NULL satisfied) |
+| `family_unit_id` | from the profile |
+| `logged_by` | the player's `user_id` (owner of the profile) |
+| `direction` | `inbound` |
+| `type` | `email` for Contact; new `interest` enum value for Interest (per decision #1) |
+| `occurred_at` | submission time |
+| `subject` / `content` | derived from lead note / form |
+| `source` marker | tie back to the `profile_contacts` row (see Traceability) |
+
+Notifications: the endpoint **already** writes one `inbound_interaction` notification per submission — keep it, just repoint `related_entity_type: "interaction"` / `related_entity_id` to the new interaction. Do **not** additionally call `createInboundInteractionAlert` (that would double-notify; it's the client composable's job on the assign path). The school-based reach-out nudge (`interactionGapRule`) now sees this interaction under `coaches.school_id`; coach `last_contact_date` updates via `trg_stamp_coach_last_contact` (AFTER INSERT). Requires extending `matchCoachByEmail` to also return `schoolId`.
+
+**B. No email match** (unknown email, or name-only):
+Do **not** create a coach. Do **not** create an interaction yet. The `profile_contacts` row stands as a **pending-assignment** lead (it already stores everything: `coach_name`, `coach_email`, `coach_title`, `school_name`, `program`, `note`). Surface it for resolution (below).
+
+### The human dedup gate — "Assign coach"
+
+The pending lead gets an **Assign coach** action, surfaced in two places:
+
+1. The player inbox card (`ProfileInbox.vue`) — currently read-only; add the CTA.
+2. A notification / badge so it's not lost ("1 coach message needs assignment").
+
+The action opens a **new lightweight assignment modal** (NOT `CoachSelect` as-is — that's school-scoped and needs a school id the lead lacks). Flow, reusing existing client-side actions under RLS:
+
+1. **Resolve the school first** — match the lead's `school_name` against the family's `schools`; suggest the hit, or let the user pick/add a school via the existing school-add flow. School id is the prerequisite for both coach creation and the interaction's NOT-NULL `school_id`.
+2. **Then suggest likely-existing coaches** within that school (and a family-wide fuzzy pass on `coach_name`) — the dedup step: steer to link, not recreate.
+3. Link to an existing coach, OR **create a new coach** via `stores/coaches.ts createCoach(schoolId, …)`, pre-filled from the lead (`coach_name` split to first/last, `coach_email`, `coach_title`).
+4. Mint the interaction via `useInteractions.create` (`direction: inbound`, `coach_id`, `school_id`) — which **auto-fires** `createInboundInteractionAlert`. No server re-implementation.
+
+On confirm, this **mints the interaction** and marks the lead resolved (small authed `resolve` endpoint sets `status` + `interaction_id`, or an RLS update on `profile_contacts`). This is the single place a coach can be born from a public lead — always human-confirmed, always dedup-suggested. All three of Chris's failure modes are structurally prevented:
+
+- **Orphan interaction** → never exists; the lead is the visible, alerted pending state until assigned.
+- **Auto-created coach needing school confirmation** → never happens; creation is explicit in the picker with school shown.
+- **Duplicate coach / needing merge** → picker surfaces the existing candidate first, so the user links instead of duplicating.
+
+### Traceability
+
+Link each interaction back to its originating lead so we never double-convert and can show provenance. Options (decide in plan): a nullable `profile_contact_id` FK on `interactions`, OR a resolution status + `interaction_id` on `profile_contacts`. Leaning `profile_contacts` gaining `status` (`pending` | `resolved` | `dismissed`) + `interaction_id` — keeps the change on the lead table, avoids touching `interactions` schema, and lets the inbox filter pending vs resolved. Matched (outcome A) leads are written `resolved` with their `interaction_id` at submission.
+
+---
+
+## Data flow
+
+```
+Coach submits Contact/Interest  (public, unauth)
+        │
+        ▼
+server endpoint  (contact.post.ts / interest.post.ts)
+        │  matchCoachByEmail(family, email)   [read-only, never creates]
+        ├── match ──► insert interactions (coach_id, coach.school_id, logged_by=player,
+        │                inbound)  → inbound nudge + last_contact trigger
+        │             write profile_contacts { status: resolved, interaction_id }
+        │             notification + email  (unchanged)
+        │
+        └── no match ► write profile_contacts { status: pending }   (no coach, no interaction)
+                       notification + email  (unchanged)
+                                    │
+                        ┌───────────┘  (later, authenticated player)
+                        ▼
+             ProfileInbox "Assign coach" → CoachSelect picker
+                        │  fuzzy-suggest existing coaches (dedup)
+                        ├── link existing ─┐
+                        └── create new  ───┤ (pre-filled, human-confirmed)
+                                           ▼
+                              mint interactions (coach_id, coach.school_id,
+                                 logged_by=player, inbound) → nudge + trigger
+                              profile_contacts { status: resolved, interaction_id }
+```
+
+## Components touched
+
+**Server**
+- `server/utils/matchCoachByEmail.ts` — return `{ coachId, schoolId }` (select `id, school_id`).
+- `server/api/public/profile/[slug]/contact.post.ts` — on match: insert interaction (admin client), repoint the existing notification to it, write lead `status: resolved` + `interaction_id`. On no match: write `status: pending` (else unchanged).
+- `server/api/public/profile/[slug]/interest.post.ts` — same, gated on having a coach identity (see Open Q #5).
+- Shared helper `server/utils/createInboundInteractionFromLead.ts` — the **matched-path** server insert only (column mapping in one place). The assign path does NOT use it — it reuses client stores.
+- New authed `server/api/player/profile/contacts/[id]/resolve.post.ts` — sets `status` + `interaction_id` after the client mints the coach/interaction; family-scope + double-convert guard.
+
+**Client** (assign path reuses existing actions — DRY)
+- `components/profile/ProfileInbox.vue` — pending badge + "Assign coach" CTA; filter resolved/pending.
+- `composables/useProfileContacts.ts` — carry `status` / `interaction_id`; add `resolveLead` action.
+- New assignment modal — school-first resolve (existing school-add flow) → coach pick/create via `stores/coaches.ts createCoach` → `useInteractions.create` → `resolve` endpoint. Not `CoachSelect` as-is.
+
+**Read endpoint**
+- `server/api/player/profile/contacts.get.ts` — add `status`, `interaction_id` to the SELECT so the inbox can filter/label.
+
+**DB (migration, applied live via MCP per repo convention)**
+- `interaction_type` enum: add value `interest` (per decision #1). Enum-add is non-transactional in PG — its own migration, before any use. Audit `type`-switch sites (interaction icons/labels, analytics groupers) for exhaustiveness so a new value doesn't fall through.
+- `profile_contacts`: add `status` (`pending`|`resolved`|`dismissed`, default `pending`) + `interaction_id` (nullable FK interactions). Backfill existing rows: `resolved` if `matched_coach_id` present else `pending`. No change to `interactions` table shape.
+
+## Error handling
+
+- Match path interaction insert fails → still write the lead as `pending` (don't lose the message); log server-side. The message surviving beats the interaction.
+- Assign with a school that has no `schools` row → creating the coach requires a school anyway (coaches.school_id NOT NULL); the picker's create-coach path resolves/creates the school as coach creation already does today. Reuse that path; don't invent a new one.
+- Double-convert guard: assign endpoint no-ops if lead already `resolved` (returns existing `interaction_id`).
+
+## Testing
+
+- Unit: `createInboundInteractionFromLead` column mapping (matched → correct school/coach/logged_by/direction).
+- Unit: assign endpoint — link-existing vs create-new; double-convert no-op; unauth rejected; family-scope enforced.
+- Unit: backfill logic classification (matched→resolved, else pending).
+- Integration/E2E: public Contact submit with a seeded matching coach → interaction appears on interactions page, inbound nudge scheduled. Unmatched submit → pending card → assign → interaction appears.
+- Regression: existing contact/interest tests (notification + email + lead) still green.
+
+## Parity (web/iOS)
+
+The interactions produced here already display on iOS (shared `interactions` table). The **assignment UI** (pending inbox + coach picker) is web-only in this slice; log an iOS handoff for the pending-assignment inbox + assign flow so a coach message can be resolved on mobile too. Flag, not block.
+
+---
+
+## Resolved decisions (Chris, 2026-08-27)
+
+1. **Interest → new `interaction_type` value `interest`** (not `other`). Contact→`email`, Interest→`interest`. Lets Interest-button usage be tracked as a first-class interaction type. Adds an enum-value migration + a switch/label audit.
+2. **No auto-link on name.** Only email-exact match auto-creates the interaction at submission. Name/school similarity only *suggests* candidates in the assignment picker; a human always confirms. Prevents silent mis-attribution.
+3. **Dismissable leads — yes.** `dismissed` status included now so spam/irrelevant messages leave the pending queue without minting an interaction. Wire the button in this slice or a fast-follow.
+4. **Traceability on the lead table** — `profile_contacts.status` + `interaction_id`. No column added to `interactions`.
+5. **Identity-less interest stays lead-only** (proposal a). An Interest submission with no coach name and no email has no identity to attach — it never becomes a coach-linked interaction. Button *usage* is still fully tracked: every Interest submission is a `profile_contacts` row (already counted in the inbox stat tiles). Only Interest submissions carrying a matchable/assignable coach become `type: interest` interactions.

--- a/planning/PLAN_public-profile-inbound-to-interaction-2026-08-27.md
+++ b/planning/PLAN_public-profile-inbound-to-interaction-2026-08-27.md
@@ -1,0 +1,1063 @@
+# Public-profile inbound coach messages → tracked interactions — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn inbound coach messages captured on the public player profile (Contact / Express Interest) into first-class, coach-linked `interactions` — auto when the coach email matches, human-assigned otherwise — without spawning orphaned or duplicate coach records.
+
+**Architecture:** Two paths. (A) **Matched** — at submission, if `matchCoachByEmail` finds a coach, the server inserts the `interactions` row (coach's `school_id` satisfies NOT NULL), repoints the existing notification to it, and marks the lead `resolved`. (B) **Unmatched** — the `profile_contacts` lead stays `pending`; the player later resolves it via a client-side assignment modal that reuses existing store actions (school resolve → `createCoach` → `useInteractions.create`, which auto-fires the inbound alert) then calls a small `resolve` endpoint. No coach is ever auto-created from unauthenticated input.
+
+**Tech Stack:** Nuxt 3 / Vue 3 / TypeScript strict, Supabase (service-role admin on server, RLS client-side), Pinia, Vitest (co-located `*.test.ts` + `tests/unit/**`), Playwright E2E. Migrations applied live via Supabase MCP `apply_migration` (repo convention — `npx supabase db push` is broken here).
+
+**Spec:** `planning/DESIGN_public-profile-inbound-to-interaction-2026-08-27.md`
+
+## Global Constraints
+
+- **Never create/mutate a coach or school from unauthenticated public input.** Matching stays read-only (email exact, family-scoped).
+- **No schema change to the `interactions` table.** `school_id` and `logged_by` stay NOT NULL; matched path supplies both, unmatched path defers creation until assignment.
+- **Single Supabase DB serves prod + QA** (`xpxzhqghxecsjhvklsqg`). Every migration is a prod write. Apply via MCP `apply_migration`, not `db push`.
+- **Enum-add is non-transactional in Postgres** — `ALTER TYPE ... ADD VALUE 'interest'` gets its own migration, committed before any code path uses the value.
+- **Authed client calls use `useAuthFetch().$fetchAuth`**, never bare `$fetch` (app sets no auth cookie → 401). See MEMORY `authed-composables-use-authfetch`.
+- **UTC date boundaries only** — no local `getFullYear()`/`getMonth()` (TZ bugs). Use `occurred_at = new Date().toISOString()`.
+- **Design tokens** — no raw hex / rgba in `<style>` or inline; use theme vars / brand utilities; `<DesignSystem*>` for empty/loading/error states. Enforced by `npm run audit:tokens`.
+- **iOS parity is a follow-up, not this slice.** Produced interactions already render on iOS; the assignment UI is web-only here. Log an iOS handoff at the end.
+
+---
+
+## File Structure
+
+**Migrations (new, applied via MCP):**
+- `supabase/migrations/<ts>_interaction_type_add_interest.sql` — `ALTER TYPE interaction_type ADD VALUE IF NOT EXISTS 'interest'`.
+- `supabase/migrations/<ts>_profile_contacts_status.sql` — add `status` + `interaction_id` + backfill.
+
+**Server:**
+- `server/utils/matchCoachByEmail.ts` — MODIFY: return `{ coachId, schoolId }`.
+- `server/utils/inboundInteraction.ts` — NEW: pure `buildInboundInteractionRow(...)` + thin `insertInboundInteraction(admin, row)`.
+- `server/api/public/profile/[slug]/contact.post.ts` — MODIFY: matched-path insert + notification repoint + lead status.
+- `server/api/public/profile/[slug]/interest.post.ts` — MODIFY: same, identity-gated.
+- `server/api/player/profile/contacts.get.ts` — MODIFY: select + expose `status`, `interaction_id`.
+- `server/api/player/profile/contacts/[id]/resolve.post.ts` — NEW: authed, sets `status` (`resolved`|`dismissed`) + `interaction_id`, family-scoped, double-convert guard.
+
+**Client:**
+- `composables/useInteractions.ts` — MODIFY: drop the stale player-only client guard (RLS already allows any family member).
+- `composables/useProfileContacts.ts` — MODIFY: carry `status`/`interaction_id`; add `resolveLead`, `dismissLead`.
+- `components/profile/AssignCoachModal.vue` — NEW: school-first → coach pick/create → interaction → resolve.
+- `components/profile/ProfileInbox.vue` — MODIFY: pending badge, Assign/Dismiss CTAs, pending/resolved filter.
+
+**Enum audit (Task 1):**
+- `types/database.ts`, `types/models.ts`, `utils/validation/schemas.ts`, `utils/interactionFormatters.ts`.
+
+---
+
+### Task 1: Add `interest` interaction type + audit all switch/label sites
+
+**Files:**
+- Create: `supabase/migrations/<ts>_interaction_type_add_interest.sql`
+- Modify: `types/database.ts` (interaction_type union ~3311-3324 + values array ~3498-3511)
+- Modify: `types/models.ts:147-160` (InteractionType union)
+- Modify: `utils/validation/schemas.ts:166-180` (Zod `type` enum)
+- Modify: `utils/interactionFormatters.ts` (4 `Record` maps: icon, bg, color, label)
+- Test: `tests/unit/utils/interactionFormatters.spec.ts` (exists) — add `interest` cases
+
+**Interfaces:**
+- Produces: interaction_type now includes literal `"interest"`, accepted by `interactionSchema`, formatted as "Interest".
+
+- [ ] **Step 1: Write the failing test** — append to `tests/unit/utils/interactionFormatters.spec.ts`:
+
+```ts
+import { getTypeIcon, formatType } from "~/utils/interactionFormatters";
+
+describe("interest interaction type", () => {
+  it("formats interest with a label and a non-default icon", () => {
+    expect(formatType("interest")).toBe("Interest");
+    expect(getTypeIcon("interest")).toBe("i-heroicons-hand-raised");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/utils/interactionFormatters.spec.ts -t "interest interaction type"`
+Expected: FAIL — `formatType("interest")` returns the default (`"Other"` via fallback) not `"Interest"`.
+
+- [ ] **Step 3: Write the migration** (`ALTER TYPE` — its own file, no other DDL):
+
+```sql
+-- Add 'interest' to interaction_type so Express-Interest submissions log as
+-- their own interaction type. Enum ADD VALUE is non-transactional; keep alone.
+ALTER TYPE interaction_type ADD VALUE IF NOT EXISTS 'interest';
+```
+
+- [ ] **Step 4: Add `interest` to every type site.**
+
+`types/models.ts` — add `| "interest"` to the InteractionType union.
+`utils/validation/schemas.ts` — add `"interest",` to the `z.enum([...])` list.
+`types/database.ts` — add `| "interest"` to the interaction_type union and `"interest",` to its values array.
+`utils/interactionFormatters.ts` — add to all four maps:
+
+```ts
+// getTypeIcon icons:
+interest: "i-heroicons-hand-raised",
+// getTypeIconBg bgs:
+interest: "bg-purple-100",
+// getTypeIconColor colors:
+interest: "text-purple-600",
+// formatType typeMap:
+interest: "Interest",
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/utils/interactionFormatters.spec.ts -t "interest interaction type"`
+Expected: PASS.
+
+- [ ] **Step 6: Apply the migration live** (MCP `apply_migration`, name `interaction_type_add_interest`). Then verify:
+
+```sql
+SELECT 1 FROM pg_enum e JOIN pg_type t ON t.oid = e.enumtypid
+WHERE t.typname = 'interaction_type' AND e.enumlabel = 'interest';
+```
+Expected: one row.
+
+- [ ] **Step 7: Full type-check + targeted tests**
+
+Run: `npm run type-check && npx vitest run tests/unit/utils/interactionFormatters.spec.ts`
+Expected: 0 type errors, all green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add supabase/migrations types/database.ts types/models.ts utils/validation/schemas.ts utils/interactionFormatters.ts tests/unit/utils/interactionFormatters.spec.ts
+git commit -m "feat: add 'interest' interaction type + formatter/label/validation support"
+```
+
+---
+
+### Task 2: `profile_contacts` gains `status` + `interaction_id` (migration + backfill)
+
+**Files:**
+- Create: `supabase/migrations/<ts>_profile_contacts_status.sql`
+- Modify: `types/database.ts` (profile_contacts Row/Insert/Update ~2028-2079, + a relationship for `interaction_id`)
+
+**Interfaces:**
+- Produces: `profile_contacts.status: 'pending' | 'resolved' | 'dismissed'` (default `'pending'`), `profile_contacts.interaction_id: string | null` (FK interactions, ON DELETE SET NULL).
+
+- [ ] **Step 1: Write the migration**
+
+```sql
+-- Resolution state for inbound leads. status gates the inbox pending queue;
+-- interaction_id ties a lead to the interaction it produced (match or assign).
+ALTER TABLE profile_contacts
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'resolved', 'dismissed')),
+  ADD COLUMN IF NOT EXISTS interaction_id uuid
+    REFERENCES interactions(id) ON DELETE SET NULL;
+
+-- Backfill: rows that already matched a coach are effectively resolved
+-- (the interaction will be minted going forward; historic ones have none),
+-- everything else is a pending lead awaiting assignment.
+UPDATE profile_contacts
+  SET status = 'resolved'
+  WHERE matched_coach_id IS NOT NULL AND status = 'pending';
+```
+
+- [ ] **Step 2: Apply live** (MCP `apply_migration`, name `profile_contacts_status`). Verify:
+
+```sql
+SELECT column_name FROM information_schema.columns
+WHERE table_name = 'profile_contacts' AND column_name IN ('status','interaction_id')
+ORDER BY column_name;
+```
+Expected: two rows (`interaction_id`, `status`).
+
+- [ ] **Step 3: Regenerate / hand-edit `types/database.ts`** — add `status: string` and `interaction_id: string | null` to profile_contacts Row, `status?`/`interaction_id?` to Insert and Update, and an `interactions` relationship entry for `interaction_id`.
+
+- [ ] **Step 4: Type-check**
+
+Run: `npm run type-check`
+Expected: 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add supabase/migrations types/database.ts
+git commit -m "feat: add status + interaction_id to profile_contacts"
+```
+
+---
+
+### Task 3: `matchCoachByEmail` also returns the matched coach's `school_id`
+
+**Files:**
+- Modify: `server/utils/matchCoachByEmail.ts`
+- Test: `tests/unit/server/utils/matchCoachByEmail.spec.ts` (new)
+
+**Interfaces:**
+- Produces: `matchCoachByEmail(admin, { familyUnitId, email }) → Promise<{ coachId: string | null; schoolId: string | null }>`.
+
+- [ ] **Step 1: Write the failing test** (fake client, chainable — mirrors repo mock style):
+
+```ts
+import { describe, it, expect } from "vitest";
+import { matchCoachByEmail } from "~/server/utils/matchCoachByEmail";
+
+function fakeAdmin(row: { id: string; school_id: string } | null) {
+  const builder = {
+    select: () => builder,
+    eq: () => builder,
+    ilike: () => builder,
+    maybeSingle: async () => ({ data: row, error: null }),
+  };
+  return { from: () => builder } as never;
+}
+
+describe("matchCoachByEmail", () => {
+  it("returns coachId and schoolId when a coach matches", async () => {
+    const res = await matchCoachByEmail(fakeAdmin({ id: "c1", school_id: "s1" }), {
+      familyUnitId: "f1",
+      email: "coach@school.edu",
+    });
+    expect(res).toEqual({ coachId: "c1", schoolId: "s1" });
+  });
+
+  it("returns nulls when no email is supplied", async () => {
+    const res = await matchCoachByEmail(fakeAdmin(null), { familyUnitId: "f1" });
+    expect(res).toEqual({ coachId: null, schoolId: null });
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/server/utils/matchCoachByEmail.spec.ts`
+Expected: FAIL — result lacks `schoolId`.
+
+- [ ] **Step 3: Implement** — change the select and return:
+
+```ts
+export interface MatchCoachByEmailResult {
+  coachId: string | null;
+  schoolId: string | null;
+}
+// ...
+  if (!email) return { coachId: null, schoolId: null };
+
+  const { data } = await admin
+    .from("coaches")
+    .select("id, school_id")
+    .eq("family_unit_id", params.familyUnitId)
+    .ilike("email", escapeIlike(email))
+    .maybeSingle();
+
+  return { coachId: data?.id ?? null, schoolId: data?.school_id ?? null };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/server/utils/matchCoachByEmail.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/utils/matchCoachByEmail.ts tests/unit/server/utils/matchCoachByEmail.spec.ts
+git commit -m "feat: matchCoachByEmail returns matched coach school_id"
+```
+
+---
+
+### Task 4: Pure `buildInboundInteractionRow` helper
+
+**Files:**
+- Create: `server/utils/inboundInteraction.ts`
+- Test: `tests/unit/server/utils/inboundInteraction.spec.ts` (new)
+
+**Interfaces:**
+- Produces:
+  ```ts
+  interface InboundLeadInput {
+    kind: "contact" | "interest";
+    coachId: string;
+    schoolId: string;
+    familyUnitId: string;
+    loggedBy: string;   // player user id
+    note: string | null;
+    program: string | null;
+    occurredAt: string; // ISO
+  }
+  function buildInboundInteractionRow(input: InboundLeadInput): InteractionInsert
+  async function insertInboundInteraction(admin, row): Promise<{ id: string } | null>
+  ```
+  `type` = `"email"` for contact, `"interest"` for interest; `direction` = `"inbound"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from "vitest";
+import { buildInboundInteractionRow } from "~/server/utils/inboundInteraction";
+
+const base = {
+  coachId: "c1", schoolId: "s1", familyUnitId: "f1", loggedBy: "u1",
+  note: "We loved your film", program: null, occurredAt: "2026-08-27T00:00:00.000Z",
+} as const;
+
+describe("buildInboundInteractionRow", () => {
+  it("maps a contact lead to an inbound email interaction", () => {
+    const row = buildInboundInteractionRow({ ...base, kind: "contact" });
+    expect(row).toMatchObject({
+      coach_id: "c1", school_id: "s1", family_unit_id: "f1", logged_by: "u1",
+      type: "email", direction: "inbound", occurred_at: base.occurredAt,
+      content: "We loved your film",
+    });
+    expect(row.subject).toContain("public profile");
+  });
+
+  it("maps an interest lead to an inbound interest interaction with program in subject", () => {
+    const row = buildInboundInteractionRow({
+      ...base, kind: "interest", note: null, program: "Pitcher",
+    });
+    expect(row.type).toBe("interest");
+    expect(row.direction).toBe("inbound");
+    expect(row.subject).toContain("Pitcher");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/server/utils/inboundInteraction.spec.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement**
+
+```ts
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "~/types/database";
+
+type InteractionInsert =
+  Database["public"]["Tables"]["interactions"]["Insert"];
+
+export interface InboundLeadInput {
+  kind: "contact" | "interest";
+  coachId: string;
+  schoolId: string;
+  familyUnitId: string;
+  loggedBy: string;
+  note: string | null;
+  program: string | null;
+  occurredAt: string;
+}
+
+export function buildInboundInteractionRow(
+  input: InboundLeadInput,
+): InteractionInsert {
+  const subject =
+    input.kind === "interest"
+      ? `Interest via public profile${input.program ? ` — ${input.program}` : ""}`
+      : "Contact via public profile";
+
+  return {
+    coach_id: input.coachId,
+    school_id: input.schoolId,
+    family_unit_id: input.familyUnitId,
+    logged_by: input.loggedBy,
+    type: input.kind === "interest" ? "interest" : "email",
+    direction: "inbound",
+    occurred_at: input.occurredAt,
+    subject,
+    content: input.note,
+  };
+}
+
+export async function insertInboundInteraction(
+  admin: SupabaseClient<Database>,
+  row: InteractionInsert,
+): Promise<{ id: string } | null> {
+  const { data, error } = await admin
+    .from("interactions")
+    .insert(row)
+    .select("id")
+    .single();
+  if (error || !data) return null;
+  return { id: data.id };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/server/utils/inboundInteraction.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/utils/inboundInteraction.ts tests/unit/server/utils/inboundInteraction.spec.ts
+git commit -m "feat: buildInboundInteractionRow + insertInboundInteraction helper"
+```
+
+---
+
+### Task 5: Wire the matched path into `contact.post.ts`
+
+**Files:**
+- Modify: `server/api/public/profile/[slug]/contact.post.ts`
+
+**Interfaces:**
+- Consumes: `matchCoachByEmail` (`{ coachId, schoolId }`), `buildInboundInteractionRow`, `insertInboundInteraction`.
+- Behavior: on `matchedCoachId != null`, insert the interaction and set the lead `status: "resolved"` + `interaction_id`; repoint the notification to the interaction. On no match, set `status: "pending"` (default; still write explicitly for clarity). Interaction-insert failure must NOT fail the response — the lead is already stored.
+
+- [ ] **Step 1: Update the match call + lead insert.** Replace the destructure and add status:
+
+```ts
+const { coachId: matchedCoachId, schoolId: matchedSchoolId } =
+  await matchCoachByEmail(admin, {
+    familyUnitId: profile.family_unit_id,
+    email: data.coachEmail,
+  });
+```
+
+In `insertRow`, add:
+```ts
+status: matchedCoachId ? "resolved" : "pending",
+```
+
+- [ ] **Step 2: After the lead insert succeeds, mint the interaction when matched.** Insert this block immediately after `inserted` is confirmed (before the notify block), guarded so a failure never throws:
+
+```ts
+let interactionId: string | null = null;
+if (matchedCoachId && matchedSchoolId && profile.user_id) {
+  try {
+    const created = await insertInboundInteraction(
+      admin,
+      buildInboundInteractionRow({
+        kind: "contact",
+        coachId: matchedCoachId,
+        schoolId: matchedSchoolId,
+        familyUnitId: profile.family_unit_id,
+        loggedBy: profile.user_id,
+        note: data.note,
+        program: null,
+        occurredAt: new Date().toISOString(),
+      }),
+    );
+    interactionId = created?.id ?? null;
+    if (interactionId) {
+      await admin
+        .from("profile_contacts")
+        .update({ interaction_id: interactionId })
+        .eq("id", inserted.id);
+    }
+  } catch (interErr) {
+    logger.warn("Failed to create inbound interaction from matched lead", interErr);
+  }
+}
+```
+
+- [ ] **Step 3: Repoint the notification** to the interaction when one exists. In the `notificationRow`, make `related_entity_type`/`related_entity_id` conditional:
+
+```ts
+related_entity_type: interactionId ? "interaction" : "profile_contact",
+related_entity_id: interactionId ?? inserted.id,
+```
+
+- [ ] **Step 4: Import the helpers** at top:
+
+```ts
+import {
+  buildInboundInteractionRow,
+  insertInboundInteraction,
+} from "~/server/utils/inboundInteraction";
+```
+
+- [ ] **Step 5: Type-check + lint**
+
+Run: `npm run type-check && npx eslint server/api/public/profile/\[slug\]/contact.post.ts`
+Expected: 0 errors.
+
+- [ ] **Step 6: Manual verify** with dev server + a seeded matching coach:
+
+Run: `npm run dev`, then (player1 family, a coach whose email is `known@school.edu`):
+```bash
+curl -s -X POST http://localhost:3000/api/public/profile/<player1-slug>/contact \
+  -H 'content-type: application/json' \
+  -d '{"coachName":"Known Coach","coachEmail":"known@school.edu","note":"Great film"}'
+```
+Expected: `{ "ok": true }`. Then query live: `profile_contacts` row `status='resolved'`, `interaction_id` set; an `interactions` row `direction='inbound'`, `type='email'`, `coach_id` = the coach.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/api/public/profile/\[slug\]/contact.post.ts
+git commit -m "feat: contact submissions from a matched coach create an inbound interaction"
+```
+
+---
+
+### Task 6: Wire the matched path into `interest.post.ts` (identity-gated)
+
+**Files:**
+- Modify: `server/api/public/profile/[slug]/interest.post.ts`
+
+**Interfaces:**
+- Consumes: same helpers as Task 5.
+- Behavior: identical to contact, but `kind: "interest"`, `program: data.program`, `note: null` (interest has no note). Only mint when matched (email present + coach found). Identity-less interest → stays `pending` lead-only (decision #5).
+
+- [ ] **Step 1: Update the match destructure** to `{ coachId: matchedCoachId, schoolId: matchedSchoolId }` (mirror Task 5 Step 1).
+
+- [ ] **Step 2: Add `status`** to the lead insert row: `status: matchedCoachId ? "resolved" : "pending",`.
+
+- [ ] **Step 3: Add the mint block** after the lead insert (mirror Task 5 Step 2) with:
+
+```ts
+buildInboundInteractionRow({
+  kind: "interest",
+  coachId: matchedCoachId,
+  schoolId: matchedSchoolId,
+  familyUnitId: profile.family_unit_id,
+  loggedBy: profile.user_id,
+  note: null,
+  program: data.program,
+  occurredAt: new Date().toISOString(),
+})
+```
+
+- [ ] **Step 4: Repoint the notification** (mirror Task 5 Step 3) and import the helpers.
+
+- [ ] **Step 5: Type-check + lint**
+
+Run: `npm run type-check && npx eslint server/api/public/profile/\[slug\]/interest.post.ts`
+Expected: 0 errors.
+
+- [ ] **Step 6: Manual verify** — POST interest with a matching `coachEmail` → `type='interest'` inbound interaction created; POST interest with no email/name → lead `status='pending'`, no interaction.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add server/api/public/profile/\[slug\]/interest.post.ts
+git commit -m "feat: matched interest submissions create an inbound interest interaction"
+```
+
+---
+
+### Task 7: Expose `status` + `interaction_id` from the leads read endpoint
+
+**Files:**
+- Modify: `server/api/player/profile/contacts.get.ts`
+- Modify: `composables/useProfileContacts.ts` (type only in this task)
+
+**Interfaces:**
+- Produces: each lead in the GET response includes `status: "pending" | "resolved" | "dismissed"` and `interaction_id: string | null`.
+
+- [ ] **Step 1: Extend the SELECT** (add `status, interaction_id`):
+
+```ts
+.select(
+  "id, type, coach_name, coach_email, coach_title, school_name, program, note, matched_coach_id, status, interaction_id, created_at",
+)
+```
+
+- [ ] **Step 2: Extend the `ProfileContactLead` interface** in `contacts.get.ts` with `status: "pending" | "resolved" | "dismissed";` and `interaction_id: string | null;`.
+
+- [ ] **Step 3: Mirror the fields** in `composables/useProfileContacts.ts` `ProfileLead` interface (`status`, `interaction_id`).
+
+- [ ] **Step 4: Type-check**
+
+Run: `npm run type-check`
+Expected: 0 errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/api/player/profile/contacts.get.ts composables/useProfileContacts.ts
+git commit -m "feat: surface lead status + interaction_id to the inbox"
+```
+
+---
+
+### Task 8: `resolve` endpoint — mark a lead resolved/dismissed
+
+**Files:**
+- Create: `server/api/player/profile/contacts/[id]/resolve.post.ts`
+- Test: `tests/unit/server/api/resolveLead.validation.spec.ts` (new — pure body-schema test)
+
+**Interfaces:**
+- Produces: `POST /api/player/profile/contacts/:id/resolve` body `{ status: "resolved" | "dismissed", interactionId?: string }`. Auth: `requireAuth` + `family_members` scope (mirror `contacts.get.ts`). Guards: lead must belong to caller's family; if already `resolved`, no-op return existing `interaction_id` (double-convert guard). `resolved` requires `interactionId`.
+- Exports `resolveBodySchema` (Zod) for unit testing.
+
+- [ ] **Step 1: Write the failing test** (schema only — the pure, unit-testable part):
+
+```ts
+import { describe, it, expect } from "vitest";
+import { resolveBodySchema } from "~/server/api/player/profile/contacts/[id]/resolve.post";
+
+describe("resolveBodySchema", () => {
+  it("requires interactionId when status is resolved", () => {
+    expect(resolveBodySchema.safeParse({ status: "resolved" }).success).toBe(false);
+    expect(
+      resolveBodySchema.safeParse({
+        status: "resolved",
+        interactionId: "00000000-0000-0000-0000-000000000001",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("allows dismissed without an interactionId", () => {
+    expect(resolveBodySchema.safeParse({ status: "dismissed" }).success).toBe(true);
+  });
+
+  it("rejects unknown status", () => {
+    expect(resolveBodySchema.safeParse({ status: "open" }).success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/server/api/resolveLead.validation.spec.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the endpoint**
+
+```ts
+/**
+ * POST /api/player/profile/contacts/:id/resolve
+ * Marks an inbound lead resolved (with the interaction the player minted) or
+ * dismissed. Family scope resolved server-side from the caller's
+ * family_members row. Idempotent: a lead already resolved returns its
+ * existing interaction_id without overwriting.
+ */
+import { defineEventHandler, getRouterParam, readBody, createError } from "h3";
+import { z } from "zod";
+import { requireAuth } from "~/server/utils/auth";
+import { useSupabaseAdmin } from "~/server/utils/supabase";
+import { useLogger } from "~/server/utils/logger";
+
+export const resolveBodySchema = z
+  .object({
+    status: z.enum(["resolved", "dismissed"]),
+    interactionId: z.string().uuid().optional(),
+  })
+  .refine((v) => v.status !== "resolved" || !!v.interactionId, {
+    message: "interactionId is required when resolving",
+    path: ["interactionId"],
+  });
+
+export default defineEventHandler(async (event) => {
+  const logger = useLogger(event, "player/profile/contacts/resolve");
+  try {
+    const { id: userId } = await requireAuth(event);
+    const leadId = getRouterParam(event, "id")!;
+    if (!/^[0-9a-f-]{36}$/i.test(leadId)) {
+      throw createError({ statusCode: 400, statusMessage: "Invalid lead id" });
+    }
+
+    const parsed = resolveBodySchema.safeParse(await readBody(event));
+    if (!parsed.success) {
+      throw createError({
+        statusCode: 422,
+        statusMessage: parsed.error.issues[0]?.message ?? "Invalid request",
+      });
+    }
+
+    const admin = useSupabaseAdmin();
+
+    const { data: membership, error: membershipError } = await admin
+      .from("family_members")
+      .select("family_unit_id")
+      .eq("user_id", userId)
+      .single();
+    if (membershipError && membershipError.code !== "PGRST116") {
+      logger.error("Failed to resolve family membership", membershipError);
+      throw createError({ statusCode: 500, statusMessage: "Failed to resolve lead" });
+    }
+    if (!membership) {
+      throw createError({ statusCode: 403, statusMessage: "Not a family member" });
+    }
+
+    const { data: lead, error: leadErr } = await admin
+      .from("profile_contacts")
+      .select("id, status, interaction_id, family_unit_id")
+      .eq("id", leadId)
+      .maybeSingle();
+    if (leadErr) {
+      logger.error("Failed to load lead", leadErr);
+      throw createError({ statusCode: 500, statusMessage: "Failed to resolve lead" });
+    }
+    if (!lead || lead.family_unit_id !== membership.family_unit_id) {
+      throw createError({ statusCode: 404, statusMessage: "Lead not found" });
+    }
+
+    // Double-convert guard: never overwrite an existing resolution.
+    if (lead.status === "resolved") {
+      return { ok: true, status: "resolved", interactionId: lead.interaction_id };
+    }
+
+    const { error: updErr } = await admin
+      .from("profile_contacts")
+      .update({
+        status: parsed.data.status,
+        interaction_id: parsed.data.interactionId ?? null,
+      })
+      .eq("id", leadId);
+    if (updErr) {
+      logger.error("Failed to update lead status", updErr);
+      throw createError({ statusCode: 500, statusMessage: "Failed to resolve lead" });
+    }
+
+    return {
+      ok: true,
+      status: parsed.data.status,
+      interactionId: parsed.data.interactionId ?? null,
+    };
+  } catch (err) {
+    if (err instanceof Error && "statusCode" in err) throw err;
+    logger.error("Failed to resolve lead", err);
+    throw createError({ statusCode: 500, statusMessage: "Failed to resolve lead" });
+  }
+});
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/server/api/resolveLead.validation.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Type-check + lint + manual smoke** (`npm run dev`; authed `$fetchAuth` from the app, or a curl with a valid session): dismiss a pending lead → `status='dismissed'`; resolve without interactionId → 422.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/api/player/profile/contacts/\[id\]/resolve.post.ts tests/unit/server/api/resolveLead.validation.spec.ts
+git commit -m "feat: resolve endpoint for inbound leads (resolve/dismiss + guards)"
+```
+
+---
+
+### Task 9: `useProfileContacts` — `resolveLead` + `dismissLead` actions
+
+**Files:**
+- Modify: `composables/useProfileContacts.ts`
+- Test: `tests/unit/composables/useProfileContacts.spec.ts` (new)
+
+**Interfaces:**
+- Consumes: `POST /api/player/profile/contacts/:id/resolve` via `$fetchAuth`.
+- Produces: `resolveLead(id: string, interactionId: string): Promise<void>` and `dismissLead(id: string): Promise<void>`; both refetch on success. Exposed from the composable's return.
+
+- [ ] **Step 1: Write the failing test** (mock `useAuthFetch`, per MEMORY `authed-composables-use-authfetch`):
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+
+const fetchAuth = vi.fn();
+vi.mock("~/composables/useAuthFetch", () => ({
+  useAuthFetch: () => ({ $fetchAuth: fetchAuth }),
+}));
+
+import { useProfileContacts } from "~/composables/useProfileContacts";
+
+describe("useProfileContacts.dismissLead", () => {
+  it("POSTs status=dismissed to the resolve endpoint", async () => {
+    fetchAuth.mockResolvedValue({ leads: [], counts: {} });
+    const { dismissLead } = useProfileContacts();
+    await dismissLead("lead-1");
+    expect(fetchAuth).toHaveBeenCalledWith(
+      "/api/player/profile/contacts/lead-1/resolve",
+      { method: "POST", body: { status: "dismissed" } },
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/composables/useProfileContacts.spec.ts`
+Expected: FAIL — `dismissLead` not exported.
+
+- [ ] **Step 3: Implement** — add inside `useProfileContacts`, before `return`:
+
+```ts
+async function resolveLead(id: string, interactionId: string): Promise<void> {
+  await $fetchAuth(`/api/player/profile/contacts/${id}/resolve`, {
+    method: "POST",
+    body: { status: "resolved", interactionId },
+  });
+  await fetchContacts();
+}
+
+async function dismissLead(id: string): Promise<void> {
+  await $fetchAuth(`/api/player/profile/contacts/${id}/resolve`, {
+    method: "POST",
+    body: { status: "dismissed" },
+  });
+  await fetchContacts();
+}
+```
+
+Add `resolveLead, dismissLead` to the returned object.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/composables/useProfileContacts.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add composables/useProfileContacts.ts tests/unit/composables/useProfileContacts.spec.ts
+git commit -m "feat: resolveLead + dismissLead actions on useProfileContacts"
+```
+
+---
+
+### Task 9B: Loosen `createInteraction` to any family member (parent OR player)
+
+**Why:** Parents and players work the recruiting record together — the app's core premise. The `interactions` RLS INSERT policy **already** allows any family member (`20260826000000_allow_family_members_create_interactions.sql`, live since 2026-08-26: `logged_by = auth.uid()` + family membership, role gate dropped). Only the stale **client** guard still blocks parents. This aligns the client with the shipped RLS so a parent can log interactions and assign inbound coaches on the player's behalf. Must land before Task 10 (the assign modal calls `createInteraction`).
+
+**Files:**
+- Modify: `composables/useInteractions.ts:253-256` (remove the role throw)
+- Modify: `tests/unit/composables/useInteractions.advanced.spec.ts:~299` (flip the now-stale assertion)
+
+**Interfaces:**
+- Produces: `createInteraction` succeeds for any authenticated family member; still requires `userStore.user` and an active family context; still stamps `logged_by: userStore.user.id` (satisfies RLS `logged_by = auth.uid()`).
+
+- [ ] **Step 1: Flip the stale test.** The existing test at `useInteractions.advanced.spec.ts:~299` asserts a parent-role user throws `"Only players can create interactions"`. That assertion is stale vs. the shipped RLS. Rewrite it to assert a parent-role user **can** create — mirror an existing passing create test's arrange/mock, set the user role to `"parent"`, and assert the insert path is reached (no throw; `supabase.from("interactions").insert` called). Keep the "not authenticated" and "no family context" guard tests unchanged.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run tests/unit/composables/useInteractions.advanced.spec.ts`
+Expected: FAIL — parent still throws because the guard is still in place.
+
+- [ ] **Step 3: Remove the role guard** in `composables/useInteractions.ts` (delete these lines):
+
+```ts
+    if (userStore.user.role !== "player") {
+      throw new Error("Only players can create interactions");
+    }
+```
+
+Leave the `if (!userStore.user)` and `if (!activeFamily.activeFamilyId.value)` guards intact.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run tests/unit/composables/useInteractions.advanced.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Full interactions suite + type-check** (catch any other test that assumed the guard)
+
+Run: `npm run type-check && npx vitest run tests/unit/composables/useInteractions`
+Expected: 0 type errors, all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add composables/useInteractions.ts tests/unit/composables/useInteractions.advanced.spec.ts
+git commit -m "feat: allow any family member (parent or player) to log interactions, matching RLS"
+```
+
+---
+
+### Task 10: `AssignCoachModal` — school-first → coach → interaction → resolve
+
+**Files:**
+- Create: `components/profile/AssignCoachModal.vue`
+- Test: `tests/unit/components/profile/AssignCoachModal.spec.ts` (new)
+
+**Interfaces:**
+- Consumes: `stores/coaches.ts createCoach(schoolId, data)`, `useInteractions().createInteraction` (client insert that auto-fires `createInboundInteractionAlert`), `useProfileContacts().resolveLead`, the family's schools list, an existing school picker/add flow.
+- Props: `lead: ProfileLead`. Emits: `resolved` (after the lead is resolved) and `close`.
+- Behavior: (1) resolve the school — suggest a `schools` match on `lead.school_name`, else pick/add; (2) suggest existing coaches in that school + a family-wide fuzzy pass on `lead.coach_name` (dedup); (3) link existing OR create new (pre-filled: `coach_name` split to first/last, `coach_email`, `coach_title`); (4) create the interaction (`direction: "inbound"`, `type: lead.type === "interest" ? "interest" : "email"`, `coach_id`, `school_id`, `content: lead.note`); (5) call `resolveLead(lead.id, interaction.id)`; emit `resolved`.
+
+- [ ] **Step 1: Write the failing test** (behavior: confirming create-new mints an interaction then resolves the lead). Mock the coaches store, `useInteractions`, and `useProfileContacts`:
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import AssignCoachModal from "~/components/profile/AssignCoachModal.vue";
+
+const createCoach = vi.fn().mockResolvedValue({ id: "coach-new", school_id: "s1" });
+const createInteraction = vi.fn().mockResolvedValue({ id: "int-1" });
+const resolveLead = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("~/stores/coaches", () => ({ useCoachesStore: () => ({ createCoach, coaches: { value: [] }, fetchCoaches: vi.fn() }) }));
+vi.mock("~/composables/useInteractions", () => ({ useInteractions: () => ({ createInteraction }) }));
+vi.mock("~/composables/useProfileContacts", () => ({ useProfileContacts: () => ({ resolveLead, dismissLead: vi.fn(), leads: { value: [] }, counts: { value: {} }, loading: { value: false }, error: { value: null }, fetchContacts: vi.fn() }) }));
+
+const lead = {
+  id: "lead-1", type: "contact", coach_name: "Jane Smith", coach_email: "jane@school.edu",
+  coach_title: "Head Coach", school_name: "State U", program: null, note: "Loved your film",
+  matched_coach_id: null, status: "pending", interaction_id: null, created_at: "2026-08-27",
+};
+
+describe("AssignCoachModal", () => {
+  it("creates a coach + inbound interaction then resolves the lead", async () => {
+    const wrapper = mount(AssignCoachModal, {
+      props: { lead, presetSchoolId: "s1" },
+      global: { stubs: { teleport: true } },
+    });
+    await wrapper.get('[data-test="create-new-coach"]').trigger("click");
+    await wrapper.get('[data-test="confirm-assign"]').trigger("click");
+    await new Promise((r) => setTimeout(r));
+
+    expect(createCoach).toHaveBeenCalledWith("s1", expect.objectContaining({
+      first_name: "Jane", last_name: "Smith", email: "jane@school.edu",
+    }));
+    expect(createInteraction).toHaveBeenCalledWith(expect.objectContaining({
+      coach_id: "coach-new", school_id: "s1", direction: "inbound", type: "email",
+    }));
+    expect(resolveLead).toHaveBeenCalledWith("lead-1", "int-1");
+    expect(wrapper.emitted("resolved")).toBeTruthy();
+  });
+});
+```
+
+> Note: match the real `useInteractions` create fn name when you open the composable (it is `createInteraction` in the return; verify at implementation time and keep the test in sync). `presetSchoolId` is a test seam so the school-resolution step can be bypassed in the unit test; production flow resolves it via the school picker in Step 3.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/components/profile/AssignCoachModal.spec.ts`
+Expected: FAIL — component does not exist.
+
+- [ ] **Step 3: Implement `AssignCoachModal.vue`** — `<script setup lang="ts">`, `withDefaults(defineProps<{ lead: ProfileLead; presetSchoolId?: string }>(), { presetSchoolId: undefined })`, `defineEmits<{ resolved: []; close: [] }>()`. Use `<DesignSystem*>` primitives and brand utilities only (no raw hex). Sections:
+  - School resolver: if `presetSchoolId` use it; else a school select/add bound to a local `schoolId` ref, seeded by matching `lead.school_name` against the family schools list.
+  - Coach step: list existing coaches in `schoolId` (dedup suggestion), a "Create new coach" toggle (`data-test="create-new-coach"`) that reveals name/email/title pre-filled from the lead (`splitName(lead.coach_name)`).
+  - Confirm button `data-test="confirm-assign"` (disabled until a coach is chosen or new-coach fields valid) runs: `createCoach` (if new) → `createInteraction({ coach_id, school_id, type: lead.type === "interest" ? "interest" : "email", direction: "inbound", occurred_at: new Date().toISOString(), content: lead.note, subject: lead.type === "interest" ? "Interest via public profile" : "Contact via public profile" })` → `resolveLead(lead.id, created.id)` → `emit("resolved")`.
+  - Local helper `splitName(full: string): { first: string; last: string }` — split on last space, last token is `last_name`, remainder `first_name`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/components/profile/AssignCoachModal.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Token audit + type-check**
+
+Run: `npm run audit:tokens && npm run type-check`
+Expected: 0 violations, 0 type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/profile/AssignCoachModal.vue tests/unit/components/profile/AssignCoachModal.spec.ts
+git commit -m "feat: AssignCoachModal converts a pending lead into a coach-linked interaction"
+```
+
+---
+
+### Task 11: `ProfileInbox` — pending badge, Assign/Dismiss CTAs, filter
+
+**Files:**
+- Modify: `components/profile/ProfileInbox.vue`
+- Test: `tests/unit/components/profile/ProfileInbox.spec.ts` (new)
+
+**Interfaces:**
+- Consumes: `useProfileContacts` (now with `status`, `resolveLead`, `dismissLead`), `AssignCoachModal`.
+- Behavior: pending leads show a "Needs coach" badge + "Assign coach" and "Dismiss" buttons; resolved leads show a "Tracked" badge and a link to the interaction (`interaction_id`); dismissed leads are hidden by default behind a filter. "Assign coach" opens `AssignCoachModal` for that lead; on `resolved`, the list refetches.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import ProfileInbox from "~/components/profile/ProfileInbox.vue";
+
+const dismissLead = vi.fn().mockResolvedValue(undefined);
+const pendingLead = { id: "l1", type: "contact", coach_name: "Jane Smith", coach_email: null, coach_title: null, school_name: "State U", program: null, note: "hi", matched_coach_id: null, status: "pending", interaction_id: null, created_at: "2026-08-27" };
+
+vi.mock("~/composables/useProfileContacts", () => ({
+  useProfileContacts: () => ({
+    leads: { value: [pendingLead] },
+    counts: { value: { interestThisMonth: 0, contactThisMonth: 1, totalThisMonth: 1 } },
+    loading: { value: false }, error: { value: null },
+    fetchContacts: vi.fn(), resolveLead: vi.fn(), dismissLead,
+  }),
+}));
+
+describe("ProfileInbox pending lead", () => {
+  it("shows a Needs coach badge and an Assign coach action", () => {
+    const wrapper = mount(ProfileInbox, { global: { stubs: { AssignCoachModal: true, StatsTiles: true } } });
+    expect(wrapper.text()).toContain("Needs coach");
+    expect(wrapper.find('[data-test="assign-coach-l1"]').exists()).toBe(true);
+  });
+
+  it("calls dismissLead when Dismiss is clicked", async () => {
+    const wrapper = mount(ProfileInbox, { global: { stubs: { AssignCoachModal: true, StatsTiles: true } } });
+    await wrapper.get('[data-test="dismiss-l1"]').trigger("click");
+    expect(dismissLead).toHaveBeenCalledWith("l1");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/unit/components/profile/ProfileInbox.spec.ts`
+Expected: FAIL — badge/buttons absent.
+
+- [ ] **Step 3: Implement** — in `ProfileInbox.vue`: pull `resolveLead, dismissLead` from the composable; a `filter` ref (`"open" | "all"`) hiding `dismissed` by default; per-lead status branch:
+  - `pending`: `<DesignSystemBadge color="amber">Needs coach</DesignSystemBadge>`, buttons `data-test="assign-coach-{{lead.id}}"` (opens modal with `activeLead = lead`) and `data-test="dismiss-{{lead.id}}"` (`@click="dismissLead(lead.id)"`).
+  - `resolved`: `<DesignSystemBadge color="green">Tracked</DesignSystemBadge>` + a `NuxtLink` to the interaction when `lead.interaction_id`.
+  - Render `<AssignCoachModal v-if="activeLead" :lead="activeLead" @resolved="onResolved" @close="activeLead = null" />` where `onResolved` clears `activeLead` and calls `fetchContacts()`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/unit/components/profile/ProfileInbox.spec.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Token audit + type-check + full unit suite**
+
+Run: `npm run audit:tokens && npm run type-check && npm test`
+Expected: 0 violations, 0 type errors, full suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/profile/ProfileInbox.vue tests/unit/components/profile/ProfileInbox.spec.ts
+git commit -m "feat: inbox surfaces pending leads with assign/dismiss + tracked state"
+```
+
+---
+
+### Task 12: E2E happy paths + browser verify + iOS handoff
+
+**Files:**
+- Create: `tests/e2e/public-profile-inbound-interaction.spec.ts`
+- Create: `planning/iOS_HANDOFF_inbound-lead-assignment-2026-08-27.md`
+
+**Interfaces:**
+- Consumes: the whole flow end-to-end against the running app.
+
+- [ ] **Step 1: Write the E2E spec** — two journeys (seeded on a demo family):
+  - **Matched:** submit Contact with a coach email that already exists in the family → assert an inbound interaction appears on the interactions page for that coach, and the inbox lead shows "Tracked".
+  - **Unmatched:** submit Contact with a novel email → inbox shows the lead "Needs coach" → open Assign coach → create new coach → confirm → interaction appears on the interactions page and the lead flips to "Tracked".
+
+```ts
+import { test, expect } from "@playwright/test";
+// Follow tests/e2e conventions: RUN_ID-scoped data, authed storageState,
+// networkidle before asserting SPA nav. Model the two journeys above.
+```
+
+- [ ] **Step 2: Run the E2E spec**
+
+Run: `npm run test:e2e -- public-profile-inbound-interaction`
+Expected: both journeys pass (Chromium).
+
+- [ ] **Step 3: Browser verify** — `npm run dev`, log in as player1, submit both a matched and an unmatched inbound message through the real public profile UI, assign the unmatched one, confirm the interaction lands on `/interactions` and the reach-out nudge picks up the school. No console errors, no blank screens.
+
+- [ ] **Step 4: Write the iOS handoff** — `planning/iOS_HANDOFF_inbound-lead-assignment-2026-08-27.md`: the pending-lead inbox + Assign-coach flow needs an iOS counterpart so leads can be resolved on mobile; the produced interactions already display on iOS. Note the new `interest` interaction type must be added to the iOS interaction-type constants/labels for parity.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/e2e/public-profile-inbound-interaction.spec.ts planning/iOS_HANDOFF_inbound-lead-assignment-2026-08-27.md
+git commit -m "test: e2e for inbound-to-interaction + iOS handoff"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Matched auto-create → Tasks 3–6. Unmatched deferral + assignment → Tasks 8–11. `interest` type → Task 1. `status`/`interaction_id` traceability → Task 2, 7. No name auto-link → enforced by design (only email match mints at submission; Tasks 5/6). Dismiss → Tasks 8, 9, 11. Identity-less interest stays lead-only → Task 6 (mint gated on match). No coach auto-creation from public input → Tasks 5/6 never create coaches; only Task 10 (authed, human-confirmed) does. School-first assignment (CoachSelect not reusable) → Task 10. No double-notify → Tasks 5/6 repoint the existing notification. Nudge is school-fed → matched path sets `school_id` from the coach (Task 4/5). iOS parity follow-up → Task 12.
+
+**Placeholder scan:** No TBD/TODO; every code step carries real code. The E2E spec body (Task 12 Step 1) is intentionally journey-described rather than fully transcribed because it must follow this repo's evolving `tests/e2e` seed/auth conventions — flagged inline, not a silent gap.
+
+**Type consistency:** `matchCoachByEmail` → `{ coachId, schoolId }` used in Tasks 5/6. `buildInboundInteractionRow` input/`type` mapping (`contact→email`, `interest→interest`) consistent across Tasks 4/5/6/10. `resolveLead(id, interactionId)` / `dismissLead(id)` defined in Task 9, consumed in Tasks 10/11. `status` union `pending|resolved|dismissed` consistent across Tasks 2/7/8/11. **Resolved:** the client create fn is `useInteractions().createInteraction(interactionData, files?)` where `interactionData` is `Omit<Interaction, "id" | "created_at">` and passes through `interactionSchema` (which gains `interest` in Task 1) — the Task 10 modal + test use exactly this.
+
+**Parent/player permissions (resolved — Task 9B):** Parents and players both manage the recruiting record. The `interactions` RLS already allows any family member to insert (live since 2026-08-26); Task 9B removes the stale client role-guard so parents can log interactions AND assign inbound coaches. No CTA gating — the "Assign coach" action is available to any family member. Task 9B must land before Task 10.

--- a/planning/iOS_HANDOFF_inbound-lead-assignment-2026-08-27.md
+++ b/planning/iOS_HANDOFF_inbound-lead-assignment-2026-08-27.md
@@ -1,0 +1,123 @@
+# iOS Handoff: Inbound Lead → Interaction Assignment
+
+**Date:** 2026-08-27
+**Source of truth:** web app (Nuxt/TypeScript), branch `feat/inbound-lead-to-interaction`
+**Status:** Web-side feature complete + E2E covered. iOS has NO counterpart yet.
+
+## What shipped on web
+
+A coach who messages a player through the **public profile** (`/p/:slug`) — via
+"Contact Player" or "Express Interest" — creates a lead row in
+`profile_contacts`. That lead is now either:
+
+1. **Auto-tracked** — if the coach's submitted email matches an existing
+   `coaches.email` row in the player's family (case-insensitive, family-scoped
+   match), the backend immediately mints an inbound `interactions` row
+   (`type: 'contact' → 'email'`, `type: 'interest' → 'interest'`,
+   `direction: 'inbound'`) and stamps `profile_contacts.status = 'resolved'`
+   + `profile_contacts.interaction_id`. No human action required.
+2. **Pending assignment** — if the email doesn't match any known coach (or no
+   email was given), the lead sits with `status = 'pending'` in the player's
+   **Inbox** until a family member manually assigns it to a coach (existing or
+   newly created), at which point the same interaction-minting happens
+   client-side and the lead flips to `resolved`.
+
+A `status = 'dismissed'` state also exists — the family member can dismiss a
+lead without ever creating an interaction or coach.
+
+## Why iOS needs this
+
+1. **The Inbox itself.** Web now has a "Public Profile → Inbox" tab
+   (`components/profile/ProfileInbox.vue`) listing every inbound lead with
+   Open/All filters, per-lead badges ("Needs coach" / "Tracked"), and
+   Assign-coach / Dismiss actions. iOS has no equivalent screen — a lead that
+   lands unmatched is currently invisible to a parent/player using only the
+   iOS app until they open web.
+2. **The Assign-coach flow.** Resolving a pending lead requires picking a
+   school, then either selecting an existing coach at that school or creating
+   a new one inline, then confirming — which both assigns the lead and logs
+   the interaction in one action (`components/profile/AssignCoachModal.vue`).
+   This is the only path to convert a "Needs coach" lead into a tracked
+   interaction from the app (dismiss is the only other lead-side action).
+3. **`interest` interaction type is new** — see below. Even without building
+   the Inbox/Assign-coach UI, iOS's interaction-type constants must add this
+   value now or auto-created/web-created `interest` interactions will
+   render incorrectly (or crash on decode, depending on how the enum is
+   modeled) the moment iOS displays an interactions list that includes one.
+
+## What already works on iOS without any new code
+
+Once an interaction exists (auto-matched or manually assigned via web),
+it is a completely ordinary row in the `interactions` table — iOS's existing
+interactions list/detail screens will display it like any other logged
+interaction, with `direction: inbound`, `subject`, and `content` populated.
+**No schema or read-path change needed for that half.**
+
+## What needs building on iOS
+
+### 1. `interest` interaction type (required, small, do first)
+- Add `"interest"` to iOS's interaction-type enum/constants (wherever
+  `email` / `call` / `text` / etc. currently live) and its display label
+  (web renders it as **"Interest"** — see `formatType()` in
+  `utils/interactionFormatters.ts`).
+- Add matching icon/color mapping if iOS's UI branches on type (web:
+  `getTypeIcon` / `getTypeIconBg` / `getTypeIconColor` in the same file —
+  purple-ish "hand-raised" treatment).
+- Verify the interaction decode path doesn't fail closed on an unrecognized
+  raw string — a lead assigned via web today can already produce an
+  `interest` row iOS will fetch.
+
+### 2. Inbound-lead inbox screen (net-new)
+- Data source: `GET /api/player/profile/contacts` → `{ leads: ProfileLead[],
+  counts: {...} }`. See `composables/useProfileContacts.ts` for the exact
+  shape (`ProfileLead`: `id, type, coach_name, coach_email, coach_title,
+  school_name, program, note, matched_coach_id, status, interaction_id,
+  created_at`).
+- List UI: badge per lead ("Interest"/"Contact" type badge; "Needs coach" /
+  "Tracked" status badge), Open/All filter, "Assign coach" + "Dismiss"
+  actions on `pending` leads, "View interaction" link on `resolved` leads
+  (`interaction_id`).
+- Web reference: `components/profile/ProfileInbox.vue`.
+
+### 3. Assign-coach flow (net-new)
+- School picker → coach picker (existing coaches at that school) OR "create
+  new coach" inline form (first/last name required, email/role optional,
+  prefilled from the lead's `coach_name`/`coach_email`).
+- On confirm: create the coach if new (existing coach-create endpoint),
+  then create the interaction (existing interaction-create endpoint) with
+  `type` derived from `lead.type` (`interest → interest`, else `→ email`),
+  `direction: inbound`, `subject` mirroring the web convention ("Interest
+  via public profile" / "Contact via public profile"), `content: lead.note`.
+- Then call `POST /api/player/profile/contacts/:id/resolve` with
+  `{ status: 'resolved', interactionId }` to close the lead out.
+- Dismiss-only path: same resolve endpoint with `{ status: 'dismissed' }`
+  (no `interactionId`).
+- Web reference: `components/profile/AssignCoachModal.vue`,
+  `server/api/player/profile/contacts/[id]/resolve.post.ts`.
+
+## Files to read on web (in build order)
+
+1. `server/utils/matchCoachByEmail.ts` — email-match logic (context only,
+   not iOS-relevant to reimplement; this runs server-side on submission).
+2. `server/utils/inboundInteraction.ts` — `buildInboundInteractionRow` /
+   `insertInboundInteraction`, the shared shape both the auto-match path and
+   the manual Assign-coach path use to mint an interaction.
+3. `composables/useProfileContacts.ts` — lead fetch/resolve/dismiss contract.
+4. `components/profile/ProfileInbox.vue` — Inbox screen UI/behavior.
+5. `components/profile/AssignCoachModal.vue` — Assign-coach modal UI/behavior.
+6. `server/api/player/profile/contacts/[id]/resolve.post.ts` — resolve/dismiss
+   endpoint (idempotent: re-resolving an already-resolved lead is a no-op
+   that returns the existing `interaction_id`).
+7. Migrations already applied live (schema is ready, no DB work needed):
+   - `interaction_type` enum += `'interest'`
+   - `profile_contacts` += `status` (`pending|resolved|dismissed`) +
+     `interaction_id` (FK → `interactions.id`)
+
+## Non-goals / explicitly out of scope (mirror web's decisions)
+
+- No auto-creation of a coach from unauthenticated public input, ever — only
+  a human-confirmed Assign-coach action creates a coach record.
+- No name-based auto-linking — only an exact (case-insensitive) email match
+  auto-resolves a lead. A name match alone leaves the lead pending.
+- No double-notification — the existing player notification (in-app +
+  email) on lead submission is unchanged; assignment doesn't fire a second one.

--- a/server/api/player/profile/contacts.get.ts
+++ b/server/api/player/profile/contacts.get.ts
@@ -26,6 +26,8 @@ interface ProfileContactLead {
   program: string | null;
   note: string | null;
   matched_coach_id: string | null;
+  status: "pending" | "resolved" | "dismissed";
+  interaction_id: string | null;
   created_at: string;
 }
 
@@ -63,7 +65,7 @@ export default defineEventHandler(async (event) => {
     const { data: leads, error: leadsError } = await supabase
       .from("profile_contacts")
       .select(
-        "id, type, coach_name, coach_email, coach_title, school_name, program, note, matched_coach_id, created_at",
+        "id, type, coach_name, coach_email, coach_title, school_name, program, note, matched_coach_id, status, interaction_id, created_at",
       )
       .eq("family_unit_id", familyUnitId)
       .order("created_at", { ascending: false })

--- a/server/api/player/profile/contacts/[id]/resolve.post.ts
+++ b/server/api/player/profile/contacts/[id]/resolve.post.ts
@@ -1,0 +1,101 @@
+/**
+ * POST /api/player/profile/contacts/:id/resolve
+ * Marks an inbound lead resolved (with the interaction the player minted) or
+ * dismissed. Family scope resolved server-side from the caller's
+ * family_members row. Idempotent: a lead already resolved returns its
+ * existing interaction_id without overwriting.
+ */
+import { defineEventHandler, getRouterParam, readBody, createError } from "h3";
+import { z } from "zod";
+import { requireAuth } from "~/server/utils/auth";
+import { useSupabaseAdmin } from "~/server/utils/supabase";
+import { useLogger } from "~/server/utils/logger";
+
+// A permissive UUID-shape check rather than Zod's strict `.uuid()`, which
+// enforces the RFC4122 version/variant nibbles and rejects otherwise
+// well-formed ids (e.g. test fixtures, some generators).
+const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const resolveBodySchema = z
+  .object({
+    status: z.enum(["resolved", "dismissed"]),
+    interactionId: z.string().regex(UUID_SHAPE, "Invalid UUID").optional(),
+  })
+  .refine((v) => v.status !== "resolved" || !!v.interactionId, {
+    message: "interactionId is required when resolving",
+    path: ["interactionId"],
+  });
+
+export default defineEventHandler(async (event) => {
+  const logger = useLogger(event, "player/profile/contacts/resolve");
+  try {
+    const { id: userId } = await requireAuth(event);
+    const leadId = getRouterParam(event, "id")!;
+    if (!/^[0-9a-f-]{36}$/i.test(leadId)) {
+      throw createError({ statusCode: 400, statusMessage: "Invalid lead id" });
+    }
+
+    const parsed = resolveBodySchema.safeParse(await readBody(event));
+    if (!parsed.success) {
+      throw createError({
+        statusCode: 422,
+        statusMessage: parsed.error.issues[0]?.message ?? "Invalid request",
+      });
+    }
+
+    const admin = useSupabaseAdmin();
+
+    const { data: membership, error: membershipError } = await admin
+      .from("family_members")
+      .select("family_unit_id")
+      .eq("user_id", userId)
+      .single();
+    if (membershipError && membershipError.code !== "PGRST116") {
+      logger.error("Failed to resolve family membership", membershipError);
+      throw createError({ statusCode: 500, statusMessage: "Failed to resolve lead" });
+    }
+    if (!membership) {
+      throw createError({ statusCode: 403, statusMessage: "Not a family member" });
+    }
+
+    const { data: lead, error: leadErr } = await admin
+      .from("profile_contacts")
+      .select("id, status, interaction_id, family_unit_id")
+      .eq("id", leadId)
+      .maybeSingle();
+    if (leadErr) {
+      logger.error("Failed to load lead", leadErr);
+      throw createError({ statusCode: 500, statusMessage: "Failed to resolve lead" });
+    }
+    if (!lead || lead.family_unit_id !== membership.family_unit_id) {
+      throw createError({ statusCode: 404, statusMessage: "Lead not found" });
+    }
+
+    // Double-convert guard: never overwrite an existing resolution.
+    if (lead.status === "resolved") {
+      return { ok: true, status: "resolved", interactionId: lead.interaction_id };
+    }
+
+    const { error: updErr } = await admin
+      .from("profile_contacts")
+      .update({
+        status: parsed.data.status,
+        interaction_id: parsed.data.interactionId ?? null,
+      })
+      .eq("id", leadId);
+    if (updErr) {
+      logger.error("Failed to update lead status", updErr);
+      throw createError({ statusCode: 500, statusMessage: "Failed to resolve lead" });
+    }
+
+    return {
+      ok: true,
+      status: parsed.data.status,
+      interactionId: parsed.data.interactionId ?? null,
+    };
+  } catch (err) {
+    if (err instanceof Error && "statusCode" in err) throw err;
+    logger.error("Failed to resolve lead", err);
+    throw createError({ statusCode: 500, statusMessage: "Failed to resolve lead" });
+  }
+});

--- a/server/api/public/profile/[slug]/contact.post.ts
+++ b/server/api/public/profile/[slug]/contact.post.ts
@@ -33,7 +33,6 @@ import {
   buildInboundInteractionRow,
   insertInboundInteraction,
 } from "~/server/utils/inboundInteraction";
-import { sendNotificationEmail } from "~/server/utils/emailService";
 import type { Database } from "~/types/database";
 
 const HASH_SLUG_RE = /^[a-z0-9]{6}$/;
@@ -281,43 +280,34 @@ export default defineEventHandler(async (event) => {
     }
 
     // Notify the player — fire-and-forget-safe: a failure here must never
-    // fail the response, since the lead is already durably stored.
+    // fail the response, since the lead is already durably stored. When an
+    // interaction was minted (matched path), skip: the
+    // notify_on_inbound_interaction_insert trigger already creates the
+    // notification for it. The notifications-INSERT trigger
+    // (push_on_notification_insert) is the single delivery channel — it
+    // handles both push and email, so no explicit email send here.
     try {
-      const { data: user } = await admin
-        .from("users")
-        .select("email, full_name")
-        .eq("id", profile.user_id)
-        .maybeSingle();
+      if (!interactionId) {
+        const coachLabel = data.coachName;
+        const schoolLabel = data.schoolName ? ` from ${data.schoolName}` : "";
+        const title = "New contact from a coach";
+        const message = `${coachLabel}${schoolLabel} reached out through your public profile.`;
 
-      const coachLabel = data.coachName;
-      const schoolLabel = data.schoolName ? ` from ${data.schoolName}` : "";
-      const title = "New contact from a coach";
-      const message = `${coachLabel}${schoolLabel} reached out through your public profile.`;
-
-      const notificationRow: NotificationInsert = {
-        user_id: profile.user_id,
-        type: "inbound_interaction",
-        title,
-        message,
-        related_entity_type: interactionId ? "interaction" : "profile_contact",
-        related_entity_id: interactionId ?? inserted.id,
-        scheduled_for: new Date().toISOString(),
-      };
-      const { error: notifyError } = await admin
-        .from("notifications")
-        .insert(notificationRow);
-      if (notifyError) {
-        logger.warn("Failed to insert notification row", notifyError);
-      }
-
-      if (user?.email) {
-        await sendNotificationEmail({
-          to: user.email,
-          subject: title,
+        const notificationRow: NotificationInsert = {
+          user_id: profile.user_id,
+          type: "inbound_interaction",
           title,
           message,
-          priority: "normal",
-        });
+          related_entity_type: "profile_contact",
+          related_entity_id: inserted.id,
+          scheduled_for: new Date().toISOString(),
+        };
+        const { error: notifyError } = await admin
+          .from("notifications")
+          .insert(notificationRow);
+        if (notifyError) {
+          logger.warn("Failed to insert notification row", notifyError);
+        }
       }
     } catch (notifyErr) {
       logger.warn("Failed to notify player of inbound contact", notifyErr);

--- a/server/api/public/profile/[slug]/contact.post.ts
+++ b/server/api/public/profile/[slug]/contact.post.ts
@@ -280,34 +280,37 @@ export default defineEventHandler(async (event) => {
     }
 
     // Notify the player — fire-and-forget-safe: a failure here must never
-    // fail the response, since the lead is already durably stored. When an
-    // interaction was minted (matched path), skip: the
-    // notify_on_inbound_interaction_insert trigger already creates the
-    // notification for it. The notifications-INSERT trigger
-    // (push_on_notification_insert) is the single delivery channel — it
-    // handles both push and email, so no explicit email send here.
+    // fail the response, since the lead is already durably stored. ALWAYS
+    // insert this notification, even on the matched path: the
+    // notify_on_inbound_interaction_insert trigger notifies
+    // `family_members WHERE user_id IS DISTINCT FROM NEW.logged_by`, and the
+    // minted interaction sets `logged_by = profile.user_id` (the player) —
+    // so the trigger excludes the player by design (it's meant for other
+    // family members). This insert is what covers the player themselves.
+    // Repoint to the interaction when one was minted; otherwise the lead
+    // itself. The notifications-INSERT trigger (push_on_notification_insert)
+    // is the single delivery channel — it handles both push and email, so no
+    // explicit email send here.
     try {
-      if (!interactionId) {
-        const coachLabel = data.coachName;
-        const schoolLabel = data.schoolName ? ` from ${data.schoolName}` : "";
-        const title = "New contact from a coach";
-        const message = `${coachLabel}${schoolLabel} reached out through your public profile.`;
+      const coachLabel = data.coachName;
+      const schoolLabel = data.schoolName ? ` from ${data.schoolName}` : "";
+      const title = "New contact from a coach";
+      const message = `${coachLabel}${schoolLabel} reached out through your public profile.`;
 
-        const notificationRow: NotificationInsert = {
-          user_id: profile.user_id,
-          type: "inbound_interaction",
-          title,
-          message,
-          related_entity_type: "profile_contact",
-          related_entity_id: inserted.id,
-          scheduled_for: new Date().toISOString(),
-        };
-        const { error: notifyError } = await admin
-          .from("notifications")
-          .insert(notificationRow);
-        if (notifyError) {
-          logger.warn("Failed to insert notification row", notifyError);
-        }
+      const notificationRow: NotificationInsert = {
+        user_id: profile.user_id,
+        type: "inbound_interaction",
+        title,
+        message,
+        related_entity_type: interactionId ? "interaction" : "profile_contact",
+        related_entity_id: interactionId ?? inserted.id,
+        scheduled_for: new Date().toISOString(),
+      };
+      const { error: notifyError } = await admin
+        .from("notifications")
+        .insert(notificationRow);
+      if (notifyError) {
+        logger.warn("Failed to insert notification row", notifyError);
       }
     } catch (notifyErr) {
       logger.warn("Failed to notify player of inbound contact", notifyErr);

--- a/server/api/public/profile/[slug]/contact.post.ts
+++ b/server/api/public/profile/[slug]/contact.post.ts
@@ -29,6 +29,10 @@ import {
 } from "~/server/utils/rateLimit";
 import { verifyTurnstile, isHoneypotTripped } from "~/server/utils/turnstile";
 import { matchCoachByEmail } from "~/server/utils/matchCoachByEmail";
+import {
+  buildInboundInteractionRow,
+  insertInboundInteraction,
+} from "~/server/utils/inboundInteraction";
 import { sendNotificationEmail } from "~/server/utils/emailService";
 import type { Database } from "~/types/database";
 
@@ -186,10 +190,11 @@ export default defineEventHandler(async (event) => {
       });
     }
 
-    const { coachId: matchedCoachId } = await matchCoachByEmail(admin, {
-      familyUnitId: profile.family_unit_id,
-      email: data.coachEmail,
-    });
+    const { coachId: matchedCoachId, schoolId: matchedSchoolId } =
+      await matchCoachByEmail(admin, {
+        familyUnitId: profile.family_unit_id,
+        email: data.coachEmail,
+      });
 
     // Defensive re-verification: a well-formed schoolId that doesn't exist
     // or belongs to another family must never reach the insert — the FK
@@ -224,6 +229,7 @@ export default defineEventHandler(async (event) => {
       note: data.note,
       ip: toValidInetOrNull(clientIp),
       user_agent: userAgent,
+      status: matchedCoachId ? "resolved" : "pending",
     };
 
     const { data: inserted, error: insertError } = await admin
@@ -238,6 +244,40 @@ export default defineEventHandler(async (event) => {
         statusCode: 500,
         statusMessage: "Failed to submit contact",
       });
+    }
+
+    // Mint an inbound interaction when the coach matched — a failure here
+    // must never fail the response, since the lead is already durably
+    // stored.
+    let interactionId: string | null = null;
+    if (matchedCoachId && matchedSchoolId && profile.user_id) {
+      try {
+        const created = await insertInboundInteraction(
+          admin,
+          buildInboundInteractionRow({
+            kind: "contact",
+            coachId: matchedCoachId,
+            schoolId: matchedSchoolId,
+            familyUnitId: profile.family_unit_id,
+            loggedBy: profile.user_id,
+            note: data.note,
+            program: null,
+            occurredAt: new Date().toISOString(),
+          }),
+        );
+        interactionId = created?.id ?? null;
+        if (interactionId) {
+          await admin
+            .from("profile_contacts")
+            .update({ interaction_id: interactionId })
+            .eq("id", inserted.id);
+        }
+      } catch (interErr) {
+        logger.warn(
+          "Failed to create inbound interaction from matched lead",
+          interErr,
+        );
+      }
     }
 
     // Notify the player — fire-and-forget-safe: a failure here must never
@@ -259,8 +299,8 @@ export default defineEventHandler(async (event) => {
         type: "inbound_interaction",
         title,
         message,
-        related_entity_type: "profile_contact",
-        related_entity_id: inserted.id,
+        related_entity_type: interactionId ? "interaction" : "profile_contact",
+        related_entity_id: interactionId ?? inserted.id,
         scheduled_for: new Date().toISOString(),
       };
       const { error: notifyError } = await admin

--- a/server/api/public/profile/[slug]/interest.post.ts
+++ b/server/api/public/profile/[slug]/interest.post.ts
@@ -32,7 +32,6 @@ import {
   buildInboundInteractionRow,
   insertInboundInteraction,
 } from "~/server/utils/inboundInteraction";
-import { sendNotificationEmail } from "~/server/utils/emailService";
 import type { Database } from "~/types/database";
 
 const HASH_SLUG_RE = /^[a-z0-9]{6}$/;
@@ -259,41 +258,32 @@ export default defineEventHandler(async (event) => {
     }
 
     // Notify the player — fire-and-forget-safe: a failure here must never
-    // fail the response, since the lead is already durably stored.
+    // fail the response, since the lead is already durably stored. When an
+    // interaction was minted (matched path), skip: the
+    // notify_on_inbound_interaction_insert trigger already creates the
+    // notification for it. The notifications-INSERT trigger
+    // (push_on_notification_insert) is the single delivery channel — it
+    // handles both push and email, so no explicit email send here.
     try {
-      const { data: user } = await admin
-        .from("users")
-        .select("email, full_name")
-        .eq("id", profile.user_id)
-        .maybeSingle();
+      if (!interactionId) {
+        const title = "New interest from a coach";
+        const message = `${coachLabel} expressed interest in your ${data.program} profile.`;
 
-      const title = "New interest from a coach";
-      const message = `${coachLabel} expressed interest in your ${data.program} profile.`;
-
-      const notificationRow: NotificationInsert = {
-        user_id: profile.user_id,
-        type: "inbound_interaction",
-        title,
-        message,
-        related_entity_type: interactionId ? "interaction" : "profile_contact",
-        related_entity_id: interactionId ?? inserted.id,
-        scheduled_for: new Date().toISOString(),
-      };
-      const { error: notifyError } = await admin
-        .from("notifications")
-        .insert(notificationRow);
-      if (notifyError) {
-        logger.warn("Failed to insert notification row", notifyError);
-      }
-
-      if (user?.email) {
-        await sendNotificationEmail({
-          to: user.email,
-          subject: title,
+        const notificationRow: NotificationInsert = {
+          user_id: profile.user_id,
+          type: "inbound_interaction",
           title,
           message,
-          priority: "normal",
-        });
+          related_entity_type: "profile_contact",
+          related_entity_id: inserted.id,
+          scheduled_for: new Date().toISOString(),
+        };
+        const { error: notifyError } = await admin
+          .from("notifications")
+          .insert(notificationRow);
+        if (notifyError) {
+          logger.warn("Failed to insert notification row", notifyError);
+        }
       }
     } catch (notifyErr) {
       logger.warn("Failed to notify player of inbound interest", notifyErr);

--- a/server/api/public/profile/[slug]/interest.post.ts
+++ b/server/api/public/profile/[slug]/interest.post.ts
@@ -28,6 +28,10 @@ import {
 } from "~/server/utils/rateLimit";
 import { verifyTurnstile, isHoneypotTripped } from "~/server/utils/turnstile";
 import { matchCoachByEmail } from "~/server/utils/matchCoachByEmail";
+import {
+  buildInboundInteractionRow,
+  insertInboundInteraction,
+} from "~/server/utils/inboundInteraction";
 import { sendNotificationEmail } from "~/server/utils/emailService";
 import type { Database } from "~/types/database";
 
@@ -183,10 +187,11 @@ export default defineEventHandler(async (event) => {
       });
     }
 
-    const { coachId: matchedCoachId } = await matchCoachByEmail(admin, {
-      familyUnitId: profile.family_unit_id,
-      email: data.coachEmail,
-    });
+    const { coachId: matchedCoachId, schoolId: matchedSchoolId } =
+      await matchCoachByEmail(admin, {
+        familyUnitId: profile.family_unit_id,
+        email: data.coachEmail,
+      });
 
     // `coach_name` is NOT NULL — anonymous interest gets a placeholder.
     const coachLabel = data.coachName ?? "A coach";
@@ -202,6 +207,7 @@ export default defineEventHandler(async (event) => {
       note: data.note ?? null,
       ip: toValidInetOrNull(clientIp),
       user_agent: userAgent,
+      status: matchedCoachId ? "resolved" : "pending",
     };
 
     const { data: inserted, error: insertError } = await admin
@@ -216,6 +222,40 @@ export default defineEventHandler(async (event) => {
         statusCode: 500,
         statusMessage: "Failed to submit interest",
       });
+    }
+
+    // Mint an inbound interaction when the coach matched — a failure here
+    // must never fail the response, since the lead is already durably
+    // stored.
+    let interactionId: string | null = null;
+    if (matchedCoachId && matchedSchoolId && profile.user_id) {
+      try {
+        const created = await insertInboundInteraction(
+          admin,
+          buildInboundInteractionRow({
+            kind: "interest",
+            coachId: matchedCoachId,
+            schoolId: matchedSchoolId,
+            familyUnitId: profile.family_unit_id,
+            loggedBy: profile.user_id,
+            note: null,
+            program: data.program,
+            occurredAt: new Date().toISOString(),
+          }),
+        );
+        interactionId = created?.id ?? null;
+        if (interactionId) {
+          await admin
+            .from("profile_contacts")
+            .update({ interaction_id: interactionId })
+            .eq("id", inserted.id);
+        }
+      } catch (interErr) {
+        logger.warn(
+          "Failed to create inbound interaction from matched lead",
+          interErr,
+        );
+      }
     }
 
     // Notify the player — fire-and-forget-safe: a failure here must never
@@ -235,8 +275,8 @@ export default defineEventHandler(async (event) => {
         type: "inbound_interaction",
         title,
         message,
-        related_entity_type: "profile_contact",
-        related_entity_id: inserted.id,
+        related_entity_type: interactionId ? "interaction" : "profile_contact",
+        related_entity_id: interactionId ?? inserted.id,
         scheduled_for: new Date().toISOString(),
       };
       const { error: notifyError } = await admin

--- a/server/api/public/profile/[slug]/interest.post.ts
+++ b/server/api/public/profile/[slug]/interest.post.ts
@@ -258,32 +258,35 @@ export default defineEventHandler(async (event) => {
     }
 
     // Notify the player — fire-and-forget-safe: a failure here must never
-    // fail the response, since the lead is already durably stored. When an
-    // interaction was minted (matched path), skip: the
-    // notify_on_inbound_interaction_insert trigger already creates the
-    // notification for it. The notifications-INSERT trigger
-    // (push_on_notification_insert) is the single delivery channel — it
-    // handles both push and email, so no explicit email send here.
+    // fail the response, since the lead is already durably stored. ALWAYS
+    // insert this notification, even on the matched path: the
+    // notify_on_inbound_interaction_insert trigger notifies
+    // `family_members WHERE user_id IS DISTINCT FROM NEW.logged_by`, and the
+    // minted interaction sets `logged_by = profile.user_id` (the player) —
+    // so the trigger excludes the player by design (it's meant for other
+    // family members). This insert is what covers the player themselves.
+    // Repoint to the interaction when one was minted; otherwise the lead
+    // itself. The notifications-INSERT trigger (push_on_notification_insert)
+    // is the single delivery channel — it handles both push and email, so no
+    // explicit email send here.
     try {
-      if (!interactionId) {
-        const title = "New interest from a coach";
-        const message = `${coachLabel} expressed interest in your ${data.program} profile.`;
+      const title = "New interest from a coach";
+      const message = `${coachLabel} expressed interest in your ${data.program} profile.`;
 
-        const notificationRow: NotificationInsert = {
-          user_id: profile.user_id,
-          type: "inbound_interaction",
-          title,
-          message,
-          related_entity_type: "profile_contact",
-          related_entity_id: inserted.id,
-          scheduled_for: new Date().toISOString(),
-        };
-        const { error: notifyError } = await admin
-          .from("notifications")
-          .insert(notificationRow);
-        if (notifyError) {
-          logger.warn("Failed to insert notification row", notifyError);
-        }
+      const notificationRow: NotificationInsert = {
+        user_id: profile.user_id,
+        type: "inbound_interaction",
+        title,
+        message,
+        related_entity_type: interactionId ? "interaction" : "profile_contact",
+        related_entity_id: interactionId ?? inserted.id,
+        scheduled_for: new Date().toISOString(),
+      };
+      const { error: notifyError } = await admin
+        .from("notifications")
+        .insert(notificationRow);
+      if (notifyError) {
+        logger.warn("Failed to insert notification row", notifyError);
       }
     } catch (notifyErr) {
       logger.warn("Failed to notify player of inbound interest", notifyErr);

--- a/server/utils/inboundInteraction.ts
+++ b/server/utils/inboundInteraction.ts
@@ -1,0 +1,50 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "~/types/database";
+
+type InteractionInsert =
+  Database["public"]["Tables"]["interactions"]["Insert"];
+
+export interface InboundLeadInput {
+  kind: "contact" | "interest";
+  coachId: string;
+  schoolId: string;
+  familyUnitId: string;
+  loggedBy: string;
+  note: string | null;
+  program: string | null;
+  occurredAt: string;
+}
+
+export function buildInboundInteractionRow(
+  input: InboundLeadInput,
+): InteractionInsert {
+  const subject =
+    input.kind === "interest"
+      ? `Interest via public profile${input.program ? ` — ${input.program}` : ""}`
+      : "Contact via public profile";
+
+  return {
+    coach_id: input.coachId,
+    school_id: input.schoolId,
+    family_unit_id: input.familyUnitId,
+    logged_by: input.loggedBy,
+    type: input.kind === "interest" ? "interest" : "email",
+    direction: "inbound",
+    occurred_at: input.occurredAt,
+    subject,
+    content: input.note,
+  };
+}
+
+export async function insertInboundInteraction(
+  admin: SupabaseClient<Database>,
+  row: InteractionInsert,
+): Promise<{ id: string } | null> {
+  const { data, error } = await admin
+    .from("interactions")
+    .insert(row)
+    .select("id")
+    .single();
+  if (error || !data) return null;
+  return { id: data.id };
+}

--- a/server/utils/matchCoachByEmail.ts
+++ b/server/utils/matchCoachByEmail.ts
@@ -8,6 +8,7 @@ export interface MatchCoachByEmailParams {
 
 export interface MatchCoachByEmailResult {
   coachId: string | null;
+  schoolId: string | null;
 }
 
 // ILIKE treats % and _ as wildcards; escape them so a case-insensitive exact
@@ -26,14 +27,14 @@ export async function matchCoachByEmail(
   params: MatchCoachByEmailParams,
 ): Promise<MatchCoachByEmailResult> {
   const email = params.email?.trim();
-  if (!email) return { coachId: null };
+  if (!email) return { coachId: null, schoolId: null };
 
   const { data } = await admin
     .from("coaches")
-    .select("id")
+    .select("id, school_id")
     .eq("family_unit_id", params.familyUnitId)
     .ilike("email", escapeIlike(email))
     .maybeSingle();
 
-  return { coachId: data?.id ?? null };
+  return { coachId: data?.id ?? null, schoolId: data?.school_id ?? null };
 }

--- a/supabase/migrations/20260910000000_interaction_type_add_interest.sql
+++ b/supabase/migrations/20260910000000_interaction_type_add_interest.sql
@@ -1,0 +1,3 @@
+-- Add 'interest' to interaction_type so Express-Interest submissions log as
+-- their own interaction type. Enum ADD VALUE is non-transactional; keep alone.
+ALTER TYPE interaction_type ADD VALUE IF NOT EXISTS 'interest';

--- a/supabase/migrations/20260911000000_profile_contacts_status.sql
+++ b/supabase/migrations/20260911000000_profile_contacts_status.sql
@@ -1,0 +1,14 @@
+-- Resolution state for inbound leads. status gates the inbox pending queue;
+-- interaction_id ties a lead to the interaction it produced (match or assign).
+ALTER TABLE profile_contacts
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'resolved', 'dismissed')),
+  ADD COLUMN IF NOT EXISTS interaction_id uuid
+    REFERENCES interactions(id) ON DELETE SET NULL;
+
+-- Backfill: rows that already matched a coach are effectively resolved
+-- (the interaction will be minted going forward; historic ones have none),
+-- everything else is a pending lead awaiting assignment.
+UPDATE profile_contacts
+  SET status = 'resolved'
+  WHERE matched_coach_id IS NOT NULL AND status = 'pending';

--- a/tests/e2e/public-profile-inbound-interaction.spec.ts
+++ b/tests/e2e/public-profile-inbound-interaction.spec.ts
@@ -1,0 +1,253 @@
+import { test, expect, type Browser, type Page } from "@playwright/test";
+import { resolve } from "path";
+import {
+  schoolHelpers,
+  createSchoolData,
+  generateUniqueSchoolName,
+  deleteSchoolDirect,
+} from "./fixtures/schools.fixture";
+
+/**
+ * Public visitor submits "Contact Player" on `/p/<slug>` and the lead becomes
+ * a tracked interaction — either automatically (coach email already known to
+ * the family) or via the player's Assign-coach flow (novel email).
+ *
+ * Modeled on profile-contact.spec.ts / profile-interest.spec.ts: Playwright's
+ * default `page` fixture is pre-authenticated as the shared `player.json`
+ * account. This spec self-publishes that account's own profile and reads its
+ * slug off the setup page's share panel. The public-page half of each flow
+ * needs a genuinely anonymous context (no cookies/localStorage), since a
+ * real coach visiting the page has no account.
+ *
+ * Turnstile is off in the test env (no NUXT_PUBLIC_TURNSTILE_SITE_KEY), so
+ * the widget never mounts and never blocks submission.
+ */
+const RUN_ID = Date.now();
+const PROFILE_PUT_PATTERN = (res: {
+  url(): string;
+  request(): { method(): string };
+}) => res.url().includes("/api/player/profile") && res.request().method() === "PUT";
+
+async function waitForProfileSave(page: Page, action: () => Promise<void>) {
+  await Promise.all([page.waitForResponse(PROFILE_PUT_PATTERN), action()]);
+}
+
+async function ensurePublishedAndGetSlug(page: Page): Promise<string> {
+  await page.goto("/settings/player-details");
+  await page.waitForLoadState("domcontentloaded");
+
+  await page
+    .locator("button", { hasText: "Public Profile" })
+    .first()
+    .click();
+
+  const publishToggle = page.locator('[data-test="publish-toggle"]');
+  await publishToggle.waitFor({ state: "visible", timeout: 15000 });
+
+  // Ensure published — an unpublished profile 410s on /p/:slug, which would
+  // make the anonymous-visitor flow below unreachable.
+  if (
+    !(await page
+      .getByText("Profile is live")
+      .isVisible()
+      .catch(() => false))
+  ) {
+    await waitForProfileSave(page, () => publishToggle.click());
+  }
+  await expect(page.getByText("Profile is live")).toBeVisible();
+
+  // Read the published slug directly off the share panel — never hardcode a
+  // slug, this account's profile may already exist from a prior run.
+  // ShareProfilePanel.vue renders the URL in a plain `<span :title="url">`
+  // with no distinguishing class — target the `title` attribute rather than
+  // a CSS class, which drifted from what sibling specs (profile-contact,
+  // profile-interest) currently assume.
+  const shareUrl = page.locator('span[title*="/p/"]');
+  await expect(shareUrl).toBeVisible();
+  const urlText = (await shareUrl.textContent())?.trim() ?? "";
+  const slug = urlText.split("/p/")[1];
+  expect(slug, `could not parse a slug out of share URL "${urlText}"`).toBeTruthy();
+  return slug;
+}
+
+async function submitContact(
+  browser: Browser,
+  slug: string,
+  fields: { coachName: string; coachEmail: string; note: string },
+): Promise<void> {
+  const anonContext = await browser.newContext({
+    storageState: { cookies: [], origins: [] },
+  });
+  try {
+    const anonPage = await anonContext.newPage();
+    await anonPage.goto(`/p/${slug}`);
+
+    await anonPage.getByRole("button", { name: "Contact Player" }).click();
+    await expect(
+      anonPage.getByRole("heading", { name: /^Contact / }),
+    ).toBeVisible();
+
+    await anonPage.locator('[data-test="coach-name"]').fill(fields.coachName);
+    await anonPage
+      .locator('[data-test="coach-email"]')
+      .fill(fields.coachEmail);
+    await anonPage.locator('[data-test="note"]').fill(fields.note);
+
+    // Honeypot (`hp`) intentionally left untouched — a real coach never
+    // sees or fills it; a filled value would silently no-op the submit.
+
+    await anonPage.getByRole("button", { name: "Send message" }).click();
+    await expect(anonPage.getByText("Message sent.")).toBeVisible();
+  } finally {
+    await anonContext.close();
+  }
+}
+
+async function openInbox(page: Page): Promise<void> {
+  await page.goto("/settings/player-details");
+  await page.waitForLoadState("domcontentloaded");
+  await page.locator("button", { hasText: "Public Profile" }).first().click();
+  await page.locator("button", { hasText: "Inbox" }).first().click();
+  // Inbox defaults to the "Open" filter, which excludes nothing relevant
+  // here, but flip to "All" so a lead that flips straight to resolved is
+  // never hidden by a stale filter state from a prior run.
+  await page.locator('[data-test="filter-all"]').click();
+}
+
+test.describe("Public profile — inbound lead becomes a tracked interaction", () => {
+  // Both tests drive the same shared player.json account (publish toggle,
+  // Inbox tab, coach assignment) — fullyParallel would run them in separate
+  // workers concurrently and race on that shared state.
+  test.describe.configure({ mode: "serial" });
+
+  let schoolId: string;
+  let matchedCoachEmail: string;
+  let matchedCoachName: string;
+
+  test.beforeAll(async ({ browser }) => {
+    // `browser.newPage()` opens a bare context — it does NOT inherit the
+    // project's `use.storageState`, unlike the `page` fixture. Load the
+    // same player auth state explicitly or this setup page is anonymous.
+    const setupContext = await browser.newContext({
+      storageState: resolve(process.cwd(), "tests/e2e/.auth/player.json"),
+    });
+    const setupPage = await setupContext.newPage();
+    const schoolData = createSchoolData({
+      name: generateUniqueSchoolName(`Inbound Lead ${RUN_ID}`),
+    });
+    schoolId = await schoolHelpers.createSchool(setupPage, schoolData);
+
+    matchedCoachName = `E2E Matched Coach ${RUN_ID}`;
+    matchedCoachEmail = `e2e-matched-${RUN_ID}@example.com`;
+    // The coach row's own name is independent of the lead's coach_name (that
+    // comes straight from the Contact form's free-text field, not a DB
+    // join) — matching happens by email only.
+    await schoolHelpers.addCoachToSchool(setupPage, schoolId, {
+      firstName: "Matched",
+      lastName: `Coach${RUN_ID}`,
+      role: "head",
+      email: matchedCoachEmail,
+    });
+
+    // addCoachToSchool only waits for `domcontentloaded`, not for the
+    // client-driven coach insert itself — without this, the public Contact
+    // submission a moment later can race the still-in-flight write and find
+    // no matching coach yet.
+    await expect(setupPage.getByText(`Coach${RUN_ID}`).first()).toBeVisible({
+      timeout: 10000,
+    });
+
+    await setupContext.close();
+  });
+
+  test.afterAll(async () => {
+    await deleteSchoolDirect(schoolId);
+  });
+
+  test("matched email auto-creates an interaction and the lead shows Tracked", async ({
+    page,
+    browser,
+  }) => {
+    const slug = await ensurePublishedAndGetSlug(page);
+    const note = `E2E matched inbound note ${RUN_ID}`;
+
+    await submitContact(browser, slug, {
+      coachName: matchedCoachName,
+      coachEmail: matchedCoachEmail,
+      note,
+    });
+
+    // Interaction appears on the interactions page — auto-minted server-side
+    // because the coach email matched an existing coach in the family.
+    await page.goto("/interactions");
+    await page.waitForLoadState("networkidle");
+    await expect(page.getByText(note)).toBeVisible({ timeout: 15000 });
+
+    // The inbox lead for this coach shows "Tracked".
+    await openInbox(page);
+    const leadRow = page.locator("li", { hasText: matchedCoachName });
+    await expect(leadRow.first()).toBeVisible({ timeout: 10000 });
+    await expect(
+      leadRow.first().getByText("Tracked", { exact: true }),
+    ).toBeVisible();
+  });
+
+  test("unmatched email needs a coach, then Assign-coach produces a tracked interaction", async ({
+    page,
+    browser,
+  }) => {
+    const slug = await ensurePublishedAndGetSlug(page);
+    const novelCoachName = `E2E Unmatched Coach ${RUN_ID}`;
+    const novelCoachEmail = `e2e-unmatched-${RUN_ID}@example.com`;
+    const note = `E2E unmatched inbound note ${RUN_ID}`;
+
+    await submitContact(browser, slug, {
+      coachName: novelCoachName,
+      coachEmail: novelCoachEmail,
+      note,
+    });
+
+    await openInbox(page);
+    const leadRow = page.locator("li", { hasText: novelCoachName });
+    await expect(leadRow.first()).toBeVisible({ timeout: 10000 });
+    await expect(
+      leadRow.first().getByText("Needs coach", { exact: true }),
+    ).toBeVisible();
+
+    await leadRow.first().getByRole("button", { name: "Assign coach" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Assign to a coach" }),
+    ).toBeVisible();
+
+    const schoolSelect = page.locator('[data-test="school-select"]');
+    await schoolSelect.locator(`option[value="${schoolId}"]`).waitFor({
+      state: "attached",
+      timeout: 10000,
+    });
+    await schoolSelect.selectOption(schoolId);
+
+    await page.locator('[data-test="create-new-coach"]').click();
+    // First/last name are prefilled from the lead's coach_name; email is
+    // prefilled from the lead's coach_email — assert the prefill rather than
+    // re-typing it, then just confirm.
+    await expect(page.locator('[data-test="new-coach-email"]')).toHaveValue(
+      novelCoachEmail,
+    );
+
+    await page.locator('[data-test="confirm-assign"]').click();
+
+    // Modal closes and the inbox refetches — lead flips to Tracked.
+    await expect(
+      page.getByRole("heading", { name: "Assign to a coach" }),
+    ).toHaveCount(0);
+    await expect(
+      leadRow.first().getByText("Tracked", { exact: true }),
+    ).toBeVisible({ timeout: 10000 });
+
+    // Interaction lands on the interactions page.
+    await page.goto("/interactions");
+    await page.waitForLoadState("networkidle");
+    await expect(page.getByText(note)).toBeVisible({ timeout: 15000 });
+  });
+});

--- a/tests/unit/components/profile/AssignCoachModal.spec.ts
+++ b/tests/unit/components/profile/AssignCoachModal.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import AssignCoachModal from "~/components/profile/AssignCoachModal.vue";
+import type { ProfileLead } from "~/composables/useProfileContacts";
+
+const createCoach = vi.fn().mockResolvedValue({ id: "coach-new", school_id: "s1" });
+const createInteraction = vi.fn().mockResolvedValue({ id: "int-1" });
+const resolveLead = vi.fn().mockResolvedValue(undefined);
+const fetchCoaches = vi.fn().mockResolvedValue(undefined);
+const fetchSchools = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("~/stores/coaches", () => ({
+  useCoachStore: () => ({
+    createCoach,
+    coaches: [],
+    fetchCoaches,
+  }),
+}));
+
+vi.mock("~/composables/useInteractions", () => ({
+  useInteractions: () => ({ createInteraction }),
+}));
+
+vi.mock("~/composables/useProfileContacts", () => ({
+  useProfileContacts: () => ({
+    resolveLead,
+    dismissLead: vi.fn(),
+    leads: { value: [] },
+    counts: { value: {} },
+    loading: { value: false },
+    error: { value: null },
+    fetchContacts: vi.fn(),
+  }),
+}));
+
+vi.mock("~/stores/schools", () => ({
+  useSchoolStore: () => ({
+    schools: [],
+    fetchSchools,
+  }),
+}));
+
+vi.mock("~/composables/useFamilyContext", () => ({
+  useFamilyContext: () => ({
+    activeFamilyId: { value: "family-1" },
+  }),
+}));
+
+const lead: ProfileLead = {
+  id: "lead-1",
+  type: "contact",
+  coach_name: "Jane Smith",
+  coach_email: "jane@school.edu",
+  coach_title: "Head Coach",
+  school_name: "State U",
+  program: null,
+  note: "Loved your film",
+  matched_coach_id: null,
+  status: "pending",
+  interaction_id: null,
+  created_at: "2026-08-27",
+};
+
+describe("AssignCoachModal", () => {
+  it("creates a coach + inbound interaction then resolves the lead", async () => {
+    const wrapper = mount(AssignCoachModal, {
+      props: { lead, presetSchoolId: "s1" },
+      global: { stubs: { teleport: true } },
+    });
+    await wrapper.get('[data-test="create-new-coach"]').trigger("click");
+    await wrapper.get('[data-test="confirm-assign"]').trigger("click");
+    await new Promise((r) => setTimeout(r));
+
+    expect(createCoach).toHaveBeenCalledWith(
+      "s1",
+      expect.objectContaining({
+        first_name: "Jane",
+        last_name: "Smith",
+        email: "jane@school.edu",
+      }),
+    );
+    expect(createInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        coach_id: "coach-new",
+        school_id: "s1",
+        direction: "inbound",
+        type: "email",
+      }),
+    );
+    expect(resolveLead).toHaveBeenCalledWith("lead-1", "int-1");
+    expect(wrapper.emitted("resolved")).toBeTruthy();
+  });
+});

--- a/tests/unit/components/profile/AssignCoachModal.spec.ts
+++ b/tests/unit/components/profile/AssignCoachModal.spec.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mount } from "@vue/test-utils";
 import AssignCoachModal from "~/components/profile/AssignCoachModal.vue";
 import type { ProfileLead } from "~/composables/useProfileContacts";
+import type { Coach, School } from "~/types/models";
 
 const createCoach = vi.fn().mockResolvedValue({ id: "coach-new", school_id: "s1" });
 const createInteraction = vi.fn().mockResolvedValue({ id: "int-1" });
@@ -9,10 +10,16 @@ const resolveLead = vi.fn().mockResolvedValue(undefined);
 const fetchCoaches = vi.fn().mockResolvedValue(undefined);
 const fetchSchools = vi.fn().mockResolvedValue(undefined);
 
+// Mutable so each test can seed the store's exposed state before mount —
+// captured by reference when the component's `useCoachStore()`/`useSchoolStore()`
+// call reads them during setup, matching Pinia's real (unwrapped) shape.
+let mockCoaches: Coach[] = [];
+let mockSchools: Pick<School, "id" | "name">[] = [];
+
 vi.mock("~/stores/coaches", () => ({
   useCoachStore: () => ({
     createCoach,
-    coaches: [],
+    coaches: mockCoaches,
     fetchCoaches,
   }),
 }));
@@ -35,7 +42,7 @@ vi.mock("~/composables/useProfileContacts", () => ({
 
 vi.mock("~/stores/schools", () => ({
   useSchoolStore: () => ({
-    schools: [],
+    schools: mockSchools,
     fetchSchools,
   }),
 }));
@@ -61,7 +68,15 @@ const lead: ProfileLead = {
   created_at: "2026-08-27",
 };
 
+const flush = () => new Promise((r) => setTimeout(r));
+
 describe("AssignCoachModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCoaches = [];
+    mockSchools = [];
+  });
+
   it("creates a coach + inbound interaction then resolves the lead", async () => {
     const wrapper = mount(AssignCoachModal, {
       props: { lead, presetSchoolId: "s1" },
@@ -69,7 +84,7 @@ describe("AssignCoachModal", () => {
     });
     await wrapper.get('[data-test="create-new-coach"]').trigger("click");
     await wrapper.get('[data-test="confirm-assign"]').trigger("click");
-    await new Promise((r) => setTimeout(r));
+    await flush();
 
     expect(createCoach).toHaveBeenCalledWith(
       "s1",
@@ -89,5 +104,78 @@ describe("AssignCoachModal", () => {
     );
     expect(resolveLead).toHaveBeenCalledWith("lead-1", "int-1");
     expect(wrapper.emitted("resolved")).toBeTruthy();
+  });
+
+  it("links an existing coach + inbound interaction then resolves the lead", async () => {
+    mockCoaches = [
+      {
+        id: "coach-existing",
+        school_id: "s1",
+        role: "head",
+        first_name: "Existing",
+        last_name: "Coach",
+        email: null,
+        phone: null,
+        twitter_handle: null,
+        instagram_handle: null,
+        notes: null,
+        tags: [],
+        source: null,
+        last_contact_date: null,
+      },
+    ];
+
+    const wrapper = mount(AssignCoachModal, {
+      props: { lead, presetSchoolId: "s1" },
+      global: { stubs: { teleport: true } },
+    });
+    await flush();
+
+    await wrapper
+      .get('[data-test="existing-coach-select"]')
+      .setValue("coach-existing");
+    await wrapper.get('[data-test="confirm-assign"]').trigger("click");
+    await flush();
+
+    expect(createCoach).not.toHaveBeenCalled();
+    expect(createInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        coach_id: "coach-existing",
+        school_id: "s1",
+        direction: "inbound",
+        type: "email",
+      }),
+    );
+    expect(resolveLead).toHaveBeenCalledWith("lead-1", "int-1");
+    expect(wrapper.emitted("resolved")).toBeTruthy();
+  });
+
+  it("resolves lead.school_name to a matching school on mount when no presetSchoolId is given", async () => {
+    mockSchools = [{ id: "s-matched", name: "state u" }];
+
+    const wrapper = mount(AssignCoachModal, {
+      props: { lead },
+      global: { stubs: { teleport: true } },
+    });
+    await flush();
+    await flush();
+
+    expect(fetchSchools).toHaveBeenCalledWith("family-1");
+    expect(
+      (wrapper.get('[data-test="school-select"]').element as HTMLSelectElement)
+        .value,
+    ).toBe("s-matched");
+
+    await wrapper.get('[data-test="create-new-coach"]').trigger("click");
+    await wrapper.get('[data-test="confirm-assign"]').trigger("click");
+    await flush();
+
+    expect(createCoach).toHaveBeenCalledWith(
+      "s-matched",
+      expect.objectContaining({ first_name: "Jane", last_name: "Smith" }),
+    );
+    expect(createInteraction).toHaveBeenCalledWith(
+      expect.objectContaining({ school_id: "s-matched" }),
+    );
   });
 });

--- a/tests/unit/components/profile/ProfileInbox.spec.ts
+++ b/tests/unit/components/profile/ProfileInbox.spec.ts
@@ -8,6 +8,8 @@ import type {
 } from "~/composables/useProfileContacts";
 
 const mockFetchContacts = vi.fn();
+const mockResolveLead = vi.fn();
+const mockDismissLead = vi.fn().mockResolvedValue(undefined);
 const state = {
   leads: ref<ProfileLead[]>([]),
   counts: ref<ProfileContactCounts>({
@@ -26,6 +28,8 @@ vi.mock("~/composables/useProfileContacts", () => ({
     loading: state.loading,
     error: state.error,
     fetchContacts: mockFetchContacts,
+    resolveLead: mockResolveLead,
+    dismissLead: mockDismissLead,
   }),
 }));
 
@@ -37,6 +41,8 @@ const stubs = {
     props: ["error"],
   },
   DesignSystemBadge: { template: "<span><slot /></span>", props: ["color", "variant", "size"] },
+  AssignCoachModal: true,
+  NuxtLink: { template: "<a :href=\"to\"><slot /></a>", props: ["to"] },
 };
 
 const sampleLead: ProfileLead = {
@@ -49,6 +55,8 @@ const sampleLead: ProfileLead = {
   program: "Baseball",
   note: "Loved your highlight film and would like to schedule a call.",
   matched_coach_id: null,
+  status: "pending",
+  interaction_id: null,
   created_at: "2026-08-01T00:00:00.000Z",
 };
 
@@ -101,5 +109,49 @@ describe("ProfileInbox", () => {
     const w = mount(ProfileInbox, { global: { stubs } });
     expect(w.text()).toContain("EMPTY");
     expect(w.text()).toContain("No leads yet");
+  });
+
+  it("shows a Needs coach badge and an Assign coach action for pending leads", () => {
+    state.leads.value = [sampleLead];
+    const w = mount(ProfileInbox, { global: { stubs } });
+    expect(w.text()).toContain("Needs coach");
+    expect(w.find('[data-test="assign-coach-lead-1"]').exists()).toBe(true);
+  });
+
+  it("calls dismissLead when Dismiss is clicked", async () => {
+    state.leads.value = [sampleLead];
+    const w = mount(ProfileInbox, { global: { stubs } });
+    await w.get('[data-test="dismiss-lead-1"]').trigger("click");
+    expect(mockDismissLead).toHaveBeenCalledWith("lead-1");
+  });
+
+  it("shows a Tracked badge and a link to the interaction for resolved leads", () => {
+    state.leads.value = [
+      { ...sampleLead, status: "resolved", interaction_id: "interaction-9" },
+    ];
+    const w = mount(ProfileInbox, { global: { stubs } });
+    expect(w.text()).toContain("Tracked");
+    const link = w.find('a[href="/interactions/interaction-9"]');
+    expect(link.exists()).toBe(true);
+  });
+
+  it("hides dismissed leads by default and shows them when the filter is switched to All", async () => {
+    state.leads.value = [{ ...sampleLead, status: "dismissed" }];
+    const w = mount(ProfileInbox, { global: { stubs } });
+    expect(w.text()).not.toContain("Coach Smith");
+
+    await w.get('[data-test="filter-all"]').trigger("click");
+    expect(w.text()).toContain("Coach Smith");
+  });
+
+  it("opens AssignCoachModal for the clicked lead when Assign coach is clicked", async () => {
+    state.leads.value = [sampleLead];
+    const w = mount(ProfileInbox, { global: { stubs } });
+    expect(w.findComponent({ name: "AssignCoachModal" }).exists()).toBe(
+      false,
+    );
+
+    await w.get('[data-test="assign-coach-lead-1"]').trigger("click");
+    expect(w.findComponent({ name: "AssignCoachModal" }).exists()).toBe(true);
   });
 });

--- a/tests/unit/composables/useInteractions.advanced.spec.ts
+++ b/tests/unit/composables/useInteractions.advanced.spec.ts
@@ -273,6 +273,25 @@ describe("useInteractions - Advanced Lifecycle", () => {
 
       expect(interactions.value).toContainEqual(newInteraction);
     });
+
+    it("should allow a parent-role user to create an interaction (matches RLS: any family member)", async () => {
+      mockUser = { ...createMockUser(), role: "parent" };
+
+      const newInteraction = createMockInteraction();
+      const insertMock = vi.fn().mockReturnValue(mockQuery);
+      mockQuery.insert = insertMock;
+      mockQuery.select = vi.fn().mockReturnValue(mockQuery);
+      mockQuery.single.mockResolvedValue({ data: newInteraction, error: null });
+
+      const { createInteraction } = useInteractions();
+      const { id, created_at, updated_at, ...interactionData } = newInteraction;
+
+      const result = await createInteraction(interactionData);
+
+      expect(result).toEqual(newInteraction);
+      expect(mockSupabase.from).toHaveBeenCalledWith("interactions");
+      expect(insertMock).toHaveBeenCalled();
+    });
   });
 
   describe("createInteraction - Error Cases", () => {
@@ -285,18 +304,6 @@ describe("useInteractions - Advanced Lifecycle", () => {
 
       await expect(createInteraction(interactionData)).rejects.toThrow(
         "User not authenticated",
-      );
-    });
-
-    it("should throw error when user is not a player", async () => {
-      mockUser = { ...createMockUser(), role: "parent" };
-
-      const { createInteraction } = useInteractions();
-      const { id, created_at, updated_at, ...interactionData } =
-        createMockInteraction();
-
-      await expect(createInteraction(interactionData)).rejects.toThrow(
-        "Only players can create interactions",
       );
     });
 

--- a/tests/unit/composables/useProfileContacts.spec.ts
+++ b/tests/unit/composables/useProfileContacts.spec.ts
@@ -87,4 +87,48 @@ describe("useProfileContacts", () => {
     expect(leads.value).toEqual([]);
     expect(mockLogger.error).toHaveBeenCalled();
   });
+
+  it("resolveLead POSTs status=resolved with interactionId to the resolve endpoint and refetches", async () => {
+    mockFetchAuth.mockResolvedValue({ leads: [], counts: sampleCounts });
+    const { useProfileContacts } = await import(
+      "~/composables/useProfileContacts"
+    );
+    const { resolveLead } = useProfileContacts();
+    mockFetchAuth.mockClear();
+    mockFetchAuth
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ leads: [], counts: sampleCounts });
+    await resolveLead("lead-1", "interaction-1");
+    expect(mockFetchAuth).toHaveBeenNthCalledWith(
+      1,
+      "/api/player/profile/contacts/lead-1/resolve",
+      { method: "POST", body: { status: "resolved", interactionId: "interaction-1" } },
+    );
+    expect(mockFetchAuth).toHaveBeenNthCalledWith(
+      2,
+      "/api/player/profile/contacts",
+    );
+  });
+
+  it("dismissLead POSTs status=dismissed to the resolve endpoint and refetches", async () => {
+    mockFetchAuth.mockResolvedValue({ leads: [], counts: sampleCounts });
+    const { useProfileContacts } = await import(
+      "~/composables/useProfileContacts"
+    );
+    const { dismissLead } = useProfileContacts();
+    mockFetchAuth.mockClear();
+    mockFetchAuth
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce({ leads: [], counts: sampleCounts });
+    await dismissLead("lead-1");
+    expect(mockFetchAuth).toHaveBeenNthCalledWith(
+      1,
+      "/api/player/profile/contacts/lead-1/resolve",
+      { method: "POST", body: { status: "dismissed" } },
+    );
+    expect(mockFetchAuth).toHaveBeenNthCalledWith(
+      2,
+      "/api/player/profile/contacts",
+    );
+  });
 });

--- a/tests/unit/server/api/public/contact.spec.ts
+++ b/tests/unit/server/api/public/contact.spec.ts
@@ -141,7 +141,9 @@ vi.mock("~/server/utils/supabase", () => ({
         return {
           insert: (row: Record<string, unknown>) => {
             mockState.notificationInserts.push(row);
-            return Promise.resolve({ error: mockState.notificationInsertError });
+            return Promise.resolve({
+              error: mockState.notificationInsertError,
+            });
           },
         };
       }
@@ -168,10 +170,8 @@ vi.mock("h3", async (importOriginal) => {
     getRequestIP: vi.fn(() => "1.2.3.4"),
     getRequestHeader: vi.fn(() => "Mozilla/5.0"),
     getHeader: vi.fn(
-      (
-        event: { _headers?: Record<string, string> },
-        name: string,
-      ) => event._headers?.[name.toLowerCase()],
+      (event: { _headers?: Record<string, string> }, name: string) =>
+        event._headers?.[name.toLowerCase()],
     ),
     readBody: vi.fn(async (event: { _body?: unknown }) => event._body ?? {}),
     createError: (cfg: { statusCode: number; statusMessage?: string }) => {
@@ -184,9 +184,8 @@ vi.mock("h3", async (importOriginal) => {
   };
 });
 
-const { default: handler } = await import(
-  "~/server/api/public/profile/[slug]/contact.post"
-);
+const { default: handler } =
+  await import("~/server/api/public/profile/[slug]/contact.post");
 
 function makeEvent(
   body: Record<string, unknown>,
@@ -214,7 +213,10 @@ describe("POST /api/public/profile/[slug]/contact", () => {
       user_id: "player-1",
       is_published: true,
     };
-    mockState.userRow = { email: "player@example.com", full_name: "Player One" };
+    mockState.userRow = {
+      email: "player@example.com",
+      full_name: "Player One",
+    };
     mockState.schoolRow = null;
     mockState.insertedContact = null;
     mockState.contactInsertError = null;
@@ -296,7 +298,7 @@ describe("POST /api/public/profile/[slug]/contact", () => {
     });
   });
 
-  it("inserts profile_contacts with matched_coach_id set on email match, mints an inbound interaction, and does not insert its own notification", async () => {
+  it("inserts profile_contacts with matched_coach_id set on email match, mints an inbound interaction, and notifies the player pointed at the interaction", async () => {
     matchCoachByEmailMock.mockResolvedValueOnce({
       coachId: "coach-42",
       schoolId: "school-42",
@@ -330,11 +332,16 @@ describe("POST /api/public/profile/[slug]/contact", () => {
       row: { interaction_id: "interaction-1" },
       id: "contact-1",
     });
-    // A DB trigger creates the player notification in production when the
-    // interaction is inserted — the mocked supabase in this unit test does
-    // not run triggers, so the endpoint itself inserts zero notifications
-    // on the matched path.
-    expect(mockState.notificationInserts).toHaveLength(0);
+    // The DB trigger that fires on interaction insert excludes the player
+    // (`logged_by`) — it's meant for other family members. The endpoint
+    // itself is what notifies the player, repointed at the interaction.
+    expect(mockState.notificationInserts).toHaveLength(1);
+    expect(mockState.notificationInserts[0]).toMatchObject({
+      user_id: "player-1",
+      type: "inbound_interaction",
+      related_entity_type: "interaction",
+      related_entity_id: "interaction-1",
+    });
   });
 
   it("inserts profile_contacts with matched_coach_id null when no coach match, and still inserts one notification", async () => {

--- a/tests/unit/server/api/public/contact.spec.ts
+++ b/tests/unit/server/api/public/contact.spec.ts
@@ -11,7 +11,11 @@ const mockState = {
   schoolRow: null as { id: string } | null,
   insertedContact: null as Record<string, unknown> | null,
   contactInsertError: null as object | null,
+  contactUpdate: null as { row: Record<string, unknown>; id: unknown } | null,
   notificationInserts: [] as Record<string, unknown>[],
+  notificationInsertError: null as object | null,
+  insertedInteraction: null as Record<string, unknown> | null,
+  interactionInsertError: null as object | null,
 };
 
 const rateLimitByIpMock = vi.fn(async () => ({
@@ -27,8 +31,10 @@ const rateLimitByKeyMock = vi.fn(async () => ({
   reset: 0,
 }));
 const verifyTurnstileMock = vi.fn(async () => ({ ok: true }));
-const matchCoachByEmailMock = vi.fn(async () => ({ coachId: null as string | null }));
-const sendNotificationEmailMock = vi.fn(async () => ({ success: true }));
+const matchCoachByEmailMock = vi.fn(async () => ({
+  coachId: null as string | null,
+  schoolId: null as string | null,
+}));
 
 vi.mock("~/server/utils/rateLimit", () => ({
   rateLimitByIp: (...args: unknown[]) => rateLimitByIpMock(...args),
@@ -52,11 +58,6 @@ vi.mock("~/server/utils/turnstile", () => ({
 
 vi.mock("~/server/utils/matchCoachByEmail", () => ({
   matchCoachByEmail: (...args: unknown[]) => matchCoachByEmailMock(...args),
-}));
-
-vi.mock("~/server/utils/emailService", () => ({
-  sendNotificationEmail: (...args: unknown[]) =>
-    sendNotificationEmailMock(...args),
 }));
 
 vi.mock("~/server/utils/supabase", () => ({
@@ -98,6 +99,30 @@ vi.mock("~/server/utils/supabase", () => ({
               }),
             };
           },
+          update: (row: Record<string, unknown>) => ({
+            eq: (_col: string, id: unknown) => {
+              mockState.contactUpdate = { row, id };
+              return Promise.resolve({ error: null });
+            },
+          }),
+        };
+      }
+      if (table === "interactions") {
+        return {
+          insert: (row: Record<string, unknown>) => {
+            mockState.insertedInteraction = row;
+            return {
+              select: () => ({
+                single: () =>
+                  Promise.resolve({
+                    data: mockState.interactionInsertError
+                      ? null
+                      : { id: "interaction-1" },
+                    error: mockState.interactionInsertError,
+                  }),
+              }),
+            };
+          },
         };
       }
       if (table === "schools") {
@@ -116,7 +141,7 @@ vi.mock("~/server/utils/supabase", () => ({
         return {
           insert: (row: Record<string, unknown>) => {
             mockState.notificationInserts.push(row);
-            return Promise.resolve({ error: null });
+            return Promise.resolve({ error: mockState.notificationInsertError });
           },
         };
       }
@@ -193,7 +218,11 @@ describe("POST /api/public/profile/[slug]/contact", () => {
     mockState.schoolRow = null;
     mockState.insertedContact = null;
     mockState.contactInsertError = null;
+    mockState.contactUpdate = null;
     mockState.notificationInserts = [];
+    mockState.notificationInsertError = null;
+    mockState.insertedInteraction = null;
+    mockState.interactionInsertError = null;
     rateLimitByIpMock.mockClear();
     rateLimitByIpMock.mockResolvedValue({
       success: true,
@@ -211,16 +240,14 @@ describe("POST /api/public/profile/[slug]/contact", () => {
     verifyTurnstileMock.mockClear();
     verifyTurnstileMock.mockResolvedValue({ ok: true });
     matchCoachByEmailMock.mockClear();
-    matchCoachByEmailMock.mockResolvedValue({ coachId: null });
-    sendNotificationEmailMock.mockClear();
-    sendNotificationEmailMock.mockResolvedValue({ success: true });
+    matchCoachByEmailMock.mockResolvedValue({ coachId: null, schoolId: null });
   });
 
   it("silently returns ok when honeypot is tripped, with no insert or notify", async () => {
     const result = await handler(makeEvent({ ...validBody, hp: "im-a-bot" }));
     expect(result).toEqual({ ok: true });
     expect(mockState.insertedContact).toBeNull();
-    expect(sendNotificationEmailMock).not.toHaveBeenCalled();
+    expect(mockState.insertedInteraction).toBeNull();
     expect(mockState.notificationInserts).toHaveLength(0);
   });
 
@@ -269,8 +296,11 @@ describe("POST /api/public/profile/[slug]/contact", () => {
     });
   });
 
-  it("inserts profile_contacts with matched_coach_id set on email match and notifies the player", async () => {
-    matchCoachByEmailMock.mockResolvedValueOnce({ coachId: "coach-42" });
+  it("inserts profile_contacts with matched_coach_id set on email match, mints an inbound interaction, and does not insert its own notification", async () => {
+    matchCoachByEmailMock.mockResolvedValueOnce({
+      coachId: "coach-42",
+      schoolId: "school-42",
+    });
     const result = await handler(makeEvent(validBody));
 
     expect(result).toEqual({ ok: true });
@@ -286,7 +316,40 @@ describe("POST /api/public/profile/[slug]/contact", () => {
       note: "Loved your film, would like to talk.",
       ip: "1.2.3.4",
       user_agent: "Mozilla/5.0",
+      status: "resolved",
     });
+    expect(mockState.insertedInteraction).toMatchObject({
+      coach_id: "coach-42",
+      school_id: "school-42",
+      family_unit_id: "family-1",
+      logged_by: "player-1",
+      direction: "inbound",
+      type: "email",
+    });
+    expect(mockState.contactUpdate).toMatchObject({
+      row: { interaction_id: "interaction-1" },
+      id: "contact-1",
+    });
+    // A DB trigger creates the player notification in production when the
+    // interaction is inserted — the mocked supabase in this unit test does
+    // not run triggers, so the endpoint itself inserts zero notifications
+    // on the matched path.
+    expect(mockState.notificationInserts).toHaveLength(0);
+  });
+
+  it("inserts profile_contacts with matched_coach_id null when no coach match, and still inserts one notification", async () => {
+    matchCoachByEmailMock.mockResolvedValueOnce({
+      coachId: null,
+      schoolId: null,
+    });
+    const result = await handler(makeEvent(validBody));
+
+    expect(result).toEqual({ ok: true });
+    expect(mockState.insertedContact).toMatchObject({
+      matched_coach_id: null,
+      status: "pending",
+    });
+    expect(mockState.insertedInteraction).toBeNull();
     expect(mockState.notificationInserts).toHaveLength(1);
     expect(mockState.notificationInserts[0]).toMatchObject({
       user_id: "player-1",
@@ -294,22 +357,6 @@ describe("POST /api/public/profile/[slug]/contact", () => {
       related_entity_type: "profile_contact",
       related_entity_id: "contact-1",
     });
-    expect(sendNotificationEmailMock).toHaveBeenCalledTimes(1);
-    expect(sendNotificationEmailMock.mock.calls[0][0]).toMatchObject({
-      to: "player@example.com",
-    });
-  });
-
-  it("inserts profile_contacts with matched_coach_id null when no coach match, and still notifies", async () => {
-    matchCoachByEmailMock.mockResolvedValueOnce({ coachId: null });
-    const result = await handler(makeEvent(validBody));
-
-    expect(result).toEqual({ ok: true });
-    expect(mockState.insertedContact).toMatchObject({
-      matched_coach_id: null,
-    });
-    expect(mockState.notificationInserts).toHaveLength(1);
-    expect(sendNotificationEmailMock).toHaveBeenCalledTimes(1);
   });
 
   it("never leaks player/coach PII in the response body", async () => {
@@ -370,11 +417,7 @@ describe("POST /api/public/profile/[slug]/contact", () => {
   });
 
   it("does not fail the response when notification insert fails", async () => {
-    const mockFrom = (
-      await import("~/server/utils/supabase")
-    ).useSupabaseAdmin();
-    void mockFrom;
-    sendNotificationEmailMock.mockRejectedValueOnce(new Error("resend down"));
+    mockState.notificationInsertError = new Error("db down");
     const result = await handler(makeEvent(validBody));
     expect(result).toEqual({ ok: true });
   });

--- a/tests/unit/server/api/public/interest.spec.ts
+++ b/tests/unit/server/api/public/interest.spec.ts
@@ -10,7 +10,11 @@ const mockState = {
   userRow: null as { email: string; full_name: string | null } | null,
   insertedContact: null as Record<string, unknown> | null,
   contactInsertError: null as object | null,
+  contactUpdate: null as { row: Record<string, unknown>; id: unknown } | null,
   notificationInserts: [] as Record<string, unknown>[],
+  notificationInsertError: null as object | null,
+  insertedInteraction: null as Record<string, unknown> | null,
+  interactionInsertError: null as object | null,
 };
 
 const rateLimitByIpMock = vi.fn(async () => ({
@@ -26,8 +30,10 @@ const rateLimitByKeyMock = vi.fn(async () => ({
   reset: 0,
 }));
 const verifyTurnstileMock = vi.fn(async () => ({ ok: true }));
-const matchCoachByEmailMock = vi.fn(async () => ({ coachId: null as string | null }));
-const sendNotificationEmailMock = vi.fn(async () => ({ success: true }));
+const matchCoachByEmailMock = vi.fn(async () => ({
+  coachId: null as string | null,
+  schoolId: null as string | null,
+}));
 
 vi.mock("~/server/utils/rateLimit", () => ({
   rateLimitByIp: (...args: unknown[]) => rateLimitByIpMock(...args),
@@ -51,11 +57,6 @@ vi.mock("~/server/utils/turnstile", () => ({
 
 vi.mock("~/server/utils/matchCoachByEmail", () => ({
   matchCoachByEmail: (...args: unknown[]) => matchCoachByEmailMock(...args),
-}));
-
-vi.mock("~/server/utils/emailService", () => ({
-  sendNotificationEmail: (...args: unknown[]) =>
-    sendNotificationEmailMock(...args),
 }));
 
 vi.mock("~/server/utils/supabase", () => ({
@@ -97,13 +98,37 @@ vi.mock("~/server/utils/supabase", () => ({
               }),
             };
           },
+          update: (row: Record<string, unknown>) => ({
+            eq: (_col: string, id: unknown) => {
+              mockState.contactUpdate = { row, id };
+              return Promise.resolve({ error: null });
+            },
+          }),
+        };
+      }
+      if (table === "interactions") {
+        return {
+          insert: (row: Record<string, unknown>) => {
+            mockState.insertedInteraction = row;
+            return {
+              select: () => ({
+                single: () =>
+                  Promise.resolve({
+                    data: mockState.interactionInsertError
+                      ? null
+                      : { id: "interaction-1" },
+                    error: mockState.interactionInsertError,
+                  }),
+              }),
+            };
+          },
         };
       }
       if (table === "notifications") {
         return {
           insert: (row: Record<string, unknown>) => {
             mockState.notificationInserts.push(row);
-            return Promise.resolve({ error: null });
+            return Promise.resolve({ error: mockState.notificationInsertError });
           },
         };
       }
@@ -175,7 +200,11 @@ describe("POST /api/public/profile/[slug]/interest", () => {
     mockState.userRow = { email: "player@example.com", full_name: "Player One" };
     mockState.insertedContact = null;
     mockState.contactInsertError = null;
+    mockState.contactUpdate = null;
     mockState.notificationInserts = [];
+    mockState.notificationInsertError = null;
+    mockState.insertedInteraction = null;
+    mockState.interactionInsertError = null;
     rateLimitByIpMock.mockClear();
     rateLimitByIpMock.mockResolvedValue({
       success: true,
@@ -193,16 +222,14 @@ describe("POST /api/public/profile/[slug]/interest", () => {
     verifyTurnstileMock.mockClear();
     verifyTurnstileMock.mockResolvedValue({ ok: true });
     matchCoachByEmailMock.mockClear();
-    matchCoachByEmailMock.mockResolvedValue({ coachId: null });
-    sendNotificationEmailMock.mockClear();
-    sendNotificationEmailMock.mockResolvedValue({ success: true });
+    matchCoachByEmailMock.mockResolvedValue({ coachId: null, schoolId: null });
   });
 
   it("silently returns ok when honeypot is tripped, with no insert or notify", async () => {
     const result = await handler(makeEvent({ ...validBody, hp: "im-a-bot" }));
     expect(result).toEqual({ ok: true });
     expect(mockState.insertedContact).toBeNull();
-    expect(sendNotificationEmailMock).not.toHaveBeenCalled();
+    expect(mockState.insertedInteraction).toBeNull();
     expect(mockState.notificationInserts).toHaveLength(0);
   });
 
@@ -290,7 +317,9 @@ describe("POST /api/public/profile/[slug]/interest", () => {
       matched_coach_id: null,
       ip: "1.2.3.4",
       user_agent: "Mozilla/5.0",
+      status: "pending",
     });
+    expect(mockState.insertedInteraction).toBeNull();
     expect(mockState.notificationInserts).toHaveLength(1);
     expect(mockState.notificationInserts[0]).toMatchObject({
       user_id: "player-1",
@@ -299,7 +328,43 @@ describe("POST /api/public/profile/[slug]/interest", () => {
       related_entity_type: "profile_contact",
       related_entity_id: "contact-1",
     });
-    expect(sendNotificationEmailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("mints an inbound interaction on email match and does not insert its own notification", async () => {
+    matchCoachByEmailMock.mockResolvedValueOnce({
+      coachId: "coach-42",
+      schoolId: "school-42",
+    });
+    const result = await handler(
+      makeEvent({
+        ...validBody,
+        coachName: "Coach Smith",
+        coachEmail: "coach@example.edu",
+      }),
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(mockState.insertedContact).toMatchObject({
+      matched_coach_id: "coach-42",
+      status: "resolved",
+    });
+    expect(mockState.insertedInteraction).toMatchObject({
+      coach_id: "coach-42",
+      school_id: "school-42",
+      family_unit_id: "family-1",
+      logged_by: "player-1",
+      direction: "inbound",
+      type: "interest",
+    });
+    expect(mockState.contactUpdate).toMatchObject({
+      row: { interaction_id: "interaction-1" },
+      id: "contact-1",
+    });
+    // A DB trigger creates the player notification in production when the
+    // interaction is inserted — the mocked supabase in this unit test does
+    // not run triggers, so the endpoint itself inserts zero notifications
+    // on the matched path.
+    expect(mockState.notificationInserts).toHaveLength(0);
   });
 
   it("sets matched_coach_id when coachEmail matches an existing coach", async () => {
@@ -331,7 +396,7 @@ describe("POST /api/public/profile/[slug]/interest", () => {
   });
 
   it("does not fail the response when notification insert fails", async () => {
-    sendNotificationEmailMock.mockRejectedValueOnce(new Error("resend down"));
+    mockState.notificationInsertError = new Error("db down");
     const result = await handler(makeEvent(validBody));
     expect(result).toEqual({ ok: true });
   });

--- a/tests/unit/server/api/public/interest.spec.ts
+++ b/tests/unit/server/api/public/interest.spec.ts
@@ -128,7 +128,9 @@ vi.mock("~/server/utils/supabase", () => ({
         return {
           insert: (row: Record<string, unknown>) => {
             mockState.notificationInserts.push(row);
-            return Promise.resolve({ error: mockState.notificationInsertError });
+            return Promise.resolve({
+              error: mockState.notificationInsertError,
+            });
           },
         };
       }
@@ -155,10 +157,8 @@ vi.mock("h3", async (importOriginal) => {
     getRequestIP: vi.fn(() => "1.2.3.4"),
     getRequestHeader: vi.fn(() => "Mozilla/5.0"),
     getHeader: vi.fn(
-      (
-        event: { _headers?: Record<string, string> },
-        name: string,
-      ) => event._headers?.[name.toLowerCase()],
+      (event: { _headers?: Record<string, string> }, name: string) =>
+        event._headers?.[name.toLowerCase()],
     ),
     readBody: vi.fn(async (event: { _body?: unknown }) => event._body ?? {}),
     createError: (cfg: { statusCode: number; statusMessage?: string }) => {
@@ -171,9 +171,8 @@ vi.mock("h3", async (importOriginal) => {
   };
 });
 
-const { default: handler } = await import(
-  "~/server/api/public/profile/[slug]/interest.post"
-);
+const { default: handler } =
+  await import("~/server/api/public/profile/[slug]/interest.post");
 
 function makeEvent(
   body: Record<string, unknown>,
@@ -197,7 +196,10 @@ describe("POST /api/public/profile/[slug]/interest", () => {
       user_id: "player-1",
       is_published: true,
     };
-    mockState.userRow = { email: "player@example.com", full_name: "Player One" };
+    mockState.userRow = {
+      email: "player@example.com",
+      full_name: "Player One",
+    };
     mockState.insertedContact = null;
     mockState.contactInsertError = null;
     mockState.contactUpdate = null;
@@ -330,7 +332,7 @@ describe("POST /api/public/profile/[slug]/interest", () => {
     });
   });
 
-  it("mints an inbound interaction on email match and does not insert its own notification", async () => {
+  it("mints an inbound interaction on email match and notifies the player pointed at the interaction", async () => {
     matchCoachByEmailMock.mockResolvedValueOnce({
       coachId: "coach-42",
       schoolId: "school-42",
@@ -360,11 +362,16 @@ describe("POST /api/public/profile/[slug]/interest", () => {
       row: { interaction_id: "interaction-1" },
       id: "contact-1",
     });
-    // A DB trigger creates the player notification in production when the
-    // interaction is inserted — the mocked supabase in this unit test does
-    // not run triggers, so the endpoint itself inserts zero notifications
-    // on the matched path.
-    expect(mockState.notificationInserts).toHaveLength(0);
+    // The DB trigger that fires on interaction insert excludes the player
+    // (`logged_by`) — it's meant for other family members. The endpoint
+    // itself is what notifies the player, repointed at the interaction.
+    expect(mockState.notificationInserts).toHaveLength(1);
+    expect(mockState.notificationInserts[0]).toMatchObject({
+      user_id: "player-1",
+      type: "inbound_interaction",
+      related_entity_type: "interaction",
+      related_entity_id: "interaction-1",
+    });
   });
 
   it("sets matched_coach_id when coachEmail matches an existing coach", async () => {

--- a/tests/unit/server/api/resolveLead.validation.spec.ts
+++ b/tests/unit/server/api/resolveLead.validation.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { resolveBodySchema } from "~/server/api/player/profile/contacts/[id]/resolve.post";
+
+describe("resolveBodySchema", () => {
+  it("requires interactionId when status is resolved", () => {
+    expect(resolveBodySchema.safeParse({ status: "resolved" }).success).toBe(false);
+    expect(
+      resolveBodySchema.safeParse({
+        status: "resolved",
+        interactionId: "00000000-0000-0000-0000-000000000001",
+      }).success,
+    ).toBe(true);
+  });
+
+  it("allows dismissed without an interactionId", () => {
+    expect(resolveBodySchema.safeParse({ status: "dismissed" }).success).toBe(true);
+  });
+
+  it("rejects unknown status", () => {
+    expect(resolveBodySchema.safeParse({ status: "open" }).success).toBe(false);
+  });
+});

--- a/tests/unit/server/utils/inboundInteraction.spec.ts
+++ b/tests/unit/server/utils/inboundInteraction.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { buildInboundInteractionRow } from "~/server/utils/inboundInteraction";
+
+const base = {
+  coachId: "c1", schoolId: "s1", familyUnitId: "f1", loggedBy: "u1",
+  note: "We loved your film", program: null, occurredAt: "2026-08-27T00:00:00.000Z",
+} as const;
+
+describe("buildInboundInteractionRow", () => {
+  it("maps a contact lead to an inbound email interaction", () => {
+    const row = buildInboundInteractionRow({ ...base, kind: "contact" });
+    expect(row).toMatchObject({
+      coach_id: "c1", school_id: "s1", family_unit_id: "f1", logged_by: "u1",
+      type: "email", direction: "inbound", occurred_at: base.occurredAt,
+      content: "We loved your film",
+    });
+    expect(row.subject).toContain("public profile");
+  });
+
+  it("maps an interest lead to an inbound interest interaction with program in subject", () => {
+    const row = buildInboundInteractionRow({
+      ...base, kind: "interest", note: null, program: "Pitcher",
+    });
+    expect(row.type).toBe("interest");
+    expect(row.direction).toBe("inbound");
+    expect(row.subject).toContain("Pitcher");
+  });
+});

--- a/tests/unit/server/utils/matchCoachByEmail.spec.ts
+++ b/tests/unit/server/utils/matchCoachByEmail.spec.ts
@@ -1,78 +1,27 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { matchCoachByEmail } from "~/server/utils/matchCoachByEmail";
 
-/**
- * Minimal chainable coaches-table stub matching the repo's mutable-mockState
- * idiom (mutable call-capture record, chainable .eq()/.ilike(), terminal
- * .maybeSingle()). See resolveAthleteId.spec.ts for the precedent.
- */
-function makeAdmin(matchRow: { id: string } | null) {
-  const calls = { select: [] as Array<[string, string]> };
-  const eq = vi.fn((col: string, val: string) => {
-    calls.select.push([col, val]);
-    return {
-      ilike: vi.fn((col2: string, val2: string) => {
-        calls.select.push([col2, val2]);
-        return { maybeSingle: () => Promise.resolve({ data: matchRow, error: null }) };
-      }),
-    };
-  });
-  const select = vi.fn(() => ({ eq }));
-  const from = vi.fn((table: string) => {
-    if (table !== "coaches") throw new Error(`unexpected table: ${table}`);
-    return { select };
-  });
-
-  return { from, calls, select } as never;
+function fakeAdmin(row: { id: string; school_id: string } | null) {
+  const builder = {
+    select: () => builder,
+    eq: () => builder,
+    ilike: () => builder,
+    maybeSingle: async () => ({ data: row, error: null }),
+  };
+  return { from: () => builder } as never;
 }
 
 describe("matchCoachByEmail", () => {
-  it("returns the coach id on a case-insensitive email match", async () => {
-    const admin = makeAdmin({ id: "existing-coach-id" });
-
-    const result = await matchCoachByEmail(admin, {
-      familyUnitId: "fam-1",
-      email: "coach@x.com", // stored as "Coach@x.com" — match asserted via mock returning a row
+  it("returns coachId and schoolId when a coach matches", async () => {
+    const res = await matchCoachByEmail(fakeAdmin({ id: "c1", school_id: "s1" }), {
+      familyUnitId: "f1",
+      email: "coach@school.edu",
     });
-
-    expect(result).toEqual({ coachId: "existing-coach-id" });
+    expect(res).toEqual({ coachId: "c1", schoolId: "s1" });
   });
 
-  it("returns null coachId when no coach matches", async () => {
-    const admin = makeAdmin(null);
-
-    const result = await matchCoachByEmail(admin, {
-      familyUnitId: "fam-1",
-      email: "unknown@example.com",
-    });
-
-    expect(result).toEqual({ coachId: null });
-  });
-
-  it("returns null coachId without querying when no email is given", async () => {
-    const admin = makeAdmin({ id: "should-not-be-returned" });
-
-    const result = await matchCoachByEmail(admin, { familyUnitId: "fam-1" });
-
-    expect(result).toEqual({ coachId: null });
-    expect((admin as unknown as { select: ReturnType<typeof vi.fn> }).select).not.toHaveBeenCalled();
-  });
-
-  it("returns null coachId for an empty-string email without querying", async () => {
-    const admin = makeAdmin({ id: "should-not-be-returned" });
-
-    const result = await matchCoachByEmail(admin, { familyUnitId: "fam-1", email: "  " });
-
-    expect(result).toEqual({ coachId: null });
-    expect((admin as unknown as { select: ReturnType<typeof vi.fn> }).select).not.toHaveBeenCalled();
-  });
-
-  it("scopes the match to the given family_unit_id", async () => {
-    const admin = makeAdmin({ id: "existing-coach-id" });
-
-    await matchCoachByEmail(admin, { familyUnitId: "fam-42", email: "coach@x.com" });
-
-    const calls = (admin as unknown as { calls: { select: Array<[string, string]> } }).calls;
-    expect(calls.select).toContainEqual(["family_unit_id", "fam-42"]);
+  it("returns nulls when no email is supplied", async () => {
+    const res = await matchCoachByEmail(fakeAdmin(null), { familyUnitId: "f1" });
+    expect(res).toEqual({ coachId: null, schoolId: null });
   });
 });

--- a/tests/unit/server/utils/matchCoachByEmail.spec.ts
+++ b/tests/unit/server/utils/matchCoachByEmail.spec.ts
@@ -1,27 +1,78 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { matchCoachByEmail } from "~/server/utils/matchCoachByEmail";
 
-function fakeAdmin(row: { id: string; school_id: string } | null) {
-  const builder = {
-    select: () => builder,
-    eq: () => builder,
-    ilike: () => builder,
-    maybeSingle: async () => ({ data: row, error: null }),
-  };
-  return { from: () => builder } as never;
+/**
+ * Minimal chainable coaches-table stub matching the repo's mutable-mockState
+ * idiom (mutable call-capture record, chainable .eq()/.ilike(), terminal
+ * .maybeSingle()). See resolveAthleteId.spec.ts for the precedent.
+ */
+function makeAdmin(matchRow: { id: string; school_id: string } | null) {
+  const calls = { select: [] as Array<[string, string]> };
+  const eq = vi.fn((col: string, val: string) => {
+    calls.select.push([col, val]);
+    return {
+      ilike: vi.fn((col2: string, val2: string) => {
+        calls.select.push([col2, val2]);
+        return { maybeSingle: () => Promise.resolve({ data: matchRow, error: null }) };
+      }),
+    };
+  });
+  const select = vi.fn(() => ({ eq }));
+  const from = vi.fn((table: string) => {
+    if (table !== "coaches") throw new Error(`unexpected table: ${table}`);
+    return { select };
+  });
+
+  return { from, calls, select } as never;
 }
 
 describe("matchCoachByEmail", () => {
-  it("returns coachId and schoolId when a coach matches", async () => {
-    const res = await matchCoachByEmail(fakeAdmin({ id: "c1", school_id: "s1" }), {
-      familyUnitId: "f1",
-      email: "coach@school.edu",
+  it("returns the coach id and school_id on a case-insensitive email match", async () => {
+    const admin = makeAdmin({ id: "existing-coach-id", school_id: "s1" });
+
+    const result = await matchCoachByEmail(admin, {
+      familyUnitId: "fam-1",
+      email: "coach@x.com", // stored as "Coach@x.com" — match asserted via mock returning a row
     });
-    expect(res).toEqual({ coachId: "c1", schoolId: "s1" });
+
+    expect(result).toEqual({ coachId: "existing-coach-id", schoolId: "s1" });
   });
 
-  it("returns nulls when no email is supplied", async () => {
-    const res = await matchCoachByEmail(fakeAdmin(null), { familyUnitId: "f1" });
-    expect(res).toEqual({ coachId: null, schoolId: null });
+  it("returns null coachId and schoolId when no coach matches", async () => {
+    const admin = makeAdmin(null);
+
+    const result = await matchCoachByEmail(admin, {
+      familyUnitId: "fam-1",
+      email: "unknown@example.com",
+    });
+
+    expect(result).toEqual({ coachId: null, schoolId: null });
+  });
+
+  it("returns null coachId and schoolId without querying when no email is given", async () => {
+    const admin = makeAdmin({ id: "should-not-be-returned", school_id: "should-not-be-returned" });
+
+    const result = await matchCoachByEmail(admin, { familyUnitId: "fam-1" });
+
+    expect(result).toEqual({ coachId: null, schoolId: null });
+    expect((admin as unknown as { select: ReturnType<typeof vi.fn> }).select).not.toHaveBeenCalled();
+  });
+
+  it("returns null coachId and schoolId for an empty-string email without querying", async () => {
+    const admin = makeAdmin({ id: "should-not-be-returned", school_id: "should-not-be-returned" });
+
+    const result = await matchCoachByEmail(admin, { familyUnitId: "fam-1", email: "  " });
+
+    expect(result).toEqual({ coachId: null, schoolId: null });
+    expect((admin as unknown as { select: ReturnType<typeof vi.fn> }).select).not.toHaveBeenCalled();
+  });
+
+  it("scopes the match to the given family_unit_id", async () => {
+    const admin = makeAdmin({ id: "existing-coach-id", school_id: "s1" });
+
+    await matchCoachByEmail(admin, { familyUnitId: "fam-42", email: "coach@x.com" });
+
+    const calls = (admin as unknown as { calls: { select: Array<[string, string]> } }).calls;
+    expect(calls.select).toContainEqual(["family_unit_id", "fam-42"]);
   });
 });

--- a/tests/unit/utils/interactionFormatters.spec.ts
+++ b/tests/unit/utils/interactionFormatters.spec.ts
@@ -96,3 +96,10 @@ describe("interactionFormatters", () => {
     });
   });
 });
+
+describe("interest interaction type", () => {
+  it("formats interest with a label and a non-default icon", () => {
+    expect(formatType("interest")).toBe("Interest");
+    expect(getTypeIcon("interest")).toBe("i-heroicons-hand-raised");
+  });
+});

--- a/types/database.ts
+++ b/types/database.ts
@@ -2033,6 +2033,7 @@ export type Database = {
           created_at: string;
           family_unit_id: string;
           id: string;
+          interaction_id: string | null;
           ip: string | null;
           matched_coach_id: string | null;
           note: string | null;
@@ -2040,6 +2041,7 @@ export type Database = {
           program: string | null;
           school_id: string | null;
           school_name: string | null;
+          status: string;
           type: string;
           user_agent: string | null;
         };
@@ -2050,6 +2052,7 @@ export type Database = {
           created_at?: string;
           family_unit_id: string;
           id?: string;
+          interaction_id?: string | null;
           ip?: string | null;
           matched_coach_id?: string | null;
           note?: string | null;
@@ -2057,6 +2060,7 @@ export type Database = {
           program?: string | null;
           school_id?: string | null;
           school_name?: string | null;
+          status?: string;
           type?: string;
           user_agent?: string | null;
         };
@@ -2067,6 +2071,7 @@ export type Database = {
           created_at?: string;
           family_unit_id?: string;
           id?: string;
+          interaction_id?: string | null;
           ip?: string | null;
           matched_coach_id?: string | null;
           note?: string | null;
@@ -2074,6 +2079,7 @@ export type Database = {
           program?: string | null;
           school_id?: string | null;
           school_name?: string | null;
+          status?: string;
           type?: string;
           user_agent?: string | null;
         };
@@ -2083,6 +2089,13 @@ export type Database = {
             columns: ["family_unit_id"];
             isOneToOne: false;
             referencedRelation: "family_units";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "profile_contacts_interaction_id_fkey";
+            columns: ["interaction_id"];
+            isOneToOne: false;
+            referencedRelation: "interactions";
             referencedColumns: ["id"];
           },
           {

--- a/types/database.ts
+++ b/types/database.ts
@@ -3321,7 +3321,8 @@ export type Database = {
         | "game"
         | "unofficial_visit"
         | "official_visit"
-        | "other";
+        | "other"
+        | "interest";
       notification_type:
         | "follow_up_reminder"
         | "deadline_alert"
@@ -3509,6 +3510,7 @@ export const Constants = {
         "unofficial_visit",
         "official_visit",
         "other",
+        "interest",
       ],
       notification_type: [
         "follow_up_reminder",

--- a/types/models.ts
+++ b/types/models.ts
@@ -157,7 +157,8 @@ export interface Interaction {
     | "game"
     | "unofficial_visit"
     | "official_visit"
-    | "other";
+    | "other"
+    | "interest";
   direction: "outbound" | "inbound";
   subject?: string | null;
   content?: string | null;

--- a/utils/interactionFormatters.ts
+++ b/utils/interactionFormatters.ts
@@ -13,6 +13,7 @@ export const getTypeIcon = (type: string): string => {
     other: "i-heroicons-chat-bubble-left",
     tweet: "i-heroicons-chat-bubble-left",
     dm: "i-heroicons-chat-bubble-left",
+    interest: "i-heroicons-hand-raised",
   };
   return icons[type] || "i-heroicons-chat-bubble-left";
 };
@@ -32,6 +33,7 @@ export const getTypeIconBg = (type: string): string => {
     other: "bg-gray-100",
     tweet: "bg-sky-100",
     dm: "bg-violet-100",
+    interest: "bg-purple-100",
   };
   return bgs[type] || "bg-slate-100";
 };
@@ -51,6 +53,7 @@ export const getTypeIconColor = (type: string): string => {
     other: "text-gray-600",
     tweet: "text-sky-600",
     dm: "text-violet-600",
+    interest: "text-purple-600",
   };
   return colors[type] || "text-slate-600";
 };
@@ -70,6 +73,7 @@ export const formatType = (type: string): string => {
     other: "Other",
     tweet: "Tweet",
     dm: "Direct Message",
+    interest: "Interest",
   };
   return typeMap[type] || type;
 };

--- a/utils/validation/schemas.ts
+++ b/utils/validation/schemas.ts
@@ -177,6 +177,7 @@ export const interactionSchema = z
       "unofficial_visit",
       "official_visit",
       "other",
+      "interest",
     ]),
     direction: z.enum(["outbound", "inbound"]),
     subject: sanitizedTextSchema(500),


### PR DESCRIPTION
## Summary

Inbound coach messages from the **public player profile** (Contact / Express Interest) now become **tracked interactions**, matched to an existing coach when possible — closing the gap left by the public-profile redesign (lead capture + email-match shipped; the interaction step never did).

- **Matched coach** (email matches an existing family coach): the public endpoint mints an inbound `interactions` row at submit time — the coach's `school_id` satisfies the NOT-NULL constraint, `logged_by` is the player, `direction: inbound`. Lead is marked `resolved` and linked via `interaction_id`.
- **Unmatched**: the lead stays `pending`; the player or parent resolves it in the inbox via **AssignCoachModal** — resolve the school, then link an existing coach or deliberately create a new one (pre-filled from the lead), which mints the interaction. **No coach is ever auto-created from unauthenticated public input** — the human dedup gate prevents the orphaned/duplicate coach records that would poison per-coach relationship tracking.
- New **`interest`** `interaction_type` value so Express-Interest usage is tracked as its own type.
- `createInteraction` opened to **any family member** (parent or player), aligning the client with the RLS policy that already allowed it — parents can log interactions and assign inbound coaches on the athlete's behalf.

### Bug fix (found during QA)
Public Contact/Interest submissions were **emailing the player twice** — the endpoints both called `sendNotificationEmail` *and* inserted a `notifications` row (which the `push_on_notification_insert` trigger → edge function also emails). Removed the redundant explicit email; the notification row is now the single email+push channel. Verified the matched path still notifies the player directly (the `notify_on_inbound_interaction` trigger excludes `logged_by`, so the endpoint keeps notifying the player itself).

## Database (migrations applied live to the shared prod DB, folded into this PR)
- `interaction_type` += `interest`.
- `profile_contacts` += `status` (`pending`/`resolved`/`dismissed`) + `interaction_id` (FK → interactions, ON DELETE SET NULL), with a backfill (`matched_coach_id` set → `resolved`).

## Test plan
- **Unit**: full suite branch-clean (only 7 pre-existing unrelated failures; branch adds zero). New/updated coverage: `matchCoachByEmail` (schoolId + preserved ILIKE/family-scope/guard tests), `buildInboundInteractionRow`, `resolve` endpoint validation, `AssignCoachModal` (create-new + link-existing + school-resolution), `ProfileInbox` states, both public endpoints (matched/unmatched notification contract).
- **E2E**: `tests/e2e/public-profile-inbound-interaction.spec.ts` — matched + unmatched journeys, 2/2 pass warm.
- Gates: `type-check` 0, `audit:tokens` 0, `lint` 0.

## Follow-ups (non-blocking)
- Add `interest` to non-exhaustive display maps (interaction analytics color, export label, type-filter dropdowns) — currently degrade gracefully.
- `resolve` endpoint: optional family-ownership check on the client-supplied `interactionId` (bounded by FK + RLS today).
- iOS parity: assignment inbox + Assign-coach flow (handoff in `planning/iOS_HANDOFF_inbound-lead-assignment-2026-08-27.md`); add `interest` type to iOS constants.
- Pre-existing sibling E2E `span.font-mono` selector bug (separate).

Spec: `planning/DESIGN_public-profile-inbound-to-interaction-2026-08-27.md` · Plan: `planning/PLAN_public-profile-inbound-to-interaction-2026-08-27.md`

https://claude.ai/code/session_01M5aykS74BtpgkdbjyG3juV
