### PR TITLE
ci(soak): run only soak specs, not the full E2E suite

### DIFF
--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -2,8 +2,10 @@ name: Memory Soak Tests
 
 on:
   # Nightly — CDP heap/node/listener readings vary run-to-run, so soak tests
-  # are unsuitable as a per-PR gate. Runs the full E2E suite with SOAK=1 so the
-  # soak specs (skipped by default) execute in a warmed session/store context.
+  # are unsuitable as a per-PR gate. Runs ONLY the soak specs (SOAK=1), which
+  # each self-baseline (baseline→after inside the test), so this job goes red
+  # only on a real memory regression — not on unrelated general-suite flakes.
+  # General E2E redness / test-isolation debris is tracked as its own effort.
   schedule:
     - cron: "0 8 * * *" # 08:00 UTC daily
   # Allow manual triggering from the Actions tab
@@ -52,8 +54,8 @@ jobs:
           NUXT_PUBLIC_SUPABASE_URL: ${{ secrets.TEST_SUPABASE_URL }}
           NUXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.TEST_SUPABASE_ANON_KEY }}
 
-      - name: Run E2E suite with soak specs enabled
-        run: npm run test:e2e
+      - name: Run soak specs only (SOAK=1)
+        run: npx playwright test --project=chromium tests/e2e/athlete-switcher-soak.spec.ts tests/e2e/task-expand-soak.spec.ts
         env:
           CI: true
           SOAK: "1"


### PR DESCRIPTION
## Why

Last night's **Memory Soak Tests** went red (run 33105370111) — as it has 3 nights running. Not a memory regression:

- **Both soak specs passed** — `athlete-switcher` and `task-expand` heap/nodes/listeners flat.
- Final tally **478 passed / 17 failed / 1 flaky** — all 17 are *general* E2E failures (profile share-URL render timeouts, task-toggle timeouts, and `strict mode violation: ... resolved to 2 elements` test-isolation debris on timestamp-named coaches).

`soak.yml` ran the **entire** E2E suite with `SOAK=1` to "warm" context, then gated on all ~508 results. Any general-suite flake turns the memory job red and **masks the actual memory signal**.

## Change

Scope the run step to the two soak spec files on chromium. Each soak spec self-baselines (baseline→after inside the test), so the full-suite warm-up was not load-bearing. `globalSetup`/`globalTeardown` still seed + mint storageState via `playwright.config.ts`.

## Not in scope

The 17-fail general-suite redness (test-isolation debris / school-leak) stays tracked as its own effort.

## Test plan

- [ ] Trigger `Memory Soak Tests` via workflow_dispatch on this branch → job runs only the 2 soak specs, goes green.

https://claude.ai/code/session_01EcC9Wwsj1NqZ3sEazRoGmE